### PR TITLE
Bind Ctrl+Shift+O to add a new workspace

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -371,6 +371,7 @@ impl AlacritreeApp {
         let mut cycle_tabs_delta: Option<i32> = None;
         let mut cycle_ws_delta: Option<i32> = None;
         let mut quit_requested = false;
+        let mut add_project_requested = false;
         ctx.input_mut(|i| {
             if consume_exact(i, egui::Modifiers::CTRL, egui::Key::B) {
                 self.show_left_sidebar = !self.show_left_sidebar;
@@ -397,6 +398,9 @@ impl AlacritreeApp {
             {
                 cycle_ws_delta = Some(-1);
             }
+            if consume_exact(i, egui::Modifiers::CTRL | egui::Modifiers::SHIFT, egui::Key::O) {
+                add_project_requested = true;
+            }
             if consume_exact(i, egui::Modifiers::CTRL, egui::Key::Q) {
                 quit_requested = true;
             }
@@ -409,6 +413,9 @@ impl AlacritreeApp {
             if let Err(e) = self.spawn_session(ctx, ws) {
                 self.last_error = Some(format!("failed to spawn shell: {e}"));
             }
+        }
+        if add_project_requested {
+            self.add_project_via_dialog();
         }
         if let Some(d) = cycle_tabs_delta {
             self.cycle_tabs(d);


### PR DESCRIPTION
## Summary
- Adds a keyboard shortcut (`Ctrl+Shift+O`) that opens the same folder picker as the `+` button in the Projects sidebar.
- Wired into `handle_shortcuts` so it's automatically suppressed while a modal is open.

## Test plan
- [ ] `cargo run -p alacritree`, press `Ctrl+Shift+O`, pick a folder — project appears in the left sidebar.
- [ ] With a modal open (e.g. create-worktree prompt), `Ctrl+Shift+O` does nothing.
- [ ] Existing shortcuts (`Ctrl+B`, `Ctrl+G`, `Ctrl+T`, `Ctrl+Tab`, `Ctrl+Alt+←/→`, `Ctrl+Q`) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)