### PR TITLE
Fix font glyph fallback to match alacritty

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -109,6 +109,8 @@ pub struct AlacritreeApp {
     quit_dialog_open: bool,
     pending_delete: Option<DeleteRequest>,
     pending_create: Option<CreateState>,
+    /// Shared across sessions; auto-invalidated when cell size changes.
+    builtin_glyphs: crate::builtin_font::BuiltinGlyphCache,
 }
 
 struct DeleteRequest {
@@ -205,6 +207,7 @@ impl AlacritreeApp {
             quit_dialog_open: false,
             pending_delete: None,
             pending_create: None,
+            builtin_glyphs: crate::builtin_font::BuiltinGlyphCache::new(),
         };
 
         if let Err(e) = app.spawn_session(&cc.egui_ctx, None) {
@@ -1617,7 +1620,13 @@ impl eframe::App for AlacritreeApp {
                     return;
                 };
                 let session = &mut self.sessions[idx];
-                let _ = terminal_view::show(ui, session, &self.config, !modal_open);
+                let _ = terminal_view::show(
+                    ui,
+                    session,
+                    &self.config,
+                    !modal_open,
+                    &mut self.builtin_glyphs,
+                );
             });
 
         if self.pending_create.is_some() {

--- a/alacritree/src/builtin_font.rs
+++ b/alacritree/src/builtin_font.rs
@@ -1,0 +1,1072 @@
+//! Hand-rolled drawing of unicode characters that need to fully cover their
+//! character area.
+//!
+//! Faithful port of `alacritty/src/renderer/text/builtin_font.rs`.  We keep
+//! the bitmap-canvas pipeline intact (instead of reimplementing each glyph as
+//! egui shapes) so the pixel output matches alacritty cell-for-cell — that's
+//! the point of `font.builtin_box_drawing`: identical, gap-free renderings of
+//! box drawing / block / sextant / Powerline characters.
+//!
+//! The crossfont-tied output type is replaced with `BuiltinGlyph`, which
+//! exposes the bitmap as an `egui::ColorImage` (white with alpha = source R)
+//! so `painter.image(..., tint)` produces fg-colored output.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::{cmp, mem, ops};
+
+use egui::{Color32, ColorImage, Context, TextureHandle, TextureOptions};
+
+use crate::config::FontDelta;
+
+/// GPU-resident cache of built-in glyphs for one cell size.  Lives at the app
+/// level so it persists across frames and across sessions; rebuilt lazily on
+/// the first draw at a new cell size.  Keyed by `char` because (cell_w_px,
+/// cell_h_px) are an invariant of the cache instance — a size change wipes
+/// every entry rather than tagging keys with the size.
+pub struct BuiltinGlyphCache {
+    /// Pixel-space cell size the cached textures were rasterized for; once
+    /// this changes (font resize, DPI change) every entry is invalidated.
+    cell_size: (u32, u32),
+    entries: HashMap<char, CachedGlyph>,
+}
+
+pub struct CachedGlyph {
+    pub texture: TextureHandle,
+    pub top: i32,
+    pub left: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl BuiltinGlyphCache {
+    pub fn new() -> Self {
+        Self { cell_size: (0, 0), entries: HashMap::new() }
+    }
+
+    /// Get or rasterize the glyph for `c` at `metrics`.  Returns `None` for
+    /// characters outside the built-in coverage range, or when the renderer
+    /// declines (e.g. powerline arrows in too-narrow cells).
+    pub fn get(
+        &mut self,
+        ctx: &Context,
+        c: char,
+        metrics: &Metrics,
+        offset: &FontDelta,
+        glyph_offset: &FontDelta,
+    ) -> Option<&CachedGlyph> {
+        let size = (metrics.average_advance.round() as u32, metrics.line_height.round() as u32);
+        if self.cell_size != size {
+            self.entries.clear();
+            self.cell_size = size;
+        }
+        if !self.entries.contains_key(&c) {
+            let glyph = builtin_glyph(c, metrics, offset, glyph_offset)?;
+            // `clone` here just unwraps Arc; the Vec<Color32> backing the
+            // image is moved into egui's texture upload.
+            let image = Arc::try_unwrap(glyph.image).unwrap_or_else(|arc| (*arc).clone());
+            let texture =
+                ctx.load_texture(format!("builtin_{:x}", c as u32), image, TextureOptions::NEAREST);
+            self.entries.insert(
+                c,
+                CachedGlyph {
+                    texture,
+                    top: glyph.top,
+                    left: glyph.left,
+                    width: glyph.width,
+                    height: glyph.height,
+                },
+            );
+        }
+        self.entries.get(&c)
+    }
+}
+
+impl Default for BuiltinGlyphCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const COLOR_FILL_ALPHA_STEP_1: Pixel = Pixel { _r: 192, _g: 192, _b: 192 };
+const COLOR_FILL_ALPHA_STEP_2: Pixel = Pixel { _r: 128, _g: 128, _b: 128 };
+const COLOR_FILL_ALPHA_STEP_3: Pixel = Pixel { _r: 64, _g: 64, _b: 64 };
+
+/// Default color used for filling.
+const COLOR_FILL: Pixel = Pixel { _r: 255, _g: 255, _b: 255 };
+
+const POWERLINE_TRIANGLE_LTR: char = '\u{e0b0}';
+const POWERLINE_ARROW_LTR: char = '\u{e0b1}';
+const POWERLINE_TRIANGLE_RTL: char = '\u{e0b2}';
+const POWERLINE_ARROW_RTL: char = '\u{e0b3}';
+
+/// Subset of `crossfont::Metrics` consumed by the built-in renderer.  Only
+/// the three fields actually referenced inside `box_drawing` /
+/// `powerline_drawing` are kept, so callers don't need a full font shaper.
+#[derive(Clone, Copy, Debug)]
+pub struct Metrics {
+    pub average_advance: f64,
+    pub line_height: f64,
+    pub descent: f32,
+}
+
+/// Output of the built-in renderer.  `image` is in egui's premultiplied
+/// `Color32` format with `(r,g,b,a) = (src,src,src,src)` so tinting at paint
+/// time multiplies cleanly into the foreground color.  `top`/`left` mirror
+/// crossfont's `RasterizedGlyph` positioning relative to the baseline; the
+/// caller converts those to a screen rect.
+pub struct BuiltinGlyph {
+    pub image: Arc<ColorImage>,
+    pub top: i32,
+    pub left: i32,
+    pub width: i32,
+    pub height: i32,
+    /// Layout advance from alacritty's `RasterizedGlyph`; cache consumers
+    /// read width/height instead, but it's preserved so this output stays
+    /// shape-compatible with the upstream renderer.
+    #[allow(dead_code)]
+    pub advance: (i32, i32),
+}
+
+/// True iff `builtin_glyph` would return `Some` for `c`.  Used by the painter
+/// to decide whether to detour through the bitmap cache before laying down
+/// text shapes — avoids the cost of a full attempt for every cell.
+pub fn is_builtin_glyph(c: char) -> bool {
+    matches!(
+        c,
+        '\u{2500}'..='\u{259f}'
+            | '\u{1fb00}'..='\u{1fb3b}'
+            | '\u{1fb82}'..='\u{1fb8b}'
+            | POWERLINE_TRIANGLE_LTR..=POWERLINE_ARROW_RTL
+    )
+}
+
+/// Returns the rasterized glyph if the character is part of the built-in font.
+pub fn builtin_glyph(
+    character: char,
+    metrics: &Metrics,
+    offset: &FontDelta,
+    glyph_offset: &FontDelta,
+) -> Option<BuiltinGlyph> {
+    let mut glyph = match character {
+        // Box drawing characters and block elements.
+        '\u{2500}'..='\u{259f}' | '\u{1fb00}'..='\u{1fb3b}' | '\u{1fb82}'..='\u{1fb8b}' => {
+            box_drawing(character, metrics, offset)
+        },
+        // Powerline symbols: '','','',''
+        POWERLINE_TRIANGLE_LTR..=POWERLINE_ARROW_RTL => {
+            powerline_drawing(character, metrics, offset)?
+        },
+        _ => return None,
+    };
+
+    // Since we want to ignore `glyph_offset` for the built-in font, subtract it to compensate its
+    // addition when loading glyphs in the renderer.
+    glyph.left -= glyph_offset.x as i32;
+    glyph.top -= glyph_offset.y as i32;
+
+    Some(glyph)
+}
+
+fn box_drawing(character: char, metrics: &Metrics, offset: &FontDelta) -> BuiltinGlyph {
+    // Ensure that width and height is at least one.
+    let height = (metrics.line_height as i32 + offset.y as i32).max(1) as usize;
+    let width = (metrics.average_advance as i32 + offset.x as i32).max(1) as usize;
+    let stroke_size = calculate_stroke_size(width);
+    let heavy_stroke_size = stroke_size * 2;
+
+    // Certain symbols require larger canvas than the cell itself, since for proper contiguous
+    // lines they require drawing on neighbour cells. So treat them specially early on and handle
+    // 'normal' characters later.
+    let mut canvas = match character {
+        // Diagonals: '╱', '╲', '╳'.
+        '\u{2571}'..='\u{2573}' => {
+            // Last coordinates.
+            let x_end = width as f32;
+            let mut y_end = height as f32;
+
+            let top = height as i32 + metrics.descent as i32 + stroke_size as i32;
+            let height = height + 2 * stroke_size;
+            let mut canvas = Canvas::new(width, height + 2 * stroke_size);
+
+            // The offset that we should take into account when drawing, since we've enlarged
+            // buffer vertically by twice of that amount.
+            let y_offset = stroke_size as f32;
+            y_end += y_offset;
+
+            let k = y_end / x_end;
+            let f_x = |x: f32, h: f32| -> f32 { -k * x + h + y_offset };
+            let g_x = |x: f32, h: f32| -> f32 { k * x + h + y_offset };
+
+            let from_x = 0.;
+            let to_x = x_end + 1.;
+            for stroke_size in 0..2 * stroke_size {
+                let stroke_size = stroke_size as f32 / 2.;
+                if character == '\u{2571}' || character == '\u{2573}' {
+                    let h = y_end - stroke_size;
+                    let from_y = f_x(from_x, h);
+                    let to_y = f_x(to_x, h);
+                    canvas.draw_line(from_x, from_y, to_x, to_y);
+                }
+                if character == '\u{2572}' || character == '\u{2573}' {
+                    let from_y = g_x(from_x, stroke_size);
+                    let to_y = g_x(to_x, stroke_size);
+                    canvas.draw_line(from_x, from_y, to_x, to_y);
+                }
+            }
+
+            return BuiltinGlyph {
+                image: canvas.into_color_image(),
+                top,
+                left: 0,
+                height: height as i32,
+                width: width as i32,
+                advance: (width as i32, height as i32),
+            };
+        },
+        _ => Canvas::new(width, height),
+    };
+
+    match character {
+        // Horizontal dashes: '┄', '┅', '┈', '┉', '╌', '╍'.
+        '\u{2504}' | '\u{2505}' | '\u{2508}' | '\u{2509}' | '\u{254c}' | '\u{254d}' => {
+            let (num_gaps, stroke_size) = match character {
+                '\u{2504}' => (2, stroke_size),
+                '\u{2505}' => (2, heavy_stroke_size),
+                '\u{2508}' => (3, stroke_size),
+                '\u{2509}' => (3, heavy_stroke_size),
+                '\u{254c}' => (1, stroke_size),
+                '\u{254d}' => (1, heavy_stroke_size),
+                _ => unreachable!(),
+            };
+
+            let dash_gap_len = cmp::max(width / 8, 1);
+            let dash_len =
+                cmp::max(width.saturating_sub(dash_gap_len * num_gaps) / (num_gaps + 1), 1);
+            let y = canvas.y_center();
+            for gap in 0..=num_gaps {
+                let x = cmp::min(gap * (dash_len + dash_gap_len), width);
+                canvas.draw_h_line(x as f32, y, dash_len as f32, stroke_size);
+            }
+        },
+        // Vertical dashes: '┆', '┇', '┊', '┋', '╎', '╏'.
+        '\u{2506}' | '\u{2507}' | '\u{250a}' | '\u{250b}' | '\u{254e}' | '\u{254f}' => {
+            let (num_gaps, stroke_size) = match character {
+                '\u{2506}' => (2, stroke_size),
+                '\u{2507}' => (2, heavy_stroke_size),
+                '\u{250a}' => (3, stroke_size),
+                '\u{250b}' => (3, heavy_stroke_size),
+                '\u{254e}' => (1, stroke_size),
+                '\u{254f}' => (1, heavy_stroke_size),
+                _ => unreachable!(),
+            };
+
+            let dash_gap_len = cmp::max(height / 8, 1);
+            let dash_len =
+                cmp::max(height.saturating_sub(dash_gap_len * num_gaps) / (num_gaps + 1), 1);
+            let x = canvas.x_center();
+            for gap in 0..=num_gaps {
+                let y = cmp::min(gap * (dash_len + dash_gap_len), height);
+                canvas.draw_v_line(x, y as f32, dash_len as f32, stroke_size);
+            }
+        },
+        // Horizontal lines: '─', '━', '╴', '╶', '╸', '╺'.
+        // Vertical lines: '│', '┃', '╵', '╷', '╹', '╻'.
+        // Light and heavy line box components:
+        // '┌','┍','┎','┏','┐','┑','┒','┓','└','┕','┖','┗','┘','┙','┚','┛',├','┝','┞','┟','┠','┡',
+        // '┢','┣','┤','┥','┦','┧','┨','┩','┪','┫','┬','┭','┮','┯','┰','┱','┲','┳','┴','┵','┶','┷',
+        // '┸','┹','┺','┻','┼','┽','┾','┿','╀','╁','╂','╃','╄','╅','╆','╇','╈','╉','╊','╋'.
+        // Mixed light and heavy lines: '╼', '╽', '╾', '╿'.
+        '\u{2500}'..='\u{2503}' | '\u{250c}'..='\u{254b}' | '\u{2574}'..='\u{257f}' => {
+            // Left horizontal line.
+            let stroke_size_h1 = match character {
+                '\u{2500}' | '\u{2510}' | '\u{2512}' | '\u{2518}' | '\u{251a}' | '\u{2524}'
+                | '\u{2526}' | '\u{2527}' | '\u{2528}' | '\u{252c}' | '\u{252e}' | '\u{2530}'
+                | '\u{2532}' | '\u{2534}' | '\u{2536}' | '\u{2538}' | '\u{253a}' | '\u{253c}'
+                | '\u{253e}' | '\u{2540}' | '\u{2541}' | '\u{2542}' | '\u{2544}' | '\u{2546}'
+                | '\u{254a}' | '\u{2574}' | '\u{257c}' => stroke_size,
+                '\u{2501}' | '\u{2511}' | '\u{2513}' | '\u{2519}' | '\u{251b}' | '\u{2525}'
+                | '\u{2529}' | '\u{252a}' | '\u{252b}' | '\u{252d}' | '\u{252f}' | '\u{2531}'
+                | '\u{2533}' | '\u{2535}' | '\u{2537}' | '\u{2539}' | '\u{253b}' | '\u{253d}'
+                | '\u{253f}' | '\u{2543}' | '\u{2545}' | '\u{2547}' | '\u{2548}' | '\u{2549}'
+                | '\u{254b}' | '\u{2578}' | '\u{257e}' => heavy_stroke_size,
+                _ => 0,
+            };
+            // Right horizontal line.
+            let stroke_size_h2 = match character {
+                '\u{2500}' | '\u{250c}' | '\u{250e}' | '\u{2514}' | '\u{2516}' | '\u{251c}'
+                | '\u{251e}' | '\u{251f}' | '\u{2520}' | '\u{252c}' | '\u{252d}' | '\u{2530}'
+                | '\u{2531}' | '\u{2534}' | '\u{2535}' | '\u{2538}' | '\u{2539}' | '\u{253c}'
+                | '\u{253d}' | '\u{2540}' | '\u{2541}' | '\u{2542}' | '\u{2543}' | '\u{2545}'
+                | '\u{2549}' | '\u{2576}' | '\u{257e}' => stroke_size,
+                '\u{2501}' | '\u{250d}' | '\u{250f}' | '\u{2515}' | '\u{2517}' | '\u{251d}'
+                | '\u{2521}' | '\u{2522}' | '\u{2523}' | '\u{252e}' | '\u{252f}' | '\u{2532}'
+                | '\u{2533}' | '\u{2536}' | '\u{2537}' | '\u{253a}' | '\u{253b}' | '\u{253e}'
+                | '\u{253f}' | '\u{2544}' | '\u{2546}' | '\u{2547}' | '\u{2548}' | '\u{254a}'
+                | '\u{254b}' | '\u{257a}' | '\u{257c}' => heavy_stroke_size,
+                _ => 0,
+            };
+            // Top vertical line.
+            let stroke_size_v1 = match character {
+                '\u{2502}' | '\u{2514}' | '\u{2515}' | '\u{2518}' | '\u{2519}' | '\u{251c}'
+                | '\u{251d}' | '\u{251f}' | '\u{2522}' | '\u{2524}' | '\u{2525}' | '\u{2527}'
+                | '\u{252a}' | '\u{2534}' | '\u{2535}' | '\u{2536}' | '\u{2537}' | '\u{253c}'
+                | '\u{253d}' | '\u{253e}' | '\u{253f}' | '\u{2541}' | '\u{2545}' | '\u{2546}'
+                | '\u{2548}' | '\u{2575}' | '\u{257d}' => stroke_size,
+                '\u{2503}' | '\u{2516}' | '\u{2517}' | '\u{251a}' | '\u{251b}' | '\u{251e}'
+                | '\u{2520}' | '\u{2521}' | '\u{2523}' | '\u{2526}' | '\u{2528}' | '\u{2529}'
+                | '\u{252b}' | '\u{2538}' | '\u{2539}' | '\u{253a}' | '\u{253b}' | '\u{2540}'
+                | '\u{2542}' | '\u{2543}' | '\u{2544}' | '\u{2547}' | '\u{2549}' | '\u{254a}'
+                | '\u{254b}' | '\u{2579}' | '\u{257f}' => heavy_stroke_size,
+                _ => 0,
+            };
+            // Bottom vertical line.
+            let stroke_size_v2 = match character {
+                '\u{2502}' | '\u{250c}' | '\u{250d}' | '\u{2510}' | '\u{2511}' | '\u{251c}'
+                | '\u{251d}' | '\u{251e}' | '\u{2521}' | '\u{2524}' | '\u{2525}' | '\u{2526}'
+                | '\u{2529}' | '\u{252c}' | '\u{252d}' | '\u{252e}' | '\u{252f}' | '\u{253c}'
+                | '\u{253d}' | '\u{253e}' | '\u{253f}' | '\u{2540}' | '\u{2543}' | '\u{2544}'
+                | '\u{2547}' | '\u{2577}' | '\u{257f}' => stroke_size,
+                '\u{2503}' | '\u{250e}' | '\u{250f}' | '\u{2512}' | '\u{2513}' | '\u{251f}'
+                | '\u{2520}' | '\u{2522}' | '\u{2523}' | '\u{2527}' | '\u{2528}' | '\u{252a}'
+                | '\u{252b}' | '\u{2530}' | '\u{2531}' | '\u{2532}' | '\u{2533}' | '\u{2541}'
+                | '\u{2542}' | '\u{2545}' | '\u{2546}' | '\u{2548}' | '\u{2549}' | '\u{254a}'
+                | '\u{254b}' | '\u{257b}' | '\u{257d}' => heavy_stroke_size,
+                _ => 0,
+            };
+
+            let x_v = canvas.x_center();
+            let y_h = canvas.y_center();
+
+            let v_line_bounds_top = canvas.v_line_bounds(x_v, stroke_size_v1);
+            let v_line_bounds_bot = canvas.v_line_bounds(x_v, stroke_size_v2);
+            let h_line_bounds_left = canvas.h_line_bounds(y_h, stroke_size_h1);
+            let h_line_bounds_right = canvas.h_line_bounds(y_h, stroke_size_h2);
+
+            let size_h1 = cmp::max(v_line_bounds_top.1 as i32, v_line_bounds_bot.1 as i32) as f32;
+            let x_h = cmp::min(v_line_bounds_top.0 as i32, v_line_bounds_bot.0 as i32) as f32;
+            let size_h2 = width as f32 - x_h;
+
+            let size_v1 =
+                cmp::max(h_line_bounds_left.1 as i32, h_line_bounds_right.1 as i32) as f32;
+            let y_v = cmp::min(h_line_bounds_left.0 as i32, h_line_bounds_right.0 as i32) as f32;
+            let size_v2 = height as f32 - y_v;
+
+            // Left horizontal line.
+            canvas.draw_h_line(0., y_h, size_h1, stroke_size_h1);
+            // Right horizontal line.
+            canvas.draw_h_line(x_h, y_h, size_h2, stroke_size_h2);
+            // Top vertical line.
+            canvas.draw_v_line(x_v, 0., size_v1, stroke_size_v1);
+            // Bottom vertical line.
+            canvas.draw_v_line(x_v, y_v, size_v2, stroke_size_v2);
+        },
+        // Light and double line box components:
+        // '═','║','╒','╓','╔','╕','╖','╗','╘','╙','╚','╛','╜','╝','╞','╟','╠','╡','╢','╣','╤','╥',
+        // '╦','╧','╨','╩','╪','╫','╬'.
+        '\u{2550}'..='\u{256c}' => {
+            let v_lines = match character {
+                '\u{2552}' | '\u{2555}' | '\u{2558}' | '\u{255b}' | '\u{255e}' | '\u{2561}'
+                | '\u{2564}' | '\u{2567}' | '\u{256a}' => (canvas.x_center(), canvas.x_center()),
+                _ => {
+                    let v_line_bounds = canvas.v_line_bounds(canvas.x_center(), stroke_size);
+                    let left_line = cmp::max(v_line_bounds.0 as i32 - 1, 0) as f32;
+                    let right_line = cmp::min(v_line_bounds.1 as i32 + 1, width as i32) as f32;
+
+                    (left_line, right_line)
+                },
+            };
+            let h_lines = match character {
+                '\u{2553}' | '\u{2556}' | '\u{2559}' | '\u{255c}' | '\u{255f}' | '\u{2562}'
+                | '\u{2565}' | '\u{2568}' | '\u{256b}' => (canvas.y_center(), canvas.y_center()),
+                _ => {
+                    let h_line_bounds = canvas.h_line_bounds(canvas.y_center(), stroke_size);
+                    let top_line = cmp::max(h_line_bounds.0 as i32 - 1, 0) as f32;
+                    let bottom_line = cmp::min(h_line_bounds.1 as i32 + 1, height as i32) as f32;
+
+                    (top_line, bottom_line)
+                },
+            };
+
+            // Get bounds for each double line we could have.
+            let v_left_bounds = canvas.v_line_bounds(v_lines.0, stroke_size);
+            let v_right_bounds = canvas.v_line_bounds(v_lines.1, stroke_size);
+            let h_top_bounds = canvas.h_line_bounds(h_lines.0, stroke_size);
+            let h_bot_bounds = canvas.h_line_bounds(h_lines.1, stroke_size);
+
+            let height = height as f32;
+            let width = width as f32;
+
+            // Left horizontal part.
+            let (top_left_size, bot_left_size) = match character {
+                '\u{2550}' | '\u{256b}' => (canvas.x_center(), canvas.x_center()),
+                '\u{2555}'..='\u{2557}' => (v_right_bounds.1, v_left_bounds.1),
+                '\u{255b}'..='\u{255d}' => (v_left_bounds.1, v_right_bounds.1),
+                '\u{2561}'..='\u{2563}' | '\u{256a}' | '\u{256c}' => {
+                    (v_left_bounds.1, v_left_bounds.1)
+                },
+                '\u{2564}'..='\u{2568}' => (canvas.x_center(), v_left_bounds.1),
+                '\u{2569}'..='\u{2569}' => (v_left_bounds.1, canvas.x_center()),
+                _ => (0., 0.),
+            };
+
+            // Right horizontal part.
+            let (top_right_x, bot_right_x, right_size) = match character {
+                '\u{2550}' | '\u{2565}' | '\u{256b}' => {
+                    (canvas.x_center(), canvas.x_center(), width)
+                },
+                '\u{2552}'..='\u{2554}' | '\u{2568}' => (v_left_bounds.0, v_right_bounds.0, width),
+                '\u{2558}'..='\u{255a}' => (v_right_bounds.0, v_left_bounds.0, width),
+                '\u{255e}'..='\u{2560}' | '\u{256a}' | '\u{256c}' => {
+                    (v_right_bounds.0, v_right_bounds.0, width)
+                },
+                '\u{2564}' | '\u{2566}' => (canvas.x_center(), v_right_bounds.0, width),
+                '\u{2567}' | '\u{2569}' => (v_right_bounds.0, canvas.x_center(), width),
+                _ => (0., 0., 0.),
+            };
+
+            // Top vertical part.
+            let (left_top_size, right_top_size) = match character {
+                '\u{2551}' | '\u{256a}' => (canvas.y_center(), canvas.y_center()),
+                '\u{2558}'..='\u{255c}' | '\u{2568}' => (h_bot_bounds.1, h_top_bounds.1),
+                '\u{255d}' => (h_top_bounds.1, h_bot_bounds.1),
+                '\u{255e}'..='\u{2560}' => (canvas.y_center(), h_top_bounds.1),
+                '\u{2561}'..='\u{2563}' => (h_top_bounds.1, canvas.y_center()),
+                '\u{2567}' | '\u{2569}' | '\u{256b}' | '\u{256c}' => {
+                    (h_top_bounds.1, h_top_bounds.1)
+                },
+                _ => (0., 0.),
+            };
+
+            // Bottom vertical part.
+            let (left_bot_y, right_bot_y, bottom_size) = match character {
+                '\u{2551}' | '\u{256a}' => (canvas.y_center(), canvas.y_center(), height),
+                '\u{2552}'..='\u{2554}' => (h_top_bounds.0, h_bot_bounds.0, height),
+                '\u{2555}'..='\u{2557}' => (h_bot_bounds.0, h_top_bounds.0, height),
+                '\u{255e}'..='\u{2560}' => (canvas.y_center(), h_bot_bounds.0, height),
+                '\u{2561}'..='\u{2563}' => (h_bot_bounds.0, canvas.y_center(), height),
+                '\u{2564}'..='\u{2566}' | '\u{256b}' | '\u{256c}' => {
+                    (h_bot_bounds.0, h_bot_bounds.0, height)
+                },
+                _ => (0., 0., 0.),
+            };
+
+            // Left horizontal line.
+            canvas.draw_h_line(0., h_lines.0, top_left_size, stroke_size);
+            canvas.draw_h_line(0., h_lines.1, bot_left_size, stroke_size);
+
+            // Right horizontal line.
+            canvas.draw_h_line(top_right_x, h_lines.0, right_size, stroke_size);
+            canvas.draw_h_line(bot_right_x, h_lines.1, right_size, stroke_size);
+
+            // Top vertical line.
+            canvas.draw_v_line(v_lines.0, 0., left_top_size, stroke_size);
+            canvas.draw_v_line(v_lines.1, 0., right_top_size, stroke_size);
+
+            // Bottom vertical line.
+            canvas.draw_v_line(v_lines.0, left_bot_y, bottom_size, stroke_size);
+            canvas.draw_v_line(v_lines.1, right_bot_y, bottom_size, stroke_size);
+        },
+        // Arcs: '╭', '╮', '╯', '╰'.
+        '\u{256d}' | '\u{256e}' | '\u{256f}' | '\u{2570}' => {
+            canvas.draw_rounded_corner(stroke_size);
+
+            // Mirror `X` axis.
+            if character == '\u{256d}' || character == '\u{2570}' {
+                let center = canvas.x_center() as usize;
+
+                let extra_offset = usize::from(stroke_size % 2 != width % 2);
+
+                let buffer = canvas.buffer_mut();
+                for y in 1..height {
+                    let left = (y - 1) * width;
+                    let right = y * width - 1;
+                    if extra_offset != 0 {
+                        buffer[right] = buffer[left];
+                    }
+                    for offset in 0..center {
+                        buffer.swap(left + offset, right - offset - extra_offset);
+                    }
+                }
+            }
+            // Mirror `Y` axis.
+            if character == '\u{256d}' || character == '\u{256e}' {
+                let center = canvas.y_center() as usize;
+
+                let extra_offset = usize::from(stroke_size % 2 != height % 2);
+
+                let buffer = canvas.buffer_mut();
+                if extra_offset != 0 {
+                    let bottom_row = (height - 1) * width;
+                    for index in 0..width {
+                        buffer[bottom_row + index] = buffer[index];
+                    }
+                }
+                for offset in 1..=center {
+                    let top_row = (offset - 1) * width;
+                    let bottom_row = (height - offset - extra_offset) * width;
+                    for index in 0..width {
+                        buffer.swap(top_row + index, bottom_row + index);
+                    }
+                }
+            }
+        },
+        // Parts of full block: '▀', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '▔', '▉', '▊', '▋', '▌',
+        // '▍', '▎', '▏', '▐', '▕', '🮂', '🮃', '🮄', '🮅', '🮆', '🮇', '🮈', '🮉', '🮊', '🮋'.
+        '\u{2580}'..='\u{2587}'
+        | '\u{2589}'..='\u{2590}'
+        | '\u{2594}'
+        | '\u{2595}'
+        | '\u{1fb82}'..='\u{1fb8b}' => {
+            let width = width as f32;
+            let height = height as f32;
+            let mut rect_width = match character {
+                '\u{2589}' | '\u{1fb8b}' => width * 7. / 8.,
+                '\u{258a}' | '\u{1fb8a}' => width * 6. / 8.,
+                '\u{258b}' | '\u{1fb89}' => width * 5. / 8.,
+                '\u{258c}' => width * 4. / 8.,
+                '\u{258d}' | '\u{1fb88}' => width * 3. / 8.,
+                '\u{258e}' | '\u{1fb87}' => width * 2. / 8.,
+                '\u{258f}' => width * 1. / 8.,
+                '\u{2590}' => width * 4. / 8.,
+                '\u{2595}' => width * 1. / 8.,
+                _ => width,
+            };
+
+            let (mut rect_height, mut y) = match character {
+                '\u{2580}' => (height * 4. / 8., height * 8. / 8.),
+                '\u{2581}' => (height * 1. / 8., height * 1. / 8.),
+                '\u{2582}' => (height * 2. / 8., height * 2. / 8.),
+                '\u{2583}' => (height * 3. / 8., height * 3. / 8.),
+                '\u{2584}' => (height * 4. / 8., height * 4. / 8.),
+                '\u{2585}' => (height * 5. / 8., height * 5. / 8.),
+                '\u{2586}' => (height * 6. / 8., height * 6. / 8.),
+                '\u{2587}' => (height * 7. / 8., height * 7. / 8.),
+                '\u{2594}' => (height * 1. / 8., height * 8. / 8.),
+                '\u{1fb82}' => (height * 2. / 8., height * 8. / 8.),
+                '\u{1fb83}' => (height * 3. / 8., height * 8. / 8.),
+                '\u{1fb84}' => (height * 5. / 8., height * 8. / 8.),
+                '\u{1fb85}' => (height * 6. / 8., height * 8. / 8.),
+                '\u{1fb86}' => (height * 7. / 8., height * 8. / 8.),
+                _ => (height, height),
+            };
+
+            // Fix `y` coordinates.
+            y = (height - y).round();
+
+            // Ensure that resulted glyph will be visible and also round sizes instead of straight
+            // flooring them.
+            rect_width = rect_width.round().max(1.);
+            rect_height = rect_height.round().max(1.);
+
+            let x = match character {
+                '\u{2590}' => canvas.x_center(),
+                '\u{2595}' | '\u{1fb87}'..='\u{1fb8b}' => width - rect_width,
+                _ => 0.,
+            };
+
+            canvas.draw_rect(x, y, rect_width, rect_height, COLOR_FILL);
+        },
+        // Shades: '░', '▒', '▓', '█'.
+        '\u{2588}' | '\u{2591}' | '\u{2592}' | '\u{2593}' => {
+            let color = match character {
+                '\u{2588}' => COLOR_FILL,
+                '\u{2591}' => COLOR_FILL_ALPHA_STEP_3,
+                '\u{2592}' => COLOR_FILL_ALPHA_STEP_2,
+                '\u{2593}' => COLOR_FILL_ALPHA_STEP_1,
+                _ => unreachable!(),
+            };
+            canvas.fill(color);
+        },
+        // Quadrants: '▖', '▗', '▘', '▙', '▚', '▛', '▜', '▝', '▞', '▟'.
+        '\u{2596}'..='\u{259F}' => {
+            let x_center = canvas.x_center().round().max(1.);
+            let y_center = canvas.y_center().round().max(1.);
+
+            let (w_second, h_second) = match character {
+                '\u{2598}' | '\u{2599}' | '\u{259a}' | '\u{259b}' | '\u{259c}' => {
+                    (x_center, y_center)
+                },
+                _ => (0., 0.),
+            };
+            let (w_first, h_first) = match character {
+                '\u{259b}' | '\u{259c}' | '\u{259d}' | '\u{259e}' | '\u{259f}' => {
+                    (x_center, y_center)
+                },
+                _ => (0., 0.),
+            };
+            let (w_third, h_third) = match character {
+                '\u{2596}' | '\u{2599}' | '\u{259b}' | '\u{259e}' | '\u{259f}' => {
+                    (x_center, y_center)
+                },
+                _ => (0., 0.),
+            };
+            let (w_fourth, h_fourth) = match character {
+                '\u{2597}' | '\u{2599}' | '\u{259a}' | '\u{259c}' | '\u{259f}' => {
+                    (x_center, y_center)
+                },
+                _ => (0., 0.),
+            };
+
+            // Second quadrant.
+            canvas.draw_rect(0., 0., w_second, h_second, COLOR_FILL);
+            // First quadrant.
+            canvas.draw_rect(x_center, 0., w_first, h_first, COLOR_FILL);
+            // Third quadrant.
+            canvas.draw_rect(0., y_center, w_third, h_third, COLOR_FILL);
+            // Fourth quadrant.
+            canvas.draw_rect(x_center, y_center, w_fourth, h_fourth, COLOR_FILL);
+        },
+        // Sextants: '🬀', '🬁', '🬂', '🬃', '🬄', '🬅', '🬆', '🬇', '🬈', '🬉', '🬊', '🬋', '🬌', '🬍', '🬎',
+        // '🬏', '🬐', '🬑', '🬒', '🬓', '🬔', '🬕', '🬖', '🬗', '🬘', '🬙', '🬚', '🬛', '🬜', '🬝', '🬞', '🬟',
+        // '🬠', '🬡', '🬢', '🬣', '🬤', '🬥', '🬦', '🬧', '🬨', '🬩', '🬪', '🬫', '🬬', '🬭', '🬮', '🬯', '🬰',
+        // '🬱', '🬲', '🬳', '🬴', '🬵', '🬶', '🬷', '🬸', '🬹', '🬺', '🬻'.
+        '\u{1fb00}'..='\u{1fb3b}' => {
+            let x_center = canvas.x_center().round().max(1.);
+            let y_third = (height as f32 / 3.).round().max(1.);
+            let y_last_third = height as f32 - 2. * y_third;
+
+            let (w_top_left, h_top_left) = match character {
+                '\u{1fb00}' | '\u{1fb02}' | '\u{1fb04}' | '\u{1fb06}' | '\u{1fb08}'
+                | '\u{1fb0a}' | '\u{1fb0c}' | '\u{1fb0e}' | '\u{1fb10}' | '\u{1fb12}'
+                | '\u{1fb15}' | '\u{1fb17}' | '\u{1fb19}' | '\u{1fb1b}' | '\u{1fb1d}'
+                | '\u{1fb1f}' | '\u{1fb21}' | '\u{1fb23}' | '\u{1fb25}' | '\u{1fb27}'
+                | '\u{1fb28}' | '\u{1fb2a}' | '\u{1fb2c}' | '\u{1fb2e}' | '\u{1fb30}'
+                | '\u{1fb32}' | '\u{1fb34}' | '\u{1fb36}' | '\u{1fb38}' | '\u{1fb3a}' => {
+                    (x_center, y_third)
+                },
+                _ => (0., 0.),
+            };
+            let (w_top_right, h_top_right) = match character {
+                '\u{1fb01}' | '\u{1fb02}' | '\u{1fb05}' | '\u{1fb06}' | '\u{1fb09}'
+                | '\u{1fb0a}' | '\u{1fb0d}' | '\u{1fb0e}' | '\u{1fb11}' | '\u{1fb12}'
+                | '\u{1fb14}' | '\u{1fb15}' | '\u{1fb18}' | '\u{1fb19}' | '\u{1fb1c}'
+                | '\u{1fb1d}' | '\u{1fb20}' | '\u{1fb21}' | '\u{1fb24}' | '\u{1fb25}'
+                | '\u{1fb28}' | '\u{1fb2b}' | '\u{1fb2c}' | '\u{1fb2f}' | '\u{1fb30}'
+                | '\u{1fb33}' | '\u{1fb34}' | '\u{1fb37}' | '\u{1fb38}' | '\u{1fb3b}' => {
+                    (x_center, y_third)
+                },
+                _ => (0., 0.),
+            };
+            let (w_mid_left, h_mid_left) = match character {
+                '\u{1fb03}' | '\u{1fb04}' | '\u{1fb05}' | '\u{1fb06}' | '\u{1fb0b}'
+                | '\u{1fb0c}' | '\u{1fb0d}' | '\u{1fb0e}' | '\u{1fb13}' | '\u{1fb14}'
+                | '\u{1fb15}' | '\u{1fb1a}' | '\u{1fb1b}' | '\u{1fb1c}' | '\u{1fb1d}'
+                | '\u{1fb22}' | '\u{1fb23}' | '\u{1fb24}' | '\u{1fb25}' | '\u{1fb29}'
+                | '\u{1fb2a}' | '\u{1fb2b}' | '\u{1fb2c}' | '\u{1fb31}' | '\u{1fb32}'
+                | '\u{1fb33}' | '\u{1fb34}' | '\u{1fb39}' | '\u{1fb3a}' | '\u{1fb3b}' => {
+                    (x_center, y_third)
+                },
+                _ => (0., 0.),
+            };
+            let (w_mid_right, h_mid_right) = match character {
+                '\u{1fb07}' | '\u{1fb08}' | '\u{1fb09}' | '\u{1fb0a}' | '\u{1fb0b}'
+                | '\u{1fb0c}' | '\u{1fb0d}' | '\u{1fb0e}' | '\u{1fb16}' | '\u{1fb17}'
+                | '\u{1fb18}' | '\u{1fb19}' | '\u{1fb1a}' | '\u{1fb1b}' | '\u{1fb1c}'
+                | '\u{1fb1d}' | '\u{1fb26}' | '\u{1fb27}' | '\u{1fb28}' | '\u{1fb29}'
+                | '\u{1fb2a}' | '\u{1fb2b}' | '\u{1fb2c}' | '\u{1fb35}' | '\u{1fb36}'
+                | '\u{1fb37}' | '\u{1fb38}' | '\u{1fb39}' | '\u{1fb3a}' | '\u{1fb3b}' => {
+                    (x_center, y_third)
+                },
+                _ => (0., 0.),
+            };
+            let (w_bottom_left, h_bottom_left) = match character {
+                '\u{1fb0f}' | '\u{1fb10}' | '\u{1fb11}' | '\u{1fb12}' | '\u{1fb13}'
+                | '\u{1fb14}' | '\u{1fb15}' | '\u{1fb16}' | '\u{1fb17}' | '\u{1fb18}'
+                | '\u{1fb19}' | '\u{1fb1a}' | '\u{1fb1b}' | '\u{1fb1c}' | '\u{1fb1d}'
+                | '\u{1fb2d}' | '\u{1fb2e}' | '\u{1fb2f}' | '\u{1fb30}' | '\u{1fb31}'
+                | '\u{1fb32}' | '\u{1fb33}' | '\u{1fb34}' | '\u{1fb35}' | '\u{1fb36}'
+                | '\u{1fb37}' | '\u{1fb38}' | '\u{1fb39}' | '\u{1fb3a}' | '\u{1fb3b}' => {
+                    (x_center, y_last_third)
+                },
+                _ => (0., 0.),
+            };
+            let (w_bottom_right, h_bottom_right) = match character {
+                '\u{1fb1e}' | '\u{1fb1f}' | '\u{1fb20}' | '\u{1fb21}' | '\u{1fb22}'
+                | '\u{1fb23}' | '\u{1fb24}' | '\u{1fb25}' | '\u{1fb26}' | '\u{1fb27}'
+                | '\u{1fb28}' | '\u{1fb29}' | '\u{1fb2a}' | '\u{1fb2b}' | '\u{1fb2c}'
+                | '\u{1fb2d}' | '\u{1fb2e}' | '\u{1fb2f}' | '\u{1fb30}' | '\u{1fb31}'
+                | '\u{1fb32}' | '\u{1fb33}' | '\u{1fb34}' | '\u{1fb35}' | '\u{1fb36}'
+                | '\u{1fb37}' | '\u{1fb38}' | '\u{1fb39}' | '\u{1fb3a}' | '\u{1fb3b}' => {
+                    (x_center, y_last_third)
+                },
+                _ => (0., 0.),
+            };
+
+            canvas.draw_rect(0., 0., w_top_left, h_top_left, COLOR_FILL);
+            canvas.draw_rect(x_center, 0., w_top_right, h_top_right, COLOR_FILL);
+            canvas.draw_rect(0., y_third, w_mid_left, h_mid_left, COLOR_FILL);
+            canvas.draw_rect(x_center, y_third, w_mid_right, h_mid_right, COLOR_FILL);
+            canvas.draw_rect(0., y_third * 2., w_bottom_left, h_bottom_left, COLOR_FILL);
+            canvas.draw_rect(x_center, y_third * 2., w_bottom_right, h_bottom_right, COLOR_FILL);
+        },
+        _ => unreachable!(),
+    }
+
+    let top = height as i32 + metrics.descent as i32;
+    BuiltinGlyph {
+        image: canvas.into_color_image(),
+        top,
+        left: 0,
+        height: height as i32,
+        width: width as i32,
+        advance: (width as i32, height as i32),
+    }
+}
+
+fn powerline_drawing(
+    character: char,
+    metrics: &Metrics,
+    offset: &FontDelta,
+) -> Option<BuiltinGlyph> {
+    let height = (metrics.line_height as i32 + offset.y as i32) as usize;
+    let width = (metrics.average_advance as i32 + offset.x as i32) as usize;
+    let extra_thickness = calculate_stroke_size(width) as i32 - 1;
+
+    let mut canvas = Canvas::new(width, height);
+
+    let slope = 1;
+    let top_y = 1;
+    let bottom_y = height as i32 - top_y - 1;
+
+    // Start with offset `1` and draw until the intersection of the f(x) = slope * x + 1 and
+    // g(x) = H - slope * x - 1 lines. The intersection happens when f(x) = g(x), which is at
+    // x = (H - 2) / (2 * slope).
+    let x_intersection = (height as i32 + 1) / 2 - 1;
+
+    // Don't use built-in font if we'd cut the tip too much, for example when the font is really
+    // narrow.
+    if x_intersection - width as i32 > 1 {
+        return None;
+    }
+
+    let top_line = (0..x_intersection).map(|x| line_equation(slope, x, top_y));
+    let bottom_line = (0..x_intersection).map(|x| line_equation(-slope, x, bottom_y));
+
+    // Inner lines to make arrows thicker.
+    let mut top_inner_line = (0..x_intersection - extra_thickness)
+        .map(|x| line_equation(slope, x, top_y + extra_thickness));
+    let mut bottom_inner_line = (0..x_intersection - extra_thickness)
+        .map(|x| line_equation(-slope, x, bottom_y - extra_thickness));
+
+    // NOTE: top_line and bottom_line have the same amount of iterations.
+    for (p1, p2) in top_line.zip(bottom_line) {
+        if character == POWERLINE_TRIANGLE_LTR || character == POWERLINE_TRIANGLE_RTL {
+            canvas.draw_rect(0., p1.1, p1.0 + 1., 1., COLOR_FILL);
+            canvas.draw_rect(0., p2.1, p2.0 + 1., 1., COLOR_FILL);
+        } else if character == POWERLINE_ARROW_LTR || character == POWERLINE_ARROW_RTL {
+            let p3 = top_inner_line.next().unwrap_or(p2);
+            let p4 = bottom_inner_line.next().unwrap_or(p1);
+
+            // If we can't fit the entire arrow in the cell, we cut off the tip of the arrow by
+            // drawing a rectangle between the two lines.
+            if p1.0 as usize + 1 == width {
+                canvas.draw_rect(p1.0, p1.1, 1., p2.1 - p1.1 + 1., COLOR_FILL);
+                break;
+            } else {
+                canvas.draw_rect(p1.0, p1.1, 1., p3.1 - p1.1 + 1., COLOR_FILL);
+                canvas.draw_rect(p4.0, p4.1, 1., p2.1 - p4.1 + 1., COLOR_FILL);
+            }
+        }
+    }
+
+    if character == POWERLINE_TRIANGLE_RTL || character == POWERLINE_ARROW_RTL {
+        canvas.flip_horizontal();
+    }
+
+    let top = height as i32 + metrics.descent as i32;
+    Some(BuiltinGlyph {
+        image: canvas.into_color_image(),
+        top,
+        left: 0,
+        height: height as i32,
+        width: width as i32,
+        advance: (width as i32, height as i32),
+    })
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Pixel {
+    _r: u8,
+    _g: u8,
+    _b: u8,
+}
+
+impl Pixel {
+    fn gray(color: u8) -> Self {
+        Self { _r: color, _g: color, _b: color }
+    }
+}
+
+impl ops::Add for Pixel {
+    type Output = Pixel;
+
+    fn add(self, rhs: Pixel) -> Self::Output {
+        let _r = self._r.saturating_add(rhs._r);
+        let _g = self._g.saturating_add(rhs._g);
+        let _b = self._b.saturating_add(rhs._b);
+        Pixel { _r, _g, _b }
+    }
+}
+
+impl ops::Div<u8> for Pixel {
+    type Output = Pixel;
+
+    fn div(self, rhs: u8) -> Self::Output {
+        let _r = self._r / rhs;
+        let _g = self._g / rhs;
+        let _b = self._b / rhs;
+        Pixel { _r, _g, _b }
+    }
+}
+
+/// Canvas which is used for simple line drawing operations.
+///
+/// The coordinate system is the following:
+///
+///  0             x
+///  --------------→
+///  |
+///  |
+///  |
+///  |
+///  |
+///  |
+/// y↓
+struct Canvas {
+    width: usize,
+    height: usize,
+    buffer: Vec<Pixel>,
+}
+
+impl Canvas {
+    fn new(width: usize, height: usize) -> Self {
+        let buffer = vec![Pixel::default(); width * height];
+        Self { width, height, buffer }
+    }
+
+    fn y_center(&self) -> f32 {
+        self.height as f32 / 2.
+    }
+
+    fn x_center(&self) -> f32 {
+        self.width as f32 / 2.
+    }
+
+    fn buffer_mut(&mut self) -> &mut [Pixel] {
+        &mut self.buffer
+    }
+
+    fn h_line_bounds(&self, y: f32, stroke_size: usize) -> (f32, f32) {
+        let start_y = cmp::max((y - stroke_size as f32 / 2.) as i32, 0) as f32;
+        let end_y = cmp::min((y + stroke_size as f32 / 2.) as i32, self.height as i32) as f32;
+        (start_y, end_y)
+    }
+
+    fn v_line_bounds(&self, x: f32, stroke_size: usize) -> (f32, f32) {
+        let start_x = cmp::max((x - stroke_size as f32 / 2.) as i32, 0) as f32;
+        let end_x = cmp::min((x + stroke_size as f32 / 2.) as i32, self.width as i32) as f32;
+        (start_x, end_x)
+    }
+
+    fn flip_horizontal(&mut self) {
+        for row in 0..self.height {
+            for col in 0..self.width / 2 {
+                let index = row * self.width;
+                self.buffer.swap(index + col, index + self.width - col - 1)
+            }
+        }
+    }
+
+    fn draw_h_line(&mut self, x: f32, y: f32, size: f32, stroke_size: usize) {
+        let (start_y, end_y) = self.h_line_bounds(y, stroke_size);
+        self.draw_rect(x, start_y, size, end_y - start_y, COLOR_FILL);
+    }
+
+    fn draw_v_line(&mut self, x: f32, y: f32, size: f32, stroke_size: usize) {
+        let (start_x, end_x) = self.v_line_bounds(x, stroke_size);
+        self.draw_rect(start_x, y, end_x - start_x, size, COLOR_FILL);
+    }
+
+    fn draw_rect(&mut self, x: f32, y: f32, width: f32, height: f32, color: Pixel) {
+        let start_x = x as usize;
+        let end_x = cmp::min((x + width) as usize, self.width);
+        let start_y = y as usize;
+        let end_y = cmp::min((y + height) as usize, self.height);
+        for y in start_y..end_y {
+            let y = y * self.width;
+            self.buffer[start_x + y..end_x + y].fill(color);
+        }
+    }
+
+    #[inline]
+    fn put_pixel(&mut self, x: f32, y: f32, color: Pixel) {
+        if x < 0. || y < 0. || x > self.width as f32 - 1. || y > self.height as f32 - 1. {
+            return;
+        }
+        let index = x as usize + y as usize * self.width;
+        if color._r > self.buffer[index]._r {
+            self.buffer[index] = color;
+        }
+    }
+
+    /// Xiaolin Wu's line drawing from (`from_x`, `from_y`) to (`to_x`, `to_y`).
+    fn draw_line(&mut self, mut from_x: f32, mut from_y: f32, mut to_x: f32, mut to_y: f32) {
+        let steep = (to_y - from_y).abs() > (to_x - from_x).abs();
+        if steep {
+            mem::swap(&mut from_x, &mut from_y);
+            mem::swap(&mut to_x, &mut to_y);
+        }
+        if from_x > to_x {
+            mem::swap(&mut from_x, &mut to_x);
+            mem::swap(&mut from_y, &mut to_y);
+        }
+
+        let delta_x = to_x - from_x;
+        let delta_y = to_y - from_y;
+        let gradient = if delta_x.abs() <= f32::EPSILON { 1. } else { delta_y / delta_x };
+
+        let x_end = f32::round(from_x);
+        let y_end = from_y + gradient * (x_end - from_x);
+        let x_gap = 1. - (from_x + 0.5).fract();
+
+        let xpxl1 = x_end;
+        let ypxl1 = y_end.trunc();
+
+        let color_1 = Pixel::gray(((1. - y_end.fract()) * x_gap * COLOR_FILL._r as f32) as u8);
+        let color_2 = Pixel::gray((y_end.fract() * x_gap * COLOR_FILL._r as f32) as u8);
+        if steep {
+            self.put_pixel(ypxl1, xpxl1, color_1);
+            self.put_pixel(ypxl1 + 1., xpxl1, color_2);
+        } else {
+            self.put_pixel(xpxl1, ypxl1, color_1);
+            self.put_pixel(xpxl1 + 1., ypxl1, color_2);
+        }
+
+        let mut intery = y_end + gradient;
+
+        let x_end = f32::round(to_x);
+        let y_end = to_y + gradient * (x_end - to_x);
+        let x_gap = (to_x + 0.5).fract();
+        let xpxl2 = x_end;
+        let ypxl2 = y_end.trunc();
+
+        let color_1 = Pixel::gray(((1. - y_end.fract()) * x_gap * COLOR_FILL._r as f32) as u8);
+        let color_2 = Pixel::gray((y_end.fract() * x_gap * COLOR_FILL._r as f32) as u8);
+        if steep {
+            self.put_pixel(ypxl2, xpxl2, color_1);
+            self.put_pixel(ypxl2 + 1., xpxl2, color_2);
+        } else {
+            self.put_pixel(xpxl2, ypxl2, color_1);
+            self.put_pixel(xpxl2, ypxl2 + 1., color_2);
+        }
+
+        if steep {
+            for x in xpxl1 as i32 + 1..xpxl2 as i32 {
+                let color_1 = Pixel::gray(((1. - intery.fract()) * COLOR_FILL._r as f32) as u8);
+                let color_2 = Pixel::gray((intery.fract() * COLOR_FILL._r as f32) as u8);
+                self.put_pixel(intery.trunc(), x as f32, color_1);
+                self.put_pixel(intery.trunc() + 1., x as f32, color_2);
+                intery += gradient;
+            }
+        } else {
+            for x in xpxl1 as i32 + 1..xpxl2 as i32 {
+                let color_1 = Pixel::gray(((1. - intery.fract()) * COLOR_FILL._r as f32) as u8);
+                let color_2 = Pixel::gray((intery.fract() * COLOR_FILL._r as f32) as u8);
+                self.put_pixel(x as f32, intery.trunc(), color_1);
+                self.put_pixel(x as f32, intery.trunc() + 1., color_2);
+                intery += gradient;
+            }
+        }
+    }
+
+    /// Draws a quarter of a circle centered in `(0., self.height - radius)` with radius
+    /// `self.width` and an attached rectangle to form a "╭" using a given `stroke_size` in the
+    /// bottom-right quadrant of the `Canvas` coordinate system.
+    fn draw_rounded_corner(&mut self, stroke_size: usize) {
+        let radius = (self.width.min(self.height) + stroke_size) as f32 / 2.;
+        let stroke_size_f = stroke_size as f32;
+
+        let mut x_offset = 0.;
+        let mut y_offset = 0.;
+        let (long_side, short_side, offset) = if self.height > self.width {
+            (&self.height, &self.width, &mut y_offset)
+        } else {
+            (&self.width, &self.height, &mut x_offset)
+        };
+        let distance_bias = if short_side % 2 == stroke_size % 2 { 0. } else { 0.5 };
+        *offset = *long_side as f32 / 2. - radius + stroke_size_f / 2.;
+        if (self.width % 2 != self.height % 2) && (long_side % 2 == stroke_size % 2) {
+            *offset += 1.;
+        }
+
+        let radius_i = (short_side + stroke_size).div_ceil(2);
+        for y in 0..radius_i {
+            for x in 0..radius_i {
+                let y = y as f32;
+                let x = x as f32;
+                let distance = x.hypot(y) + distance_bias;
+                let value = if distance < radius - stroke_size_f - 1. {
+                    0.
+                } else if distance < radius - stroke_size_f {
+                    1. + distance - (radius - stroke_size_f)
+                } else if distance < radius - 1. {
+                    1.
+                } else if distance < radius {
+                    radius - distance
+                } else {
+                    0.
+                };
+
+                self.put_pixel(
+                    x + x_offset,
+                    y + y_offset,
+                    Pixel::gray((COLOR_FILL._r as f32 * value) as u8),
+                );
+            }
+        }
+
+        if self.height > self.width {
+            self.draw_rect(
+                self.x_center() - stroke_size_f * 0.5,
+                0.,
+                stroke_size_f,
+                y_offset,
+                COLOR_FILL,
+            );
+        } else {
+            self.draw_rect(
+                0.,
+                self.y_center() - stroke_size_f * 0.5,
+                x_offset,
+                stroke_size_f,
+                COLOR_FILL,
+            );
+        }
+    }
+
+    fn fill(&mut self, color: Pixel) {
+        self.buffer.fill(color);
+    }
+
+    /// Convert the gray-scale canvas to an egui-ready white image whose alpha
+    /// channel is the source intensity.  Painting via `painter.image(_, _, _,
+    /// fg_tint)` then multiplies the white through the tint, producing the
+    /// requested foreground color modulated by the glyph's coverage.
+    fn into_color_image(self) -> Arc<ColorImage> {
+        let pixels: Vec<Color32> = self
+            .buffer
+            .iter()
+            .map(|p| Color32::from_rgba_premultiplied(p._r, p._r, p._r, p._r))
+            .collect();
+        Arc::new(ColorImage { size: [self.width, self.height], pixels })
+    }
+}
+
+fn calculate_stroke_size(cell_width: usize) -> usize {
+    cmp::max((cell_width as f32 / 8.).round() as usize, 1)
+}
+
+fn line_equation(slope: i32, x: i32, offset: i32) -> (f32, f32) {
+    (x as f32, (slope * x + offset) as f32)
+}

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -36,6 +36,27 @@ pub struct FontConfig {
     pub bold: FontFace,
     pub italic: FontFace,
     pub bold_italic: FontFace,
+    /// Extra spacing per cell, mirroring alacritty's `font.offset`.  Added to
+    /// the per-cell width/height after the egui glyph metrics have been
+    /// floored to whole device pixels.
+    pub offset: FontDelta,
+    /// Pixel offset applied when painting glyphs inside the cell, mirroring
+    /// alacritty's `font.glyph_offset`.  Built-in glyphs deliberately ignore
+    /// this offset (they already align to the cell), matching alacritty.
+    pub glyph_offset: FontDelta,
+    /// When true, render box drawing / block / Powerline / Symbols-for-Legacy-
+    /// Computing characters from the built-in renderer instead of the font.
+    /// Default `true` matches alacritty.
+    pub builtin_box_drawing: bool,
+}
+
+/// Pixel delta with x/y, mirroring alacritty's `Delta<i8>` for `font.offset`
+/// and `font.glyph_offset`.  Kept as `i8` because that's the type alacritty's
+/// schema accepts and going wider would silently lose round-trip equivalence.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FontDelta {
+    pub x: i8,
+    pub y: i8,
 }
 
 impl FontConfig {
@@ -170,6 +191,9 @@ impl Default for FontConfig {
             bold: FontFace::default(),
             italic: FontFace::default(),
             bold_italic: FontFace::default(),
+            offset: FontDelta::default(),
+            glyph_offset: FontDelta::default(),
+            builtin_box_drawing: true,
         }
     }
 }
@@ -411,6 +435,9 @@ struct RawFont {
     bold: RawFontFace,
     italic: RawFontFace,
     bold_italic: RawFontFace,
+    offset: RawFontDelta,
+    glyph_offset: RawFontDelta,
+    builtin_box_drawing: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -418,6 +445,13 @@ struct RawFont {
 struct RawFontFace {
     family: Option<String>,
     style: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RawFontDelta {
+    x: Option<i8>,
+    y: Option<i8>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -648,6 +682,17 @@ impl RawConfig {
             family: self.font.bold_italic.family.clone(),
             style: self.font.bold_italic.style.clone(),
         };
+        font.offset = FontDelta {
+            x: self.font.offset.x.unwrap_or(font.offset.x),
+            y: self.font.offset.y.unwrap_or(font.offset.y),
+        };
+        font.glyph_offset = FontDelta {
+            x: self.font.glyph_offset.x.unwrap_or(font.glyph_offset.x),
+            y: self.font.glyph_offset.y.unwrap_or(font.glyph_offset.y),
+        };
+        if let Some(b) = self.font.builtin_box_drawing {
+            font.builtin_box_drawing = b;
+        }
 
         // ---- Cursor ----
         let mut cursor = config.cursor;

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -6,13 +6,25 @@
 //! mishandles `family:weight=bold` patterns when the family is an `<alias>`,
 //! so building the pattern programmatically is what makes weight/slant pick
 //! the real variant for aliased families.
+//!
+//! Beyond the four explicit faces we ask fontconfig for a `FcFontSort`
+//! Unicode-coverage-trimmed list and register every entry as a fallback.
+//! egui resolves glyphs by walking each family's font list in order, so
+//! this is what mirrors alacritty/crossfont's per-glyph fallback for
+//! symbols and box-drawing characters that aren't in the primary face.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use egui::{Context, FontData, FontDefinitions, FontFamily};
 
 use crate::config::FontFace;
+
+/// Hard cap on fallback faces.  fontconfig's trimmed sort tops out at a few
+/// dozen on a typical system; this just bounds startup memory and parse cost
+/// when someone has hundreds of fonts installed.
+const MAX_FALLBACK_FACES: usize = 32;
 
 pub const BOLD_FAMILY: &str = "alacritree_bold";
 pub const ITALIC_FAMILY: &str = "alacritree_italic";
@@ -42,6 +54,17 @@ impl Variant {
     }
 }
 
+/// Platform default that mirrors `crossfont::FontDescription::default`.  Used
+/// when the user hasn't set `[font.normal] family`, so alacritree picks the
+/// same face alacritty would pick from the same (empty) config.
+const DEFAULT_FAMILY: &str = if cfg!(target_os = "macos") {
+    "Menlo"
+} else if cfg!(windows) {
+    "Consolas"
+} else {
+    "monospace"
+};
+
 pub fn install_terminal_fonts(
     ctx: &Context,
     normal: &FontFace,
@@ -49,9 +72,7 @@ pub fn install_terminal_fonts(
     italic: &FontFace,
     bold_italic: &FontFace,
 ) {
-    let Some(family) = normal.family.as_deref() else {
-        return;
-    };
+    let family = normal.family.as_deref().unwrap_or(DEFAULT_FAMILY);
 
     // The variant lookups compare their resolved path against this one to
     // detect when fontconfig substituted the regular face for a missing variant.
@@ -102,7 +123,94 @@ pub fn install_terminal_fonts(
         &normal_bytes,
     );
 
+    let mut loaded_paths: HashSet<PathBuf> = HashSet::new();
+    loaded_paths.insert(normal_match.path.clone());
+
+    // Each variant gets its own fallback chain seeded from that variant's
+    // configured family — same as crossfont's per-FontDesc fallback search,
+    // so bold cells cascade through bold's chain and so on.
+    let normal_targets = [FontFamily::Monospace, FontFamily::Proportional];
+    let variant_targets =
+        [BOLD_FAMILY, ITALIC_FAMILY, BOLD_ITALIC_FAMILY].map(|n| [FontFamily::Name(n.into())]);
+    let seeds: [(&str, Option<&str>, Variant, &[FontFamily]); 4] = [
+        (family, normal.style.as_deref(), Variant::Normal, &normal_targets),
+        (bold_family, bold.style.as_deref(), Variant::Bold, &variant_targets[0]),
+        (italic_family, italic.style.as_deref(), Variant::Italic, &variant_targets[1]),
+        (
+            bold_italic_family,
+            bold_italic.style.as_deref(),
+            Variant::BoldItalic,
+            &variant_targets[2],
+        ),
+    ];
+    for (family, style, variant, targets) in seeds {
+        register_fallback_faces(&mut defs, family, style, variant, targets, &mut loaded_paths);
+    }
+
     ctx.set_fonts(defs);
+}
+
+/// Append every font from fontconfig's trimmed sort to `target_families` so
+/// that glyphs missing from the primary face (symbols, box drawing, emoji)
+/// fall through to a system font that has them.  Mirrors what crossfont does
+/// per-glyph in upstream alacritty.
+fn register_fallback_faces(
+    defs: &mut FontDefinitions,
+    family: &str,
+    style: Option<&str>,
+    variant: Variant,
+    target_families: &[FontFamily],
+    loaded_paths: &mut HashSet<PathBuf>,
+) {
+    let fallbacks = gather_fallback_faces(family, style, variant, loaded_paths, MAX_FALLBACK_FACES);
+    if fallbacks.is_empty() {
+        return;
+    }
+
+    for face in fallbacks {
+        let bytes = match std::fs::read(&face.path) {
+            Ok(b) => b,
+            Err(e) => {
+                log::debug!("skipping fallback font {}: {e}", face.path.display());
+                continue;
+            },
+        };
+        let id = format!("alacritree_fallback_{}", defs.font_data.len());
+        let data = FontData { index: face.face_index, ..FontData::from_owned(bytes) };
+        defs.font_data.insert(id.clone(), Arc::new(data));
+
+        for family in target_families {
+            defs.families.entry(family.clone()).or_default().push(id.clone());
+        }
+        loaded_paths.insert(face.path);
+    }
+}
+
+struct FallbackFace {
+    path: PathBuf,
+    face_index: u32,
+}
+
+#[cfg(unix)]
+fn gather_fallback_faces(
+    family: &str,
+    style: Option<&str>,
+    variant: Variant,
+    skip_paths: &HashSet<PathBuf>,
+    limit: usize,
+) -> Vec<FallbackFace> {
+    fontconfig_resolve::sorted_fallbacks(family, style, variant, skip_paths, limit)
+}
+
+#[cfg(not(unix))]
+fn gather_fallback_faces(
+    _family: &str,
+    _style: Option<&str>,
+    _variant: Variant,
+    _skip_paths: &HashSet<PathBuf>,
+    _limit: usize,
+) -> Vec<FallbackFace> {
+    Vec::new()
 }
 
 fn insert_face(defs: &mut FontDefinitions, id: &str, bytes: Vec<u8>) {
@@ -228,15 +336,16 @@ mod fontconfig_resolve {
     //! Doing this in code (vs `fc-match` CLI) is what makes `<alias>` rules
     //! plus weight/slant pick the right variant.
 
+    use std::collections::HashSet;
     use std::ffi::CString;
     use std::path::PathBuf;
 
     use fontconfig::{
         FC_FAMILY, FC_SLANT, FC_SLANT_ITALIC, FC_SLANT_ROMAN, FC_STYLE, FC_WEIGHT, FC_WEIGHT_BOLD,
-        FC_WEIGHT_REGULAR, Fontconfig, Pattern,
+        FC_WEIGHT_REGULAR, Fontconfig, Pattern, sort_fonts,
     };
 
-    use super::{ResolvedFace, Variant};
+    use super::{FallbackFace, ResolvedFace, Variant};
 
     pub fn resolve(family: &str, style: Option<&str>, variant: Variant) -> Option<ResolvedFace> {
         let fc = Fontconfig::new()?;
@@ -263,5 +372,65 @@ mod fontconfig_resolve {
         let matched = pattern.font_match();
         let path = matched.filename()?;
         Some(ResolvedFace { path: PathBuf::from(path) })
+    }
+
+    /// `FcFontSort` with `trim=true` returns fonts in match order, dropping
+    /// any whose Unicode coverage is fully covered by an earlier entry.  This
+    /// is the same chain `FcFontMatch` walks per glyph when crossfont misses,
+    /// so registering it up front in egui gives equivalent coverage.
+    pub fn sorted_fallbacks(
+        family: &str,
+        style: Option<&str>,
+        variant: Variant,
+        skip_paths: &HashSet<PathBuf>,
+        limit: usize,
+    ) -> Vec<FallbackFace> {
+        let Some(fc) = Fontconfig::new() else {
+            return Vec::new();
+        };
+        let mut pattern = Pattern::new(&fc);
+
+        if let Ok(family_c) = CString::new(family) {
+            pattern.add_string(FC_FAMILY, &family_c);
+        }
+        if let Some(style) = style {
+            if let Ok(style_c) = CString::new(style) {
+                pattern.add_string(FC_STYLE, &style_c);
+            }
+        }
+        let (weight, slant) = match variant {
+            Variant::Normal => (FC_WEIGHT_REGULAR, FC_SLANT_ROMAN),
+            Variant::Bold => (FC_WEIGHT_BOLD, FC_SLANT_ROMAN),
+            Variant::Italic => (FC_WEIGHT_REGULAR, FC_SLANT_ITALIC),
+            Variant::BoldItalic => (FC_WEIGHT_BOLD, FC_SLANT_ITALIC),
+        };
+        pattern.add_integer(FC_WEIGHT, weight);
+        pattern.add_integer(FC_SLANT, slant);
+
+        // FcFontSort requires FcConfigSubstitute + FcDefaultSubstitute to have
+        // been applied to the input pattern; otherwise <alias> rules never
+        // expand and the result list misses the fonts the user actually has.
+        // The 0.8 fontconfig wrapper keeps those private but applies them as
+        // a side effect inside `font_match`, so we run it for the side effect
+        // and discard the matched pattern.
+        let _ = pattern.font_match();
+
+        let sorted = sort_fonts(&pattern, true);
+        let mut out = Vec::with_capacity(limit.min(16));
+        for matched in sorted.iter() {
+            if out.len() >= limit {
+                break;
+            }
+            let Some(path_str) = matched.filename() else {
+                continue;
+            };
+            let path = PathBuf::from(path_str);
+            if skip_paths.contains(&path) {
+                continue;
+            }
+            let face_index = matched.face_index().unwrap_or(0).max(0) as u32;
+            out.push(FallbackFace { path, face_index });
+        }
+        out
     }
 }

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -2,6 +2,7 @@
 
 mod app;
 mod bindings;
+mod builtin_font;
 mod clipboard;
 mod colors;
 mod config;

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -25,9 +25,13 @@ pub fn show(ui: &mut Ui, session: &mut Session, config: &Config, allow_focus: bo
     // Floor cell size to whole device pixels — matches alacritty's
     // `compute_cell_size`.  Without this, fractional cell widths combined
     // with egui's AA fringe leave visible seams between adjacent cells.
+    // `font.offset` is added in pixel space so the round-trip through ppp is
+    // identical to alacritty (which adds offset to the integer cell metrics).
     let ppp = ui.ctx().pixels_per_point();
-    let cell_w = (cell_w_pt * ppp).floor().max(1.0) / ppp;
-    let cell_h = (cell_h_pt * ppp).floor().max(1.0) / ppp;
+    let offset_x = config.font.offset.x as f32;
+    let offset_y = config.font.offset.y as f32;
+    let cell_w = ((cell_w_pt * ppp).floor() + offset_x).max(1.0) / ppp;
+    let cell_h = ((cell_h_pt * ppp).floor() + offset_y).max(1.0) / ppp;
 
     let pad_x = config.window.padding_x;
     let pad_y = config.window.padding_y;
@@ -436,13 +440,15 @@ fn paint_run(
     if !style.flags.contains(Flags::HIDDEN) {
         // Per-glyph paint: egui's run layout drifts off the cursor's `col * cell_w` grid (worse with zoom).
         let glyph_font = font_for_flags(style.flags, font_id);
+        let glyph_dx = config.font.glyph_offset.x as f32;
+        let glyph_dy = config.font.glyph_offset.y as f32;
         let mut buf = [0u8; 4];
         for (i, ch) in run.chars().enumerate() {
             if ch == ' ' {
                 continue;
             }
             painter.text(
-                Pos2::new(x + i as f32 * cell_w, y),
+                Pos2::new(x + i as f32 * cell_w + glyph_dx, y + glyph_dy),
                 egui::Align2::LEFT_TOP,
                 ch.encode_utf8(&mut buf).to_string(),
                 glyph_font.clone(),

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -8,6 +8,7 @@ use egui::{
     Color32, FontFamily, FontId, PointerButton, Pos2, Rect, Response, Sense, Stroke, Ui, Vec2,
 };
 
+use crate::builtin_font::{BuiltinGlyphCache, Metrics, is_builtin_glyph};
 use crate::clipboard::{self, Target};
 use crate::colors::{background, foreground, resolve, rgb_to_color32};
 use crate::config::Config;
@@ -15,7 +16,13 @@ use crate::fonts::{BOLD_FAMILY, BOLD_ITALIC_FAMILY, ITALIC_FAMILY};
 use crate::input::event_to_bytes;
 use crate::session::{EventProxy, Session, TermSize};
 
-pub fn show(ui: &mut Ui, session: &mut Session, config: &Config, allow_focus: bool) -> Response {
+pub fn show(
+    ui: &mut Ui,
+    session: &mut Session,
+    config: &Config,
+    allow_focus: bool,
+    builtin_glyphs: &mut BuiltinGlyphCache,
+) -> Response {
     let font_id = FontId::monospace(config.font.egui_size());
     let (cell_w_pt, cell_h_pt) = ui.ctx().fonts(|f| {
         let w = f.glyph_width(&font_id, 'M');
@@ -67,7 +74,30 @@ pub fn show(ui: &mut Ui, session: &mut Session, config: &Config, allow_focus: bo
 
     drain_pty_events(session);
     handle_selection(ui, &response, session, config, rect, cell_w, cell_h, cols, rows);
-    paint_grid(&painter, rect, session, config, &font_id, cell_w, cell_h);
+    // Built-in renderer expects the *unadjusted* pixel cell size so it can
+    // re-apply `font.offset` itself — passing `cell_w * ppp` (which already
+    // includes the offset) would double-add it.  Descent is zero here: the
+    // alacritty renderer's `top - descent` math collapses when descent is
+    // zero, and `paint_builtin_glyph` positions images using that simplified
+    // form.
+    let metrics = Metrics {
+        average_advance: (cell_w_pt * ppp).floor() as f64,
+        line_height: (cell_h_pt * ppp).floor() as f64,
+        descent: 0.0,
+    };
+    paint_grid(
+        &painter,
+        rect,
+        session,
+        config,
+        &font_id,
+        cell_w,
+        cell_h,
+        ppp,
+        &metrics,
+        builtin_glyphs,
+        ui.ctx(),
+    );
 
     if allow_focus && response.has_focus() {
         let consumed: Vec<Vec<u8>> =
@@ -272,6 +302,7 @@ impl Style {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn paint_grid(
     painter: &egui::Painter,
     rect: Rect,
@@ -280,6 +311,10 @@ fn paint_grid(
     font_id: &FontId,
     cell_w: f32,
     cell_h: f32,
+    ppp: f32,
+    metrics: &Metrics,
+    builtin_glyphs: &mut BuiltinGlyphCache,
+    ctx: &egui::Context,
 ) {
     let term = session.term.lock();
     let runtime_palette = term.colors();
@@ -337,6 +372,10 @@ fn paint_grid(
                 font_id,
                 bg_color,
                 selected,
+                ppp,
+                metrics,
+                builtin_glyphs,
+                ctx,
             );
         }
     }
@@ -389,6 +428,10 @@ fn paint_run(
     font_id: &FontId,
     default_bg: Color32,
     selected: bool,
+    ppp: f32,
+    metrics: &Metrics,
+    builtin_glyphs: &mut BuiltinGlyphCache,
+    ctx: &egui::Context,
 ) {
     if run.is_empty() {
         return;
@@ -447,8 +490,22 @@ fn paint_run(
             if ch == ' ' {
                 continue;
             }
+            let cell_x = x + i as f32 * cell_w;
+            if config.font.builtin_box_drawing
+                && is_builtin_glyph(ch)
+                && let Some(cached) = builtin_glyphs.get(
+                    ctx,
+                    ch,
+                    metrics,
+                    &config.font.offset,
+                    &config.font.glyph_offset,
+                )
+            {
+                paint_builtin_glyph(painter, cached, cell_x, y, cell_h, ppp, fg);
+                continue;
+            }
             painter.text(
-                Pos2::new(x + i as f32 * cell_w + glyph_dx, y + glyph_dy),
+                Pos2::new(cell_x + glyph_dx, y + glyph_dy),
                 egui::Align2::LEFT_TOP,
                 ch.encode_utf8(&mut buf).to_string(),
                 glyph_font.clone(),
@@ -536,4 +593,28 @@ fn paint_cursor(
             glyph_color,
         );
     }
+}
+
+/// Place the cached pixel-space glyph into the cell.  alacritty positions
+/// glyphs as `screen_y_top = baseline - top` with `baseline = cell_bottom`;
+/// because we pass `descent = 0` to the renderer, that simplifies to
+/// `cell_h - top`.  We do the same arithmetic in logical points by dividing
+/// the pixel offsets by `ppp`.
+fn paint_builtin_glyph(
+    painter: &egui::Painter,
+    cached: &crate::builtin_font::CachedGlyph,
+    cell_x: f32,
+    cell_y: f32,
+    cell_h: f32,
+    ppp: f32,
+    fg: Color32,
+) {
+    let w_pt = cached.width as f32 / ppp;
+    let h_pt = cached.height as f32 / ppp;
+    let dy_pt = cell_h - cached.top as f32 / ppp;
+    let dx_pt = cached.left as f32 / ppp;
+    let glyph_rect =
+        Rect::from_min_size(Pos2::new(cell_x + dx_pt, cell_y + dy_pt), Vec2::new(w_pt, h_pt));
+    let uv = Rect::from_min_max(Pos2::new(0.0, 0.0), Pos2::new(1.0, 1.0));
+    painter.image(cached.texture.id(), glyph_rect, uv, fg);
 }


### PR DESCRIPTION
## Summary
- Previously only the user's primary face + its bold/italic variants were registered, so glyphs missing from that font (⌂, ⎿, ✽, …) fell through only to the four bundled epaint fonts (Hack/Ubuntu/NotoEmoji/emoji-icon) and rendered as tofu.
- Use fontconfig's `FcFontSort` with `trim=true` to get the same Unicode-coverage chain alacritty walks per glyph via crossfont, then append every entry to all four monospace family lists in egui.
- Capped at 32 fallback faces to bound startup memory; non-Unix builds keep the old behavior.

## Test plan
- [ ] `cargo run -p alacritree` and confirm ⌂ ⎿ ✽ render in a terminal session
- [ ] Verify bold/italic cells still pick the correct primary variant
- [ ] Spot check Unicode coverage stays sane on a system without `monospace` aliased