### PR TITLE
Wire up more alacritty keyboard actions and document shortcuts

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -491,6 +491,28 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::Quit) => {
                 self.quit_dialog_open = true;
             },
+            BindingAction::Named(NamedAction::ClearHistory) => {
+                use alacritty_terminal::vte::ansi::{ClearMode, Handler};
+                if let Some(idx) = self.active_session_index() {
+                    self.sessions[idx].term.lock().clear_screen(ClearMode::Saved);
+                }
+            },
+            BindingAction::Named(NamedAction::ToggleFullscreen) => {
+                let on = ctx.input(|i| i.viewport().fullscreen.unwrap_or(false));
+                ctx.send_viewport_cmd(egui::ViewportCommand::Fullscreen(!on));
+            },
+            BindingAction::Named(NamedAction::ToggleMaximized) => {
+                let on = ctx.input(|i| i.viewport().maximized.unwrap_or(false));
+                ctx.send_viewport_cmd(egui::ViewportCommand::Maximized(!on));
+            },
+            BindingAction::Named(NamedAction::Minimize) => {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
+            },
+            BindingAction::Named(NamedAction::SelectNextTab) => self.cycle_tabs(1),
+            BindingAction::Named(NamedAction::SelectPreviousTab) => self.cycle_tabs(-1),
+            BindingAction::Named(NamedAction::SelectTab(n)) => self.select_tab(n),
+            BindingAction::Named(NamedAction::SelectLastTab) => self.select_last_tab(),
+            BindingAction::Named(NamedAction::NoOp) => {},
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
             },
@@ -522,6 +544,27 @@ impl AlacritreeApp {
         if let Some(s) = scroll {
             term.scroll_display(s);
         }
+    }
+
+    fn select_tab(&mut self, n: u8) {
+        if n == 0 {
+            return;
+        }
+        let indices = self.current_session_indices();
+        let Some(&session_idx) = indices.get((n - 1) as usize) else {
+            return;
+        };
+        let id = self.sessions[session_idx].id;
+        self.set_active_in_current_workspace(id);
+    }
+
+    fn select_last_tab(&mut self) {
+        let indices = self.current_session_indices();
+        let Some(&session_idx) = indices.last() else {
+            return;
+        };
+        let id = self.sessions[session_idx].id;
+        self.set_active_in_current_workspace(id);
     }
 
     fn show_tab_strip(&mut self, ui: &mut egui::Ui) {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -389,12 +389,10 @@ impl AlacritreeApp {
             if consume_exact(i, egui::Modifiers::CTRL, egui::Key::Tab) {
                 cycle_tabs_delta = Some(1);
             }
-            if consume_exact(i, egui::Modifiers::CTRL | egui::Modifiers::ALT, egui::Key::ArrowRight)
-            {
+            if consume_exact(i, egui::Modifiers::ALT, egui::Key::ArrowRight) {
                 cycle_ws_delta = Some(1);
             }
-            if consume_exact(i, egui::Modifiers::CTRL | egui::Modifiers::ALT, egui::Key::ArrowLeft)
-            {
+            if consume_exact(i, egui::Modifiers::ALT, egui::Key::ArrowLeft) {
                 cycle_ws_delta = Some(-1);
             }
             if consume_exact(i, egui::Modifiers::CTRL, egui::Key::Q) {

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -31,11 +31,22 @@ pub enum NamedAction {
     ScrollLineDown,
     ScrollToTop,
     ScrollToBottom,
+    ClearHistory,
     SpawnNewInstance,
     IncreaseFontSize,
     DecreaseFontSize,
     ResetFontSize,
+    ToggleFullscreen,
+    ToggleMaximized,
+    Minimize,
+    SelectNextTab,
+    SelectPreviousTab,
+    /// 1-indexed.
+    SelectTab(u8),
+    SelectLastTab,
     Quit,
+    /// Used to unbind a key — consumes the press without acting on it.
+    NoOp,
 }
 
 #[derive(Debug, Deserialize)]
@@ -126,6 +137,8 @@ fn default_bindings() -> Vec<KeyBinding> {
     #[cfg(target_os = "macos")]
     {
         let cmd = Modifiers::COMMAND;
+        let cmd_shift = Modifiers::COMMAND | Modifiers::SHIFT;
+        let cmd_ctrl = Modifiers::COMMAND | Modifiers::CTRL;
         b.extend([
             KeyBinding { key: Key::V, mods: cmd, action: BindingAction::Named(Paste) },
             KeyBinding { key: Key::C, mods: cmd, action: BindingAction::Named(Copy) },
@@ -147,6 +160,32 @@ fn default_bindings() -> Vec<KeyBinding> {
                 mods: cmd,
                 action: BindingAction::Named(DecreaseFontSize),
             },
+            KeyBinding {
+                key: Key::CloseBracket,
+                mods: cmd_shift,
+                action: BindingAction::Named(SelectNextTab),
+            },
+            KeyBinding {
+                key: Key::OpenBracket,
+                mods: cmd_shift,
+                action: BindingAction::Named(SelectPreviousTab),
+            },
+            KeyBinding { key: Key::Num1, mods: cmd, action: BindingAction::Named(SelectTab(1)) },
+            KeyBinding { key: Key::Num2, mods: cmd, action: BindingAction::Named(SelectTab(2)) },
+            KeyBinding { key: Key::Num3, mods: cmd, action: BindingAction::Named(SelectTab(3)) },
+            KeyBinding { key: Key::Num4, mods: cmd, action: BindingAction::Named(SelectTab(4)) },
+            KeyBinding { key: Key::Num5, mods: cmd, action: BindingAction::Named(SelectTab(5)) },
+            KeyBinding { key: Key::Num6, mods: cmd, action: BindingAction::Named(SelectTab(6)) },
+            KeyBinding { key: Key::Num7, mods: cmd, action: BindingAction::Named(SelectTab(7)) },
+            KeyBinding { key: Key::Num8, mods: cmd, action: BindingAction::Named(SelectTab(8)) },
+            KeyBinding { key: Key::Num9, mods: cmd, action: BindingAction::Named(SelectLastTab) },
+            KeyBinding {
+                key: Key::F,
+                mods: cmd_ctrl,
+                action: BindingAction::Named(ToggleFullscreen),
+            },
+            KeyBinding { key: Key::M, mods: cmd, action: BindingAction::Named(Minimize) },
+            KeyBinding { key: Key::K, mods: cmd, action: BindingAction::Named(ClearHistory) },
             KeyBinding { key: Key::Q, mods: cmd, action: BindingAction::Named(Quit) },
         ]);
     }
@@ -345,13 +384,30 @@ fn parse_action(name: &str) -> BindingAction {
         "ScrollLineDown" => BindingAction::Named(ScrollLineDown),
         "ScrollToTop" => BindingAction::Named(ScrollToTop),
         "ScrollToBottom" => BindingAction::Named(ScrollToBottom),
+        "ClearHistory" => BindingAction::Named(ClearHistory),
         "SpawnNewInstance" | "CreateNewWindow" | "CreateNewTab" => {
             BindingAction::Named(SpawnNewInstance)
         },
         "IncreaseFontSize" => BindingAction::Named(IncreaseFontSize),
         "DecreaseFontSize" => BindingAction::Named(DecreaseFontSize),
         "ResetFontSize" => BindingAction::Named(ResetFontSize),
+        "ToggleFullscreen" => BindingAction::Named(ToggleFullscreen),
+        "ToggleMaximized" => BindingAction::Named(ToggleMaximized),
+        "Minimize" => BindingAction::Named(Minimize),
+        "SelectNextTab" => BindingAction::Named(SelectNextTab),
+        "SelectPreviousTab" => BindingAction::Named(SelectPreviousTab),
+        "SelectTab1" => BindingAction::Named(SelectTab(1)),
+        "SelectTab2" => BindingAction::Named(SelectTab(2)),
+        "SelectTab3" => BindingAction::Named(SelectTab(3)),
+        "SelectTab4" => BindingAction::Named(SelectTab(4)),
+        "SelectTab5" => BindingAction::Named(SelectTab(5)),
+        "SelectTab6" => BindingAction::Named(SelectTab(6)),
+        "SelectTab7" => BindingAction::Named(SelectTab(7)),
+        "SelectTab8" => BindingAction::Named(SelectTab(8)),
+        "SelectTab9" => BindingAction::Named(SelectTab(9)),
+        "SelectLastTab" => BindingAction::Named(SelectLastTab),
         "Quit" => BindingAction::Named(Quit),
+        "None" => BindingAction::Named(NoOp),
         other => BindingAction::Unsupported(other.to_string()),
     }
 }

--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -15,11 +15,13 @@ fn main() {
     let dest = env::var("OUT_DIR").unwrap();
     let mut file = File::create(Path::new(&dest).join("gl_bindings.rs")).unwrap();
 
-    Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, [
-        "GL_ARB_blend_func_extended",
-        "GL_KHR_robustness",
-        "GL_KHR_debug",
-    ])
+    Registry::new(
+        Api::Gl,
+        (3, 3),
+        Profile::Core,
+        Fallbacks::All,
+        ["GL_ARB_blend_func_extended", "GL_KHR_robustness", "GL_KHR_debug"],
+    )
     .write_bindings(GlobalGenerator, &mut file)
     .unwrap();
 

--- a/alacritty/src/display/damage.rs
+++ b/alacritty/src/display/damage.rs
@@ -361,12 +361,10 @@ mod tests {
         let width = 10;
         let size_info = SizeInfo::new(viewport_height, viewport_height, 5., 5., 0., 0., true);
         frame_damage.add_viewport_rect(&size_info, x, y, width, height);
-        assert_eq!(frame_damage.rects[0], Rect {
-            x,
-            y: viewport_height as i32 - y - height,
-            width,
-            height
-        });
+        assert_eq!(
+            frame_damage.rects[0],
+            Rect { x, y: viewport_height as i32 - y - height, width, height }
+        );
         assert_eq!(frame_damage.rects[0].y, viewport_y_to_damage_y(&size_info, y, height));
         assert_eq!(damage_y_to_viewport_y(&size_info, &frame_damage.rects[0]), y);
     }

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -264,10 +264,10 @@ mod tests {
 
         let lines = message_buffer.message().unwrap().text(&size);
 
-        assert_eq!(lines, vec![
-            String::from("hahahahahahahahaha [X]"),
-            String::from("[MESSAGE TRUNCATED]   ")
-        ]);
+        assert_eq!(
+            lines,
+            vec![String::from("hahahahahahahahaha [X]"), String::from("[MESSAGE TRUNCATED]   ")]
+        );
     }
 
     #[test]
@@ -353,11 +353,10 @@ mod tests {
 
         let lines = message_buffer.message().unwrap().text(&size);
 
-        assert_eq!(lines, vec![
-            String::from("a [X]"),
-            String::from("bc   "),
-            String::from("defg ")
-        ]);
+        assert_eq!(
+            lines,
+            vec![String::from("a [X]"), String::from("bc   "), String::from("defg ")]
+        );
     }
 
     #[test]
@@ -369,11 +368,10 @@ mod tests {
 
         let lines = message_buffer.message().unwrap().text(&size);
 
-        assert_eq!(lines, vec![
-            String::from("ab  [X]"),
-            String::from("c 👩 d  "),
-            String::from("fgh    ")
-        ]);
+        assert_eq!(
+            lines,
+            vec![String::from("ab  [X]"), String::from("c 👩 d  "), String::from("fgh    ")]
+        );
     }
 
     #[test]

--- a/alacritty/src/migrate/mod.rs
+++ b/alacritty/src/migrate/mod.rs
@@ -107,10 +107,11 @@ fn migrate_toml(toml: String) -> Result<DocumentMut, String> {
     };
 
     // Move `draw_bold_text_with_bright_colors` to its own section.
-    move_value(&mut document, &["draw_bold_text_with_bright_colors"], &[
-        "colors",
-        "draw_bold_text_with_bright_colors",
-    ])?;
+    move_value(
+        &mut document,
+        &["draw_bold_text_with_bright_colors"],
+        &["colors", "draw_bold_text_with_bright_colors"],
+    )?;
 
     // Move bindings to their own section.
     move_value(&mut document, &["key_bindings"], &["keyboard", "bindings"])?;
@@ -300,11 +301,11 @@ not_moved = 9
         let mut document = input.parse::<DocumentMut>().unwrap();
 
         move_value(&mut document, &["root_value"], &["new_table", "root_value"]).unwrap();
-        move_value(&mut document, &["table", "table_value"], &[
-            "preexisting",
-            "subtable",
-            "new_name",
-        ])
+        move_value(
+            &mut document,
+            &["table", "table_value"],
+            &["preexisting", "subtable", "new_name"],
+        )
         .unwrap();
 
         let output = document.to_string();

--- a/alacritty_config_derive/tests/config.rs
+++ b/alacritty_config_derive/tests/config.rs
@@ -126,22 +126,28 @@ fn config_deserialize() {
     // Verify all log messages are correct.
     let mut error_logs = logger.error_logs.lock().unwrap();
     error_logs.sort_unstable();
-    assert_eq!(error_logs.as_slice(), [
-        "Config error: enom_error: unknown variant `HugaBuga`, expected one of `One`, `Two`, \
+    assert_eq!(
+        error_logs.as_slice(),
+        [
+            "Config error: enom_error: unknown variant `HugaBuga`, expected one of `One`, `Two`, \
          `Three`",
-        "Config error: field1: invalid type: string \"testing\", expected usize",
-    ]);
+            "Config error: field1: invalid type: string \"testing\", expected usize",
+        ]
+    );
     let mut warn_logs = logger.warn_logs.lock().unwrap();
     warn_logs.sort_unstable();
-    assert_eq!(warn_logs.as_slice(), [
-        "Config warning: enom_error has been deprecated\nUse `alacritty migrate` to automatically \
+    assert_eq!(
+        warn_logs.as_slice(),
+        [
+            "Config warning: enom_error has been deprecated\nUse `alacritty migrate` to automatically \
          resolve it",
-        "Config warning: field1 has been deprecated; use field2 instead\nUse `alacritty migrate` \
+            "Config warning: field1 has been deprecated; use field2 instead\nUse `alacritty migrate` \
          to automatically resolve it",
-        "Config warning: gone has been removed; it's gone\nUse `alacritty migrate` to \
+            "Config warning: gone has been removed; it's gone\nUse `alacritty migrate` to \
          automatically resolve it",
-        "Unused config key: field3",
-    ]);
+            "Unused config key: field3",
+        ]
+    );
 }
 
 /// Logger storing all messages for later validation.

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -416,11 +416,10 @@ mod tests {
         let mut selection = Selection::new(SelectionType::Simple, location, Side::Left);
         selection.update(location, Side::Right);
 
-        assert_eq!(selection.to_range(&term(1, 2)).unwrap(), SelectionRange {
-            start: location,
-            end: location,
-            is_block: false
-        });
+        assert_eq!(
+            selection.to_range(&term(1, 2)).unwrap(),
+            SelectionRange { start: location, end: location, is_block: false }
+        );
     }
 
     /// Test case of single cell selection.
@@ -434,11 +433,10 @@ mod tests {
         let mut selection = Selection::new(SelectionType::Simple, location, Side::Right);
         selection.update(location, Side::Left);
 
-        assert_eq!(selection.to_range(&term(1, 2)).unwrap(), SelectionRange {
-            start: location,
-            end: location,
-            is_block: false
-        });
+        assert_eq!(
+            selection.to_range(&term(1, 2)).unwrap(),
+            SelectionRange { start: location, end: location, is_block: false }
+        );
     }
 
     /// Test adjacent cell selection from left to right.
@@ -524,11 +522,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(0)..Line(size.0 as i32)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(0), Column(0)),
-            end: Point::new(Line(5), Column(4)),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(0), Column(0)),
+                end: Point::new(Line(5), Column(4)),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -539,11 +540,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(0)..Line(size.0 as i32)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(0), Column(1)),
-            end: Point::new(Line(5), Column(3)),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(0), Column(1)),
+                end: Point::new(Line(5), Column(3)),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -554,11 +558,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(0)..Line(size.0 as i32)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(0), Column(2)),
-            end: Point::new(Line(5), Column(3)),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(0), Column(2)),
+                end: Point::new(Line(5), Column(3)),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -569,11 +576,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(0)..Line(size.0 as i32)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(0), Column(2)),
-            end: Point::new(Line(5), Column(3)),
-            is_block: true
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(0), Column(2)),
+                end: Point::new(Line(5), Column(3)),
+                is_block: true
+            }
+        );
     }
 
     #[test]
@@ -612,11 +622,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(1)..Line(size.0 as i32 - 1)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(1), Column(0)),
-            end: Point::new(Line(3), Column(3)),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(1), Column(0)),
+                end: Point::new(Line(3), Column(3)),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -627,11 +640,14 @@ mod tests {
         selection.update(Point::new(Line(1), Column(1)), Side::Left);
         selection = selection.rotate(&size, &(Line(1)..Line(size.0 as i32 - 1)), -5).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(6), Column(1)),
-            end: Point::new(Line(8), size.last_column()),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(6), Column(1)),
+                end: Point::new(Line(8), size.last_column()),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -642,11 +658,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(1)..Line(size.0 as i32 - 1)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(1), Column(2)),
-            end: Point::new(Line(3), Column(3)),
-            is_block: true,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(1), Column(2)),
+                end: Point::new(Line(3), Column(3)),
+                is_block: true,
+            }
+        );
     }
 
     #[test]

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -23,8 +23,8 @@ These cannot be rebound today.
 | `Ctrl+T`             | Open a new shell session in the current workspace     |
 | `Ctrl+Tab`           | Cycle to the next session in the current workspace    |
 | `Ctrl+Shift+Tab`     | Cycle to the previous session                         |
-| `Ctrl+Alt+Right`     | Switch to the next workspace (home / worktrees)       |
-| `Ctrl+Alt+Left`      | Switch to the previous workspace                      |
+| `Alt+Right`          | Switch to the next workspace (home / worktrees)       |
+| `Alt+Left`           | Switch to the previous workspace                      |
 | `Ctrl+Q`             | Open the quit confirmation dialog                     |
 | `Enter`              | Confirm a modal (quit, delete worktree, create branch)|
 | `Escape`             | Cancel a modal                                        |

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,188 @@
+# Keyboard shortcuts
+
+Alacritree has two layers of shortcuts:
+
+1. **Built-in app shortcuts** — hard-coded, not configurable. They drive
+   alacritree-specific UI (sidebars, workspaces, session list, quit dialog).
+2. **Configurable terminal bindings** — parsed from your
+   `[[keyboard.bindings]]` tables in `alacritty.toml` / `alacritree.toml`, with
+   a set of defaults that mirror alacritty.
+
+When both layers would match the same key, the built-in shortcut wins.
+
+---
+
+## Built-in app shortcuts
+
+These cannot be rebound today.
+
+| Shortcut             | Action                                                |
+| -------------------- | ----------------------------------------------------- |
+| `Ctrl+B`             | Toggle the left (projects/worktrees) sidebar          |
+| `Ctrl+G`             | Toggle the right (git status) sidebar                 |
+| `Ctrl+T`             | Open a new shell session in the current workspace     |
+| `Ctrl+Tab`           | Cycle to the next session in the current workspace    |
+| `Ctrl+Shift+Tab`     | Cycle to the previous session                         |
+| `Ctrl+Alt+Right`     | Switch to the next workspace (home / worktrees)       |
+| `Ctrl+Alt+Left`      | Switch to the previous workspace                      |
+| `Ctrl+Q`             | Open the quit confirmation dialog                     |
+| `Enter`              | Confirm a modal (quit, delete worktree, create branch)|
+| `Escape`             | Cancel a modal                                        |
+
+Modal-specific keys (`Enter`/`Escape`) only fire while a modal is open and never
+reach the terminal grid.
+
+---
+
+## Configurable terminal bindings
+
+These are parsed from `[[keyboard.bindings]]` and matched against egui key
+events before the terminal sees them. Alacritty's own default set is preloaded,
+and your TOML entries are checked first — so your config overrides any default.
+
+### Defaults on every platform
+
+| Shortcut             | Action                                                |
+| -------------------- | ----------------------------------------------------- |
+| `Ctrl+Shift+V`       | Paste from the clipboard                              |
+| `Ctrl+Shift+C`       | Copy the current selection                            |
+| `Shift+Insert`       | Paste from the primary (X11) selection                |
+| `Ctrl+0`             | Reset font size                                       |
+| `Ctrl+=` / `Ctrl++`  | Increase font size                                    |
+| `Ctrl+-`             | Decrease font size                                    |
+| `Shift+Home`         | Scroll to the top of the scrollback                   |
+| `Shift+End`          | Scroll to the bottom                                  |
+| `Shift+PageUp`       | Scroll one page up                                    |
+| `Shift+PageDown`     | Scroll one page down                                  |
+| `Shift+Tab`          | Send `CSI Z` (reverse tab — readline/vim)             |
+| `Alt+Shift+Tab`      | Send `ESC` + `CSI Z`                                  |
+
+### Additional defaults on macOS
+
+| Shortcut             | Action                                                |
+| -------------------- | ----------------------------------------------------- |
+| `Cmd+V`              | Paste                                                 |
+| `Cmd+C`              | Copy                                                  |
+| `Cmd+N` / `Cmd+T`    | Open a new shell session in the current workspace     |
+| `Cmd+0`              | Reset font size                                       |
+| `Cmd+=` / `Cmd++`    | Increase font size                                    |
+| `Cmd+-`              | Decrease font size                                    |
+| `Cmd+Shift+]`        | Next session in the current workspace                 |
+| `Cmd+Shift+[`        | Previous session                                      |
+| `Cmd+1` … `Cmd+8`    | Select the Nth session in the current workspace       |
+| `Cmd+9`              | Select the last session                               |
+| `Ctrl+Cmd+F`         | Toggle fullscreen                                     |
+| `Cmd+M`              | Minimize the window                                   |
+| `Cmd+K`              | Clear the scrollback buffer                           |
+| `Cmd+Q`              | Open the quit confirmation dialog                     |
+
+---
+
+## Supported actions
+
+Use any of these as the `action = "..."` value in a `[[keyboard.bindings]]`
+entry. Names match alacritty's own action names, so existing configs port over.
+
+### Clipboard
+
+- `Paste` — paste from the system clipboard.
+- `Copy` — copy the current selection to the clipboard. *(Selection isn't wired
+  up in the alacritree grid yet; this becomes a no-op when there's nothing
+  selected.)*
+- `PasteSelection` — paste from the primary (X11) selection.
+
+### Font size
+
+- `IncreaseFontSize`
+- `DecreaseFontSize`
+- `ResetFontSize`
+
+### Scrolling
+
+- `ScrollPageUp` / `ScrollPageDown`
+- `ScrollHalfPageUp` / `ScrollHalfPageDown`
+- `ScrollLineUp` / `ScrollLineDown`
+- `ScrollToTop` / `ScrollToBottom`
+- `ClearHistory` — drop the scrollback buffer (does not clear the visible
+  screen; pair with `chars = "\x0c"` on a separate binding if you also want a
+  `Ctrl+L`-style screen clear).
+
+### Window / sessions
+
+- `SpawnNewInstance` / `CreateNewWindow` / `CreateNewTab` — all three open a
+  new shell session in the current workspace. (Alacritty distinguishes
+  windows from tabs; alacritree has a single window with sessions per
+  workspace, so they collapse to the same action.)
+- `SelectNextTab` / `SelectPreviousTab` — cycle through sessions in the
+  current workspace.
+- `SelectTab1` … `SelectTab9` — select the Nth session in the current
+  workspace. Out-of-range indices are ignored.
+- `SelectLastTab` — select the last session in the current workspace.
+- `ToggleFullscreen`
+- `ToggleMaximized`
+- `Minimize`
+- `Quit` — open the quit confirmation dialog.
+
+### Misc
+
+- `None` — consume the key without doing anything. Useful to unbind a
+  default shortcut.
+
+---
+
+## Not supported
+
+These alacritty actions exist but are intentionally not wired up:
+
+- **Vi mode** (`ToggleViMode`, all `ViAction`/`ViMotion` variants) — alacritree
+  does not track terminal modes, so any binding gated by `mode = "Vi"` or
+  `mode = "~Vi"` is dropped at parse time.
+- **Search mode** (`SearchForward`, `SearchBackward`, all `SearchAction`
+  variants) — no in-app search UI yet.
+- **Hints** (`Hint(...)`) — regex hinting is an alacritty renderer feature.
+- **Mouse-only actions** (`CopySelection`, `ClearSelection`,
+  `ExpandSelection`) — depend on the selection model alacritree's grid does
+  not have.
+- **Platform-specific window actions** (`Hide`, `HideOtherApplications`,
+  `ToggleSimpleFullscreen`) — alacritty calls into AppKit directly; eframe
+  doesn't expose the equivalent.
+- **`ClearLogNotice`** — alacritree has no in-app log notice.
+- **`Command`** (`command = { ... }`) — spawning arbitrary external processes
+  from a keybinding is a security surface we haven't designed for yet.
+
+Bindings with these actions are still parsed; they just log at `debug` and
+otherwise do nothing.
+
+---
+
+## Customizing
+
+Add `[[keyboard.bindings]]` tables to `alacritty.toml` or `alacritree.toml`
+under your config directory (typically `~/.config/alacritty/`). Both files are
+deep-merged, so alacritree-specific overrides can live in `alacritree.toml`
+without touching the alacritty config.
+
+```toml
+# Example: bind Ctrl+Shift+T to open a new session, and unbind Cmd+M on macOS.
+[[keyboard.bindings]]
+key = "T"
+mods = "Control|Shift"
+action = "CreateNewTab"
+
+[[keyboard.bindings]]
+key = "M"
+mods = "Command"
+action = "None"
+```
+
+Modifier names: `Control` / `Ctrl`, `Shift`, `Alt` / `Option`, `Super` /
+`Command` / `Meta`. Combine with `|`.
+
+For raw byte sequences, use `chars = "..."` instead of `action`:
+
+```toml
+[[keyboard.bindings]]
+key = "Return"
+mods = "Alt"
+chars = "\r"   # ESC + CR — meta-Enter for tmux prefix, etc.
+```


### PR DESCRIPTION
## Summary
- Wire up the remaining alacritty actions that make sense in alacritree: `ClearHistory`, `ToggleFullscreen`, `ToggleMaximized`, `Minimize`, `SelectNextTab`/`SelectPreviousTab`/`SelectTab1..9`/`SelectLastTab`, plus `None` to unbind a key. Adds the matching macOS defaults (`Cmd+1..9`, `Cmd+Shift+[/]`, `Cmd+K`, `Cmd+M`, `Ctrl+Cmd+F`) so stock alacritty configs keep working.
- Switch the workspace cycling shortcut from `Ctrl+Alt+←/→` to plain `Alt+←/→` — easier to hit and avoids clashing with common keymap-switcher / tiling-WM bindings.
- Document the full shortcut set (built-in app + configurable terminal bindings) in `docs/keyboard-shortcuts.md`, including which alacritty actions are intentionally not supported and why.
- Bundle a separate rustfmt-only cleanup commit on the vendored alacritty crates (no logic changes).

## Test plan
- [ ] `cargo run -p alacritree`
- [ ] Toggle fullscreen / maximize / minimize with the new bindings on macOS, verify viewport state matches
- [ ] Open ≥2 sessions in a workspace, cycle with `Cmd+Shift+[`/`]` and jump with `Cmd+1..9` / `Cmd+9` (last)
- [ ] `Cmd+K` clears scrollback while leaving the visible viewport intact
- [ ] `Alt+←/→` cycles workspaces; old `Ctrl+Alt+←/→` no longer fires
- [ ] A user `[[keyboard.bindings]]` entry with `action = "None"` actually unbinds a key

🤖 Generated with [Claude Code](https://claude.com/claude-code)