### PR TITLE
Surface bell as sidebar attention + desktop notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "git2",
  "home",
  "log",
+ "notify-rust",
  "png 0.17.16",
  "rfd",
  "serde",
@@ -914,6 +915,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1930,7 +1940,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.17",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2059,7 +2069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2131,6 +2141,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "time",
 ]
 
 [[package]]
@@ -2317,10 +2339,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "notify-types"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -2527,6 +2569,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.9.4",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
  "objc2-core-foundation",
 ]
@@ -2725,7 +2769,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2863,6 +2907,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3438,6 +3488,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.17",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +3574,25 @@ dependencies = [
  "weezl",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tiny-skia"
@@ -4167,7 +4248,7 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -4219,8 +4300,30 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4229,11 +4332,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4241,6 +4368,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4259,10 +4397,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -4274,13 +4439,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4325,7 +4508,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4365,7 +4548,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4374,6 +4557,24 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "png 0.17.16",
  "rfd",
  "serde",
+ "serde_json",
  "toml",
  "xdg",
 ]

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -22,6 +22,8 @@ home = "0.5.5"
 fontdb = { version = "0.23", default-features = false, features = ["fontconfig", "memmap"] }
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
 png = "0.17"
+# Desktop notifications when a background session rings the bell.
+notify-rust = "4"
 
 [target.'cfg(unix)'.dependencies]
 # Used for font matching: matches what alacritty does via crossfont so that

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = "0.11"
 git2 = { version = "0.20", default-features = false }
 rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "async-std"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = { workspace = true }
 xdg = "3.0.0"
 home = "0.5.5"

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1244,16 +1244,20 @@ impl AlacritreeApp {
 
         for idx in 0..self.sessions.len() {
             let outcome = self.sessions[idx].drain_events();
-            if !outcome.bell {
+            if !outcome.attention {
                 continue;
             }
             let is_visible_to_user = Some(idx) == visible_idx && focused;
             if is_visible_to_user {
                 continue;
             }
+            // Only toast on the *transition* into needs_attention — otherwise
+            // BEL + title-transition firing in the same idle cycle would
+            // produce two toasts for the same "Claude is done" event.
+            let was_attending = self.sessions[idx].needs_attention;
             self.sessions[idx].needs_attention = true;
-            if self.config.ui.notifications {
-                notify_bell(&self.sessions[idx]);
+            if !was_attending && self.config.ui.notifications {
+                notify_attention(&self.sessions[idx]);
             }
         }
 
@@ -1739,10 +1743,12 @@ impl eframe::App for AlacritreeApp {
     }
 }
 
-/// Fire a desktop notification for a session that rang the bell.  Runs on a
-/// throwaway thread because `notify-rust` performs synchronous D-Bus / WinRT
-/// calls and we don't want to stall the egui paint loop on a slow notifier.
-fn notify_bell(session: &Session) {
+/// Fire a desktop notification for a session that's asking for the user's
+/// attention (bell, or title transitioning out of a working spinner).  Runs
+/// on a throwaway thread because `notify-rust` performs synchronous D-Bus /
+/// WinRT calls and we don't want to stall the egui paint loop on a slow
+/// notifier.
+fn notify_attention(session: &Session) {
     let where_label = session
         .working_directory
         .as_ref()

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -30,6 +30,11 @@ struct Theme {
     text_dim: Color32,
     text_muted: Color32,
     accent: Color32,
+    /// Highlight color for "this session rang the bell while you weren't
+    /// looking" indicators (sidebar dots, tab segments).  Kept distinct from
+    /// `accent` (which means "this is the active workspace") so the two
+    /// signals don't read as the same thing.
+    attention: Color32,
     /// Logical-pixel size for headings (titles like "Projects", "Git").
     /// `FontConfig::UI_HEADING_RATIO` of the terminal font size.
     font_heading: f32,
@@ -63,6 +68,7 @@ impl Theme {
             text_dim: blend_toward(text, sidebar_bg, 0.35),
             text_muted: blend_toward(text, sidebar_bg, 0.55),
             accent,
+            attention: rgb_to_color32(config.palette.normal[3]), // ANSI yellow
             font_heading: config.font.ui_heading_px(),
             font_normal: config.font.ui_normal_px(),
             ui_scale: config.font.ui_normal_px() / 11.25,
@@ -554,7 +560,11 @@ impl AlacritreeApp {
             let click_rect = seg_rect.expand2(egui::vec2(0.0, 4.0));
             let id = ui.id().with(("tab_strip", self.sessions[session_idx].id));
             let resp = ui.interact(click_rect, id, egui::Sense::click());
-            let color = if is_active {
+            // Attention wins over the active/inactive shading so a bell from a
+            // non-active tab pulls the eye even when another tab is selected.
+            let color = if self.sessions[session_idx].needs_attention {
+                theme.attention
+            } else if is_active {
                 theme.text
             } else if resp.hovered() {
                 theme.text_dim
@@ -586,6 +596,22 @@ impl AlacritreeApp {
         let mut home_clicked = false;
         let theme = self.theme;
 
+        // Snapshot attention flags up-front so the `iter_mut` over projects
+        // below isn't blocked from calling back into `&self` helpers.
+        let home_attention = self.workspace_needs_attention(&None);
+        let project_attention: Vec<bool> =
+            self.projects.iter().map(|p| self.project_needs_attention(p)).collect();
+        let worktree_attention: Vec<Vec<bool>> = self
+            .projects
+            .iter()
+            .map(|p| {
+                p.worktrees
+                    .iter()
+                    .map(|wt| self.workspace_needs_attention(&Some(wt.path.clone())))
+                    .collect()
+            })
+            .collect();
+
         let panel_resp = SidePanel::left("left_sidebar")
             .resizable(true)
             .default_width(240.0 * theme.ui_scale)
@@ -606,7 +632,9 @@ impl AlacritreeApp {
                 ui.separator();
 
                 ScrollArea::vertical().show(ui, |ui| {
-                    if home_row(ui, self.current_workspace.is_none(), &theme).clicked() {
+                    if home_row(ui, self.current_workspace.is_none(), home_attention, &theme)
+                        .clicked()
+                    {
                         home_clicked = true;
                     }
                     ui.add_space(2.0);
@@ -622,6 +650,12 @@ impl AlacritreeApp {
                     }
 
                     for (idx, project) in self.projects.iter_mut().enumerate() {
+                        let proj_attention = project_attention.get(idx).copied().unwrap_or(false);
+                        // Bubble attention up to the project row only when the
+                        // project is collapsed — once expanded, the actual
+                        // worktree rows already show the dot, and doubling it
+                        // on the parent reads as noise.
+                        let show_proj_dot = proj_attention && !project.expanded;
                         row_with_trailing(
                             ui,
                             |ui| {
@@ -660,13 +694,21 @@ impl AlacritreeApp {
                                 {
                                     create_request.set(Some(idx));
                                 }
+                                if show_proj_dot {
+                                    attention_dot(ui, &theme);
+                                }
                             },
                         );
 
                         if project.expanded {
-                            for wt in &project.worktrees {
+                            for (wt_idx, wt) in project.worktrees.iter().enumerate() {
                                 let is_active = self.current_workspace.as_deref() == Some(&wt.path);
-                                let action = worktree_row(ui, wt, is_active, &theme);
+                                let wt_attention = worktree_attention
+                                    .get(idx)
+                                    .and_then(|v| v.get(wt_idx))
+                                    .copied()
+                                    .unwrap_or(false);
+                                let action = worktree_row(ui, wt, is_active, wt_attention, &theme);
                                 if action.activate {
                                     activate_request.set(Some(wt.path.clone()));
                                 }
@@ -1004,6 +1046,17 @@ fn file_row(
 /// glyphs of different intrinsic heights (e.g. `+` vs `↻`) end up on different
 /// baselines. `painter.text` with `CENTER_CENTER` centers the galley in the
 /// rect, giving real grid alignment.
+/// Small filled circle used as a "this session rang the bell" indicator.
+/// Painted (rather than a `RichText("●")`) so its size is independent of the
+/// font metrics — `RichText("●")` renders inconsistently across fallback fonts.
+fn attention_dot(ui: &mut egui::Ui, theme: &Theme) {
+    let s = theme.ui_scale;
+    let size = egui::vec2(10.0 * s, 14.0 * s);
+    let (rect, _) = ui.allocate_exact_size(size, egui::Sense::hover());
+    let radius = 3.0 * s;
+    ui.painter().circle_filled(rect.center(), radius, theme.attention);
+}
+
 fn icon_button(ui: &mut egui::Ui, glyph: &str, color: Color32, theme: &Theme) -> egui::Response {
     let s = theme.ui_scale;
     let size = egui::vec2(16.0 * s, 16.0 * s);
@@ -1048,7 +1101,7 @@ where
     });
 }
 
-fn home_row(ui: &mut egui::Ui, is_active: bool, theme: &Theme) -> egui::Response {
+fn home_row(ui: &mut egui::Ui, is_active: bool, attention: bool, theme: &Theme) -> egui::Response {
     // Reserve a slot *before* the labels so the hover bg paints beneath them.
     let bg_idx = ui.painter().add(egui::Shape::Noop);
     let panel_x = ui.max_rect().x_range();
@@ -1068,6 +1121,9 @@ fn home_row(ui: &mut egui::Ui, is_active: bool, theme: &Theme) -> egui::Response
                         .strong()
                         .small(),
                 );
+                if attention {
+                    attention_dot(ui, theme);
+                }
             });
         })
         .response
@@ -1096,6 +1152,7 @@ fn worktree_row(
     ui: &mut egui::Ui,
     wt: &Worktree,
     is_active: bool,
+    attention: bool,
     theme: &Theme,
 ) -> WorktreeAction {
     // Reserve a slot *before* the labels so the hover bg paints beneath them.
@@ -1129,6 +1186,9 @@ fn worktree_row(
                         if btn.clicked() {
                             delete_clicked = true;
                         }
+                    }
+                    if attention {
+                        attention_dot(ui, theme);
                     }
                 },
             );
@@ -1169,6 +1229,50 @@ impl AlacritreeApp {
         for id in exited_ids {
             self.close_session(id);
         }
+    }
+
+    /// Drain pending PTY events from every session — including ones the user
+    /// isn't currently looking at — and translate background bells into
+    /// sidebar attention dots + (optional) desktop notifications.  When the
+    /// session ringing the bell is the visible-and-focused one, the user has
+    /// already seen it, so we suppress both signals.
+    fn process_session_events(&mut self, ctx: &Context) {
+        let visible_idx = self.active_session_index();
+        // `viewport().focused` is `None` on platforms that don't report focus;
+        // treat unknown as "focused" so we don't pile up stale attention dots.
+        let focused = ctx.input(|i| i.viewport().focused).unwrap_or(true);
+
+        for idx in 0..self.sessions.len() {
+            let outcome = self.sessions[idx].drain_events();
+            if !outcome.bell {
+                continue;
+            }
+            let is_visible_to_user = Some(idx) == visible_idx && focused;
+            if is_visible_to_user {
+                continue;
+            }
+            self.sessions[idx].needs_attention = true;
+            if self.config.ui.notifications {
+                notify_bell(&self.sessions[idx]);
+            }
+        }
+
+        // Visible session shouldn't keep an attention marker once the user is
+        // actually looking at it — covers tab switches, workspace switches,
+        // and refocusing the window after stepping away.
+        if focused {
+            if let Some(idx) = visible_idx {
+                self.sessions[idx].needs_attention = false;
+            }
+        }
+    }
+
+    fn workspace_needs_attention(&self, ws: &WorkspaceKey) -> bool {
+        self.sessions.iter().any(|s| s.working_directory == *ws && s.needs_attention)
+    }
+
+    fn project_needs_attention(&self, project: &Project) -> bool {
+        project.worktrees.iter().any(|wt| self.workspace_needs_attention(&Some(wt.path.clone())))
     }
 
     fn show_delete_dialog(&mut self, ctx: &Context) {
@@ -1573,6 +1677,7 @@ impl eframe::App for AlacritreeApp {
         if !modal_open {
             self.handle_shortcuts(ctx);
         }
+        self.process_session_events(ctx);
         let theme = self.theme;
         // GL clear is the sole source of the bg when opacity < 1; painting any
         // panel fill on top would compound the alpha through egui's blend.
@@ -1632,4 +1737,31 @@ impl eframe::App for AlacritreeApp {
 
         self.reap_exited_sessions();
     }
+}
+
+/// Fire a desktop notification for a session that rang the bell.  Runs on a
+/// throwaway thread because `notify-rust` performs synchronous D-Bus / WinRT
+/// calls and we don't want to stall the egui paint loop on a slow notifier.
+fn notify_bell(session: &Session) {
+    let where_label = session
+        .working_directory
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| session.title.clone());
+    let body = if where_label.is_empty() {
+        "Session is waiting for input".to_string()
+    } else {
+        format!("{where_label} is waiting for input")
+    };
+    std::thread::Builder::new()
+        .name("alacritree-notify".into())
+        .spawn(move || {
+            if let Err(e) =
+                notify_rust::Notification::new().summary("alacritree").body(&body).show()
+            {
+                log::debug!("desktop notification failed: {e}");
+            }
+        })
+        .ok();
 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::Receiver;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Mutex, OnceLock};
 
 use eframe::CreationContext;
 use egui::{Color32, Context, Frame, Margin, RichText, ScrollArea, SidePanel, Stroke};
@@ -19,6 +20,12 @@ use crate::worktree::{self as wt, CreateRequest, Progress};
 /// `None` is the home workspace (sessions inherit `$PWD`); `Some` is a worktree path.
 type WorkspaceKey = Option<PathBuf>;
 
+/// Channel from notification-worker threads back to the app.  Set once by
+/// `AlacritreeApp::new`; each worker reads it to deliver the workspace the
+/// user clicked on.  Static because the worker has no other handle to the
+/// app and there's only ever one app instance per process.
+static NOTIFY_TX: OnceLock<Mutex<Sender<WorkspaceKey>>> = OnceLock::new();
+
 #[derive(Clone, Copy)]
 struct Theme {
     terminal_bg: Color32,
@@ -30,10 +37,8 @@ struct Theme {
     text_dim: Color32,
     text_muted: Color32,
     accent: Color32,
-    /// Highlight color for "this session rang the bell while you weren't
-    /// looking" indicators (sidebar dots, tab segments).  Kept distinct from
-    /// `accent` (which means "this is the active workspace") so the two
-    /// signals don't read as the same thing.
+    /// "Needs attention" highlight.  Distinct from `accent` ("active
+    /// workspace") so the two signals don't read as the same thing.
     attention: Color32,
     /// Logical-pixel size for headings (titles like "Projects", "Git").
     /// `FontConfig::UI_HEADING_RATIO` of the terminal font size.
@@ -115,6 +120,7 @@ pub struct AlacritreeApp {
     quit_dialog_open: bool,
     pending_delete: Option<DeleteRequest>,
     pending_create: Option<CreateState>,
+    notify_rx: Receiver<WorkspaceKey>,
 }
 
 struct DeleteRequest {
@@ -197,6 +203,13 @@ impl AlacritreeApp {
             })
             .collect();
 
+        let (notify_tx, notify_rx) = mpsc::channel();
+        // `set` may fail only if a previous instance already initialized the
+        // static (e.g. tests).  In that case the old sender points at a dead
+        // app, so overwriting via `Mutex` would be ideal — but since we only
+        // ever spawn one app per process, ignoring the error is fine.
+        let _ = NOTIFY_TX.set(Mutex::new(notify_tx));
+
         let mut app = Self {
             show_left_sidebar: persisted.show_left_sidebar,
             show_right_sidebar: persisted.show_right_sidebar,
@@ -211,6 +224,7 @@ impl AlacritreeApp {
             quit_dialog_open: false,
             pending_delete: None,
             pending_create: None,
+            notify_rx,
         };
 
         if let Err(e) = app.spawn_session(&cc.egui_ctx, None) {
@@ -596,9 +610,11 @@ impl AlacritreeApp {
         let mut home_clicked = false;
         let theme = self.theme;
 
-        // Snapshot attention flags up-front so the `iter_mut` over projects
-        // below isn't blocked from calling back into `&self` helpers.
+        // Snapshot attention + agent-glyph state up-front so the `iter_mut`
+        // over projects below isn't blocked from calling back into `&self`
+        // helpers.
         let home_attention = self.workspace_needs_attention(&None);
+        let home_agent_glyph = self.workspace_agent_glyph(&None);
         let project_attention: Vec<bool> =
             self.projects.iter().map(|p| self.project_needs_attention(p)).collect();
         let worktree_attention: Vec<Vec<bool>> = self
@@ -608,6 +624,16 @@ impl AlacritreeApp {
                 p.worktrees
                     .iter()
                     .map(|wt| self.workspace_needs_attention(&Some(wt.path.clone())))
+                    .collect()
+            })
+            .collect();
+        let worktree_agent: Vec<Vec<Option<char>>> = self
+            .projects
+            .iter()
+            .map(|p| {
+                p.worktrees
+                    .iter()
+                    .map(|wt| self.workspace_agent_glyph(&Some(wt.path.clone())))
                     .collect()
             })
             .collect();
@@ -632,8 +658,14 @@ impl AlacritreeApp {
                 ui.separator();
 
                 ScrollArea::vertical().show(ui, |ui| {
-                    if home_row(ui, self.current_workspace.is_none(), home_attention, &theme)
-                        .clicked()
+                    if home_row(
+                        ui,
+                        self.current_workspace.is_none(),
+                        home_attention,
+                        home_agent_glyph,
+                        &theme,
+                    )
+                    .clicked()
                     {
                         home_clicked = true;
                     }
@@ -708,7 +740,13 @@ impl AlacritreeApp {
                                     .and_then(|v| v.get(wt_idx))
                                     .copied()
                                     .unwrap_or(false);
-                                let action = worktree_row(ui, wt, is_active, wt_attention, &theme);
+                                let wt_glyph = worktree_agent
+                                    .get(idx)
+                                    .and_then(|v| v.get(wt_idx))
+                                    .copied()
+                                    .unwrap_or(None);
+                                let action =
+                                    worktree_row(ui, wt, is_active, wt_attention, wt_glyph, &theme);
                                 if action.activate {
                                     activate_request.set(Some(wt.path.clone()));
                                 }
@@ -1046,15 +1084,38 @@ fn file_row(
 /// glyphs of different intrinsic heights (e.g. `+` vs `↻`) end up on different
 /// baselines. `painter.text` with `CENTER_CENTER` centers the galley in the
 /// rect, giving real grid alignment.
-/// Small filled circle used as a "this session rang the bell" indicator.
-/// Painted (rather than a `RichText("●")`) so its size is independent of the
-/// font metrics — `RichText("●")` renders inconsistently across fallback fonts.
+/// Painted (rather than `RichText("●")`) so its size is independent of font
+/// metrics — `RichText("●")` renders inconsistently across fallback fonts.
 fn attention_dot(ui: &mut egui::Ui, theme: &Theme) {
     let s = theme.ui_scale;
     let size = egui::vec2(10.0 * s, 14.0 * s);
     let (rect, _) = ui.allocate_exact_size(size, egui::Sense::hover());
     let radius = 3.0 * s;
     ui.painter().circle_filled(rect.center(), radius, theme.attention);
+}
+
+/// Priority: attention dot > agent glyph (animated by the agent's own title
+/// updates) > the row's default marker.
+fn paint_row_status_icon(
+    ui: &mut egui::Ui,
+    theme: &Theme,
+    attention: bool,
+    agent_glyph: Option<char>,
+    default_glyph: &str,
+    is_active: bool,
+) {
+    if attention {
+        attention_dot(ui, theme);
+        return;
+    }
+    let s = theme.ui_scale;
+    let (glyph, color) = match agent_glyph {
+        Some(g) => (g.to_string(), if is_active { theme.accent } else { theme.text }),
+        None => {
+            (default_glyph.to_string(), if is_active { theme.accent } else { theme.text_muted })
+        },
+    };
+    ui.label(RichText::new(glyph).color(color).size(10.0 * s));
 }
 
 fn icon_button(ui: &mut egui::Ui, glyph: &str, color: Color32, theme: &Theme) -> egui::Response {
@@ -1101,7 +1162,13 @@ where
     });
 }
 
-fn home_row(ui: &mut egui::Ui, is_active: bool, attention: bool, theme: &Theme) -> egui::Response {
+fn home_row(
+    ui: &mut egui::Ui,
+    is_active: bool,
+    attention: bool,
+    agent_glyph: Option<char>,
+    theme: &Theme,
+) -> egui::Response {
     // Reserve a slot *before* the labels so the hover bg paints beneath them.
     let bg_idx = ui.painter().add(egui::Shape::Noop);
     let panel_x = ui.max_rect().x_range();
@@ -1110,20 +1177,13 @@ fn home_row(ui: &mut egui::Ui, is_active: bool, attention: bool, theme: &Theme) 
     let resp = frame
         .show(ui, |ui| {
             ui.horizontal(|ui| {
-                ui.label(
-                    RichText::new("⌂")
-                        .color(if is_active { theme.accent } else { theme.text_muted })
-                        .size(10.0 * theme.ui_scale),
-                );
+                paint_row_status_icon(ui, theme, attention, agent_glyph, "⌂", is_active);
                 ui.label(
                     RichText::new("Home")
                         .color(if is_active { theme.text } else { theme.text_dim })
                         .strong()
                         .small(),
                 );
-                if attention {
-                    attention_dot(ui, theme);
-                }
             });
         })
         .response
@@ -1153,6 +1213,7 @@ fn worktree_row(
     wt: &Worktree,
     is_active: bool,
     attention: bool,
+    agent_glyph: Option<char>,
     theme: &Theme,
 ) -> WorktreeAction {
     // Reserve a slot *before* the labels so the hover bg paints beneath them.
@@ -1166,13 +1227,19 @@ fn worktree_row(
     let frame = Frame::default().inner_margin(Margin { left: 16, right: 0, top: 3, bottom: 3 });
     let resp = frame
         .show(ui, |ui| {
-            let icon = if wt.is_main { "●" } else { "○" };
-            let icon_color = if is_active { theme.accent } else { theme.text_muted };
+            let default_icon = if wt.is_main { "●" } else { "○" };
             let name_color = if is_active { theme.text } else { theme.text_dim };
             row_with_trailing(
                 ui,
                 |ui| {
-                    ui.label(RichText::new(icon).color(icon_color).size(10.0 * theme.ui_scale));
+                    paint_row_status_icon(
+                        ui,
+                        theme,
+                        attention,
+                        agent_glyph,
+                        default_icon,
+                        is_active,
+                    );
                     ui.add(
                         egui::Label::new(RichText::new(&wt.name).color(name_color).small())
                             .truncate(),
@@ -1186,9 +1253,6 @@ fn worktree_row(
                         if btn.clicked() {
                             delete_clicked = true;
                         }
-                    }
-                    if attention {
-                        attention_dot(ui, theme);
                     }
                 },
             );
@@ -1231,11 +1295,24 @@ impl AlacritreeApp {
         }
     }
 
-    /// Drain pending PTY events from every session — including ones the user
-    /// isn't currently looking at — and translate background bells into
-    /// sidebar attention dots + (optional) desktop notifications.  When the
-    /// session ringing the bell is the visible-and-focused one, the user has
-    /// already seen it, so we suppress both signals.
+    /// Handle workspace-switch requests from clicked notifications.  Only
+    /// the most recent click is honored — if multiple toasts piled up, the
+    /// user most likely meant the latest one.
+    fn process_notification_actions(&mut self, ctx: &Context) {
+        let mut latest: Option<WorkspaceKey> = None;
+        while let Ok(ws) = self.notify_rx.try_recv() {
+            latest = Some(ws);
+        }
+        let Some(ws) = latest else { return };
+        match ws {
+            None => self.activate_home(ctx),
+            Some(p) => self.activate_worktree(ctx, &p),
+        }
+        ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+    }
+
+    /// Drain every session's PTY events and surface "needs attention" for
+    /// any session the user isn't currently looking at.
     fn process_session_events(&mut self, ctx: &Context) {
         let visible_idx = self.active_session_index();
         // `viewport().focused` is `None` on platforms that don't report focus;
@@ -1257,7 +1334,7 @@ impl AlacritreeApp {
             let was_attending = self.sessions[idx].needs_attention;
             self.sessions[idx].needs_attention = true;
             if !was_attending && self.config.ui.notifications {
-                notify_attention(&self.sessions[idx]);
+                notify_attention(&self.sessions[idx], ctx);
             }
         }
 
@@ -1277,6 +1354,28 @@ impl AlacritreeApp {
 
     fn project_needs_attention(&self, project: &Project) -> bool {
         project.worktrees.iter().any(|wt| self.workspace_needs_attention(&Some(wt.path.clone())))
+    }
+
+    /// Prefer the active session's glyph so two parallel agents don't fight
+    /// over which icon the sidebar shows.
+    fn workspace_agent_glyph(&self, ws: &WorkspaceKey) -> Option<char> {
+        let active_id = self.active_session.get(ws).copied();
+        let mut active_glyph = None;
+        let mut other_glyph = None;
+        for s in &self.sessions {
+            if s.working_directory != *ws {
+                continue;
+            }
+            let Some(g) = s.agent_glyph() else { continue };
+            if Some(s.id) == active_id {
+                active_glyph = Some(g);
+                break;
+            }
+            if other_glyph.is_none() {
+                other_glyph = Some(g);
+            }
+        }
+        active_glyph.or(other_glyph)
     }
 
     fn show_delete_dialog(&mut self, ctx: &Context) {
@@ -1681,6 +1780,7 @@ impl eframe::App for AlacritreeApp {
         if !modal_open {
             self.handle_shortcuts(ctx);
         }
+        self.process_notification_actions(ctx);
         self.process_session_events(ctx);
         let theme = self.theme;
         // GL clear is the sole source of the bg when opacity < 1; painting any
@@ -1743,12 +1843,11 @@ impl eframe::App for AlacritreeApp {
     }
 }
 
-/// Fire a desktop notification for a session that's asking for the user's
-/// attention (bell, or title transitioning out of a working spinner).  Runs
-/// on a throwaway thread because `notify-rust` performs synchronous D-Bus /
-/// WinRT calls and we don't want to stall the egui paint loop on a slow
-/// notifier.
-fn notify_attention(session: &Session) {
+/// Spawn a throwaway thread so `notify-rust`'s synchronous D-Bus / WinRT
+/// calls don't stall the egui paint loop.  On Linux the thread sticks around
+/// for `wait_for_action` and posts the session's workspace back through
+/// `NOTIFY_TX` when the user clicks the notification.
+fn notify_attention(session: &Session, ctx: &egui::Context) {
     let where_label = session
         .working_directory
         .as_ref()
@@ -1760,14 +1859,47 @@ fn notify_attention(session: &Session) {
     } else {
         format!("{where_label} is waiting for input")
     };
+    let key = session.working_directory.clone();
+    let ctx = ctx.clone();
     std::thread::Builder::new()
         .name("alacritree-notify".into())
-        .spawn(move || {
-            if let Err(e) =
-                notify_rust::Notification::new().summary("alacritree").body(&body).show()
-            {
-                log::debug!("desktop notification failed: {e}");
-            }
-        })
+        .spawn(move || notify_worker(body, key, ctx))
         .ok();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn notify_worker(body: String, key: WorkspaceKey, ctx: egui::Context) {
+    // `default` is the action id freedesktop notifiers fire on body-click.
+    let result = notify_rust::Notification::new()
+        .summary("alacritree")
+        .body(&body)
+        .action("default", "Open")
+        .show();
+    let handle = match result {
+        Ok(h) => h,
+        Err(e) => {
+            log::debug!("desktop notification failed: {e}");
+            return;
+        },
+    };
+    handle.wait_for_action(|action| {
+        if action == "__closed" {
+            return;
+        }
+        if let Some(lock) = NOTIFY_TX.get() {
+            if let Ok(tx) = lock.lock() {
+                let _ = tx.send(key.clone());
+                ctx.request_repaint();
+            }
+        }
+    });
+}
+
+#[cfg(not(all(unix, not(target_os = "macos"))))]
+fn notify_worker(body: String, _key: WorkspaceKey, _ctx: egui::Context) {
+    // mac-notification-sys / WinRT don't expose blocking action waits via
+    // notify-rust today — fall back to a fire-and-forget toast.
+    if let Err(e) = notify_rust::Notification::new().summary("alacritree").body(&body).show() {
+        log::debug!("desktop notification failed: {e}");
+    }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -141,9 +141,9 @@ pub struct UiTheme {
     pub sidebar_foreground: Option<Color32>,
     pub sidebar_border: Option<Color32>,
     pub sidebar_accent: Option<Color32>,
-    /// Fire a desktop notification when a non-visible session rings the bell.
-    /// On by default — CLIs like Claude Code ring BEL when they finish or
-    /// need input, which is exactly the cue worth surfacing.
+    /// Fire a desktop notification when a non-visible session asks for the
+    /// user's attention (rings BEL, or its title transitions out of a spinner
+    /// state — the way Claude Code says "done thinking").
     pub notifications: bool,
 }
 

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -141,9 +141,7 @@ pub struct UiTheme {
     pub sidebar_foreground: Option<Color32>,
     pub sidebar_border: Option<Color32>,
     pub sidebar_accent: Option<Color32>,
-    /// Fire a desktop notification when a non-visible session asks for the
-    /// user's attention (rings BEL, or its title transitions out of a spinner
-    /// state — the way Claude Code says "done thinking").
+    /// Fire a desktop notification when a non-visible session needs attention.
     pub notifications: bool,
 }
 

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -135,12 +135,28 @@ pub struct Palette {
     pub draw_bold_with_bright: bool,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct UiTheme {
     pub sidebar_background: Option<Color32>,
     pub sidebar_foreground: Option<Color32>,
     pub sidebar_border: Option<Color32>,
     pub sidebar_accent: Option<Color32>,
+    /// Fire a desktop notification when a non-visible session rings the bell.
+    /// On by default — CLIs like Claude Code ring BEL when they finish or
+    /// need input, which is exactly the cue worth surfacing.
+    pub notifications: bool,
+}
+
+impl Default for UiTheme {
+    fn default() -> Self {
+        Self {
+            sidebar_background: None,
+            sidebar_foreground: None,
+            sidebar_border: None,
+            sidebar_accent: None,
+            notifications: true,
+        }
+    }
 }
 
 impl Default for Config {
@@ -550,6 +566,7 @@ struct RawUi {
     sidebar_foreground: Option<RgbStr>,
     sidebar_border: Option<RgbStr>,
     sidebar_accent: Option<RgbStr>,
+    notifications: Option<bool>,
 }
 
 /// Wrapper that parses `"0xrrggbb"`, `"#rrggbb"`, or `"rrggbb"` into an `Rgb`.
@@ -627,6 +644,7 @@ impl RawConfig {
             sidebar_foreground: self.ui.sidebar_foreground.map(|v| rgb_to_color32(v.0)),
             sidebar_border: self.ui.sidebar_border.map(|v| rgb_to_color32(v.0)),
             sidebar_accent: self.ui.sidebar_accent.map(|v| rgb_to_color32(v.0)),
+            notifications: self.ui.notifications.unwrap_or(true),
         };
 
         // ---- Font ----

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -69,9 +69,23 @@ pub struct Session {
     pub cell_size: (f32, f32),
     pub term: Arc<FairMutex<Term<EventProxy>>>,
     pub events: mpsc::Receiver<TermEvent>,
+    /// Bell rang while the user wasn't looking — surfaced as a sidebar
+    /// indicator until they switch to or refocus this session.  Claude Code
+    /// (and most CLIs that solicit input) ring the bell to flag "I'm done /
+    /// I need you", which is exactly the cue we want.
+    pub needs_attention: bool,
     notifier: Notifier,
     sender: EventLoopSender,
     exited: bool,
+}
+
+/// Outcome of draining one session's pending PTY events for a single frame.
+#[derive(Default)]
+pub struct DrainOutcome {
+    /// At least one `Event::Bell` was observed.  Caller decides whether the
+    /// user can already see the session (visible + focused) or it warrants a
+    /// notification.
+    pub bell: bool,
 }
 
 impl Session {
@@ -126,6 +140,7 @@ impl Session {
             cell_size,
             term,
             events,
+            needs_attention: false,
             notifier: Notifier(sender.clone()),
             sender,
             exited: false,
@@ -134,6 +149,23 @@ impl Session {
 
     pub fn write(&self, bytes: Vec<u8>) {
         self.notifier.notify(bytes);
+    }
+
+    /// Pull every pending event out of the PTY channel.  Called once per frame
+    /// for every session — including background ones — so bells, title
+    /// changes, and child-exits from non-visible sessions don't pile up.
+    pub fn drain_events(&mut self) -> DrainOutcome {
+        let mut outcome = DrainOutcome::default();
+        while let Ok(event) = self.events.try_recv() {
+            match event {
+                TermEvent::PtyWrite(s) => self.write(s.into_bytes()),
+                TermEvent::Title(t) => self.title = t,
+                TermEvent::ChildExit(_) => self.exited = true,
+                TermEvent::Bell => outcome.bell = true,
+                _ => {},
+            }
+        }
+        outcome
     }
 
     pub fn resize(&mut self, size: TermSize, cell_size: (f32, f32)) {
@@ -148,10 +180,6 @@ impl Session {
         let ws = window_size(size, cell_size);
         let _ = self.sender.send(Msg::Resize(ws));
         self.term.lock().resize(size);
-    }
-
-    pub fn mark_exited(&mut self) {
-        self.exited = true;
     }
 
     pub fn is_exited(&self) -> bool {

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -69,10 +69,9 @@ pub struct Session {
     pub cell_size: (f32, f32),
     pub term: Arc<FairMutex<Term<EventProxy>>>,
     pub events: mpsc::Receiver<TermEvent>,
-    /// Bell rang while the user wasn't looking — surfaced as a sidebar
-    /// indicator until they switch to or refocus this session.  Claude Code
-    /// (and most CLIs that solicit input) ring the bell to flag "I'm done /
-    /// I need you", which is exactly the cue we want.
+    /// Session asked for the user's attention (BEL, or title transitioning
+    /// out of a working spinner) while they weren't looking.  Surfaced as a
+    /// sidebar indicator until they switch to or refocus this session.
     pub needs_attention: bool,
     notifier: Notifier,
     sender: EventLoopSender,
@@ -82,10 +81,25 @@ pub struct Session {
 /// Outcome of draining one session's pending PTY events for a single frame.
 #[derive(Default)]
 pub struct DrainOutcome {
-    /// At least one `Event::Bell` was observed.  Caller decides whether the
-    /// user can already see the session (visible + focused) or it warrants a
-    /// notification.
-    pub bell: bool,
+    /// Something this session emitted suggests it wants the user's attention.
+    /// Sources:
+    /// - `Event::Bell` (the universal signal — any CLI ringing BEL).
+    /// - Title transitioning out of a braille-spinner state (the pattern
+    ///   Claude Code uses to indicate "done thinking" since it doesn't ring
+    ///   BEL).  Caller still decides whether the session is currently
+    ///   visible+focused (in which case the signal is suppressed).
+    pub attention: bool,
+}
+
+/// Heuristic for "this title looks like a working/spinner state".  Matches
+/// any title containing a Braille glyph (`U+2800..=U+28FF`), which is the
+/// near-universal spinner alphabet (Claude Code, oh-my-posh, ollama, cargo's
+/// progress indicator, etc.).
+fn is_spinner_title(title: &str) -> bool {
+    title.chars().any(|c| {
+        let n = c as u32;
+        (0x2800..=0x28FF).contains(&n)
+    })
 }
 
 impl Session {
@@ -159,9 +173,17 @@ impl Session {
         while let Ok(event) = self.events.try_recv() {
             match event {
                 TermEvent::PtyWrite(s) => self.write(s.into_bytes()),
-                TermEvent::Title(t) => self.title = t,
+                TermEvent::Title(t) => {
+                    // A spinner-shaped title transitioning to a non-spinner one
+                    // is how Claude Code (and similar tools that don't ring
+                    // BEL) signal "done — your turn".  Treat it like a bell.
+                    if is_spinner_title(&self.title) && !is_spinner_title(&t) {
+                        outcome.attention = true;
+                    }
+                    self.title = t;
+                },
                 TermEvent::ChildExit(_) => self.exited = true,
-                TermEvent::Bell => outcome.bell = true,
+                TermEvent::Bell => outcome.attention = true,
                 _ => {},
             }
         }

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -69,25 +69,17 @@ pub struct Session {
     pub cell_size: (f32, f32),
     pub term: Arc<FairMutex<Term<EventProxy>>>,
     pub events: mpsc::Receiver<TermEvent>,
-    /// Session asked for the user's attention (BEL, or title transitioning
-    /// out of a working spinner) while they weren't looking.  Surfaced as a
-    /// sidebar indicator until they switch to or refocus this session.
+    /// Latched attention flag, cleared when the user views this session.
     pub needs_attention: bool,
     notifier: Notifier,
     sender: EventLoopSender,
     exited: bool,
 }
 
-/// Outcome of draining one session's pending PTY events for a single frame.
 #[derive(Default)]
 pub struct DrainOutcome {
-    /// Something this session emitted suggests it wants the user's attention.
-    /// Sources:
-    /// - `Event::Bell` (the universal signal — any CLI ringing BEL).
-    /// - Title transitioning out of a braille-spinner state (the pattern
-    ///   Claude Code uses to indicate "done thinking" since it doesn't ring
-    ///   BEL).  Caller still decides whether the session is currently
-    ///   visible+focused (in which case the signal is suppressed).
+    /// Set if any event in this batch warrants flagging the session: BEL, or
+    /// a title transitioning out of a spinner state.
     pub attention: bool,
 }
 
@@ -101,6 +93,12 @@ fn is_spinner_title(title: &str) -> bool {
         (0x2800..=0x28FF).contains(&n)
     })
 }
+
+/// Substrings that identify an LLM-agent CLI by its OSC 0/2 title.  Listed in
+/// match-priority order; the first match wins.  Extend cautiously — a false
+/// positive turns a random shell title into an "agent icon" in the sidebar.
+const AGENT_TITLE_MARKERS: &[&str] =
+    &["Claude Code", "Gemini", "Codex", "Aider", "Cursor", "Continue"];
 
 impl Session {
     pub fn spawn(
@@ -206,6 +204,19 @@ impl Session {
 
     pub fn is_exited(&self) -> bool {
         self.exited
+    }
+
+    /// Leading glyph of this session's title if the title looks like a
+    /// recognized LLM-agent CLI.  Painting this each frame gives a free
+    /// spinner animation because the agent rewrites its title each tick.
+    pub fn agent_glyph(&self) -> Option<char> {
+        let matches_agent = AGENT_TITLE_MARKERS.iter().any(|m| self.title.contains(m));
+        if !matches_agent {
+            return None;
+        }
+        let first = self.title.trim_start().chars().next()?;
+        // Skip alphanumeric leads (bare names like "Codex") — would render as a plain letter.
+        if first.is_alphanumeric() { None } else { Some(first) }
     }
 
     pub fn shutdown(&self) {

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -1,6 +1,8 @@
+use std::cell::Cell;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use alacritty_terminal::event::{Event as TermEvent, EventListener, Notify, WindowSize};
 use alacritty_terminal::event_loop::{EventLoop, EventLoopSender, Msg, Notifier};
@@ -71,10 +73,39 @@ pub struct Session {
     pub events: mpsc::Receiver<TermEvent>,
     /// Latched attention flag, cleared when the user views this session.
     pub needs_attention: bool,
+    /// Shell pid spawned for this PTY.  Used to walk to the foreground
+    /// process group when identifying which agent is running.  None on
+    /// platforms where we don't yet capture it (Windows).
+    shell_pid: Option<u32>,
+    /// Cached result of the last foreground-process probe — refreshed on a
+    /// timer instead of polling `/proc` every frame.  `Cell` is enough since
+    /// `Session` isn't `Sync` and the values are `Copy`.
+    agent_cache: Cell<AgentCache>,
     notifier: Notifier,
     sender: EventLoopSender,
     exited: bool,
 }
+
+#[derive(Clone, Copy, Default)]
+struct AgentCache {
+    polled_at: Option<Instant>,
+    /// Static glyph for the foreground process if it's a recognized agent.
+    process_glyph: Option<char>,
+}
+
+const AGENT_CACHE_TTL: Duration = Duration::from_millis(1000);
+
+/// Map a foreground process name (from `/proc/<pid>/comm`) to its static
+/// sidebar glyph.  `comm` is kernel-truncated to 15 bytes, so we compare with
+/// `starts_with` — `cursor-agent` would otherwise miss.
+const AGENT_PROCESS_GLYPHS: &[(&str, char)] = &[
+    ("claude", '✳'),
+    ("codex", '◇'),
+    ("gemini", '✦'),
+    ("aider", '▲'),
+    ("cursor-agent", '❖'),
+    ("continue", '⊕'),
+];
 
 #[derive(Default)]
 pub struct DrainOutcome {
@@ -94,11 +125,91 @@ fn is_spinner_title(title: &str) -> bool {
     })
 }
 
-/// Substrings that identify an LLM-agent CLI by its OSC 0/2 title.  Listed in
-/// match-priority order; the first match wins.  Extend cautiously — a false
-/// positive turns a random shell title into an "agent icon" in the sidebar.
-const AGENT_TITLE_MARKERS: &[&str] =
-    &["Claude Code", "Gemini", "Codex", "Aider", "Cursor", "Continue"];
+/// `<glyph> <text>` titles are the universal agent-CLI shape: a non-ASCII
+/// leading glyph followed by whitespace.  Plain titles (`~/foo`, `bash`)
+/// fail both checks.
+fn title_decorative_glyph(title: &str) -> Option<char> {
+    let trimmed = title.trim_start();
+    let mut chars = trimmed.chars();
+    let first = chars.next()?;
+    if (first as u32) < 0x80 {
+        return None;
+    }
+    if !chars.next().is_some_and(|c| c.is_whitespace()) {
+        return None;
+    }
+    Some(first)
+}
+
+#[cfg(unix)]
+fn pty_shell_pid(pty: &alacritty_terminal::tty::Pty) -> Option<u32> {
+    Some(pty.child().id())
+}
+
+#[cfg(not(unix))]
+fn pty_shell_pid(_pty: &alacritty_terminal::tty::Pty) -> Option<u32> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn foreground_process_glyph(shell_pid: u32) -> Option<char> {
+    let tpgid = read_tpgid(shell_pid)?;
+    if tpgid <= 0 {
+        return None;
+    }
+    let comm = std::fs::read_to_string(format!("/proc/{tpgid}/comm")).ok();
+    let cmdline = read_cmdline(tpgid as u32);
+    let comm_trim = comm.as_deref().map(str::trim).unwrap_or("");
+
+    // Match `comm` first (cheap), then anywhere in `cmdline` — picks up
+    // `node /path/to/agent-cli.js`-style wrappers that hide behind their
+    // runtime's name.
+    let by_comm =
+        AGENT_PROCESS_GLYPHS.iter().find(|(name, _)| comm_trim.starts_with(name)).map(|(_, g)| *g);
+    if by_comm.is_some() {
+        return by_comm;
+    }
+    if let Some(cmd) = &cmdline {
+        let glyph =
+            AGENT_PROCESS_GLYPHS.iter().find(|(name, _)| cmd.contains(name)).map(|(_, g)| *g);
+        if glyph.is_some() {
+            return glyph;
+        }
+        log::debug!("foreground process not matched: comm={comm_trim:?} cmdline={cmd:?}");
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn read_cmdline(pid: u32) -> Option<String> {
+    // `cmdline` is NUL-separated argv; rendering with spaces is good enough
+    // for substring matching and human-readable logging.
+    let bytes = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    if bytes.is_empty() {
+        return None;
+    }
+    let s: String = bytes.iter().map(|&b| if b == 0 { ' ' } else { b as char }).collect();
+    Some(s.trim().to_string())
+}
+
+/// `/proc/<pid>/stat` is `pid (comm) state ppid pgrp session tty_nr tpgid …`.
+/// `comm` may contain spaces and unmatched parens, so split on the *last* `)`
+/// before tokenizing the rest.
+#[cfg(target_os = "linux")]
+fn read_tpgid(shell_pid: u32) -> Option<i32> {
+    let stat = std::fs::read_to_string(format!("/proc/{shell_pid}/stat")).ok()?;
+    let close = stat.rfind(')')?;
+    let after = &stat[close + 1..];
+    // After `comm`: state(0) ppid(1) pgrp(2) session(3) tty_nr(4) tpgid(5).
+    after.split_whitespace().nth(5)?.parse::<i32>().ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn foreground_process_glyph(_shell_pid: u32) -> Option<char> {
+    // macOS would use `libproc::proc_pidfdinfo` / `tcgetpgrp` on the master
+    // FD; Windows is its own world.  Not wired up yet.
+    None
+}
 
 impl Session {
     pub fn spawn(
@@ -134,6 +245,7 @@ impl Session {
         // alacritty routes OSC 7 / signals by this id, so each session needs its own.
         let window_id = next_window_id();
         let pty = tty::new(&pty_options, window_size, window_id)?;
+        let shell_pid = pty_shell_pid(&pty);
 
         let event_loop = EventLoop::new(term.clone(), proxy, pty, false, false)?;
         let sender = event_loop.channel();
@@ -153,6 +265,8 @@ impl Session {
             term,
             events,
             needs_attention: false,
+            shell_pid,
+            agent_cache: Cell::new(AgentCache::default()),
             notifier: Notifier(sender.clone()),
             sender,
             exited: false,
@@ -206,17 +320,31 @@ impl Session {
         self.exited
     }
 
-    /// Leading glyph of this session's title if the title looks like a
-    /// recognized LLM-agent CLI.  Painting this each frame gives a free
-    /// spinner animation because the agent rewrites its title each tick.
+    /// Sidebar glyph for the agent running here.  Identity comes from the
+    /// PTY's foreground process (`/proc` on Linux); the displayed glyph
+    /// prefers the title's current leading char so the agent's own spinner
+    /// frames animate for free, falling back to a per-agent static glyph
+    /// when the title is plain ASCII.  When proc identification yields
+    /// nothing, accept a decorative title as a permissive fallback so
+    /// agents we don't have in the process map still show *something*.
     pub fn agent_glyph(&self) -> Option<char> {
-        let matches_agent = AGENT_TITLE_MARKERS.iter().any(|m| self.title.contains(m));
-        if !matches_agent {
-            return None;
+        let proc_glyph = self.process_agent_glyph();
+        let title_glyph = title_decorative_glyph(&self.title);
+        if proc_glyph.is_some() {
+            return title_glyph.or(proc_glyph);
         }
-        let first = self.title.trim_start().chars().next()?;
-        // Skip alphanumeric leads (bare names like "Codex") — would render as a plain letter.
-        if first.is_alphanumeric() { None } else { Some(first) }
+        title_glyph
+    }
+
+    fn process_agent_glyph(&self) -> Option<char> {
+        let cached = self.agent_cache.get();
+        let fresh = cached.polled_at.is_some_and(|t| t.elapsed() < AGENT_CACHE_TTL);
+        if fresh {
+            return cached.process_glyph;
+        }
+        let glyph = self.shell_pid.and_then(foreground_process_glyph);
+        self.agent_cache.set(AgentCache { polled_at: Some(Instant::now()), process_glyph: glyph });
+        glyph
     }
 
     pub fn shutdown(&self) {

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -61,7 +61,6 @@ pub fn show(ui: &mut Ui, session: &mut Session, config: &Config, allow_focus: bo
 
     let painter = ui.painter_at(rect);
 
-    drain_pty_events(session);
     handle_selection(ui, &response, session, config, rect, cell_w, cell_h, cols, rows);
     paint_grid(&painter, rect, session, config, &font_id, cell_w, cell_h);
 
@@ -78,18 +77,6 @@ pub fn show(ui: &mut Ui, session: &mut Session, config: &Config, allow_focus: bo
     }
 
     response
-}
-
-fn drain_pty_events(session: &mut Session) {
-    use alacritty_terminal::event::Event as TermEvent;
-    while let Ok(event) = session.events.try_recv() {
-        match event {
-            TermEvent::PtyWrite(s) => session.write(s.into_bytes()),
-            TermEvent::Title(t) => session.title = t,
-            TermEvent::ChildExit(_) => session.mark_exited(),
-            _ => {},
-        }
-    }
 }
 
 fn handle_selection(

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -105,10 +105,8 @@ fn run_create(
         send(&format!("Copied {copied} LLM config item(s)"));
     }
 
-    // Force Claude Code to ring BEL on completion / waiting-for-input so the
-    // sidebar attention indicator + desktop notification fire without the
-    // user having to configure each worktree by hand.  We only ever overwrite
-    // this one key, preserving anything else the user copied over.
+    // Pre-flip Claude Code's BEL setting so the user doesn't have to
+    // configure each worktree by hand.  Other keys in the file are preserved.
     if let Err(e) = enable_claude_terminal_bell(&target) {
         log::warn!("failed to write Claude bell config in {}: {e}", target.display());
     } else {

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -105,7 +105,37 @@ fn run_create(
         send(&format!("Copied {copied} LLM config item(s)"));
     }
 
+    // Force Claude Code to ring BEL on completion / waiting-for-input so the
+    // sidebar attention indicator + desktop notification fire without the
+    // user having to configure each worktree by hand.  We only ever overwrite
+    // this one key, preserving anything else the user copied over.
+    if let Err(e) = enable_claude_terminal_bell(&target) {
+        log::warn!("failed to write Claude bell config in {}: {e}", target.display());
+    } else {
+        send("Enabled Claude Code terminal bell");
+    }
+
     Ok(target)
+}
+
+fn enable_claude_terminal_bell(worktree_root: &Path) -> std::io::Result<()> {
+    let dir = worktree_root.join(".claude");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join("settings.local.json");
+
+    let mut value: serde_json::Value = match std::fs::read_to_string(&path) {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|_| serde_json::json!({})),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
+        Err(e) => return Err(e),
+    };
+    if !value.is_object() {
+        value = serde_json::json!({});
+    }
+    value["preferredNotifChannel"] = serde_json::json!("terminal_bell");
+
+    let pretty = serde_json::to_string_pretty(&value)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(path, pretty)
 }
 
 fn run_git(cwd: &Path, args: &[&str]) -> Result<(), String> {


### PR DESCRIPTION
## Summary
- Track a `needs_attention` flag per session and drain every PTY (not just the visible one) so bells from background workspaces aren't dropped.
- When a non-visible session rings BEL (Claude Code rings it on "done generating" and on permission prompts), surface a yellow dot on the worktree/home row, on collapsed parent projects, and on the tab strip segment.
- Fire a desktop toast via `notify-rust` from a worker thread so D-Bus / WinRT calls don't stall the paint loop.
- Toggle the toast via `[ui].notifications` in `alacritree.toml` (default on). The sidebar indicator is always on — it has no notification cost.
- Indicator auto-clears once the user focuses the window with that session visible.

## Test plan
- [ ] Run Claude Code in a worktree, switch to another workspace, let Claude finish → yellow dot appears on the original row and a desktop notification fires.
- [ ] Click back to the worktree (window focused) → dot disappears.
- [ ] With multiple sessions in one workspace (Ctrl+T), bell on a non-active tab → that tab strip segment turns yellow.
- [ ] Bell on a worktree under a collapsed project → dot bubbles up to the project row.
- [ ] Set `notifications = false` under `[ui]` → no desktop toast, sidebar dot still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)