### PR TITLE
scoop: bump alacritree to v0.1.1

### DIFF
--- a/bucket/alacritree.json
+++ b/bucket/alacritree.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.0.0",
+    "version": "0.1.1",
     "description": "Alacritty fork with worktree-aware sidebars",
     "homepage": "https://github.com/mathix420/alacritree",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mathix420/alacritree/releases/download/v0.0.0/alacritree-v0.0.0-x86_64-windows.zip",
-            "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+            "url": "https://github.com/mathix420/alacritree/releases/download/v0.1.1/alacritree-v0.1.1-x86_64-windows.zip",
+            "hash": "beb8cfb06a41956ed97bf5f1db8609328ebcb9bbeb28e1c442cfad789b0849b4"
         }
     },
     "bin": "alacritree.exe",


### PR DESCRIPTION
Manual one-time bump: v0.1.1 is the first release that produced a Windows zip, so the placeholder manifest committed in 3c3fae6c can finally be replaced with real values.

After this lands, enable **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests** so future releases auto-PR via `scoop-update.yml`.