### PR TITLE
feat: open links on click in the terminal view

### DIFF
--- a/alacritree/src/links.rs
+++ b/alacritree/src/links.rs
@@ -1,0 +1,195 @@
+//! Detect clickable links in the terminal grid.
+//!
+//! Mirrors alacritty's default URL hint behaviour: OSC 8 hyperlinks and
+//! `scheme://...` URLs visible in the viewport are recognised so the
+//! terminal view can underline them on hover and open them on click.
+
+use std::cell::RefCell;
+use std::process::{Command, Stdio};
+
+use alacritty_terminal::grid::BidirectionalIterator;
+use alacritty_terminal::index::{Direction, Point};
+use alacritty_terminal::term::Term;
+use alacritty_terminal::term::search::{Match, RegexIter, RegexSearch};
+
+use crate::session::EventProxy;
+
+// Identical to alacritty's built-in URL hint regex so the set of recognised
+// schemes (and the trailing-character rules) stay in sync with what users
+// experience in vanilla alacritty.
+#[rustfmt::skip]
+const URL_REGEX: &str = "(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)\
+                         [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`\\\\]+";
+
+thread_local! {
+    // RegexSearch holds lazily-populated DFAs and needs `&mut` to query, but
+    // recompiling the pattern every frame is wasteful.  egui runs the UI on
+    // one thread, so a TLS RefCell is enough.
+    static URL_SEARCH: RefCell<RegexSearch> =
+        RefCell::new(RegexSearch::new(URL_REGEX).expect("URL_REGEX must compile"));
+}
+
+#[derive(Debug, Clone)]
+pub struct Link {
+    pub bounds: Match,
+    pub uri: String,
+}
+
+/// Find a clickable link covering `point`, if any.
+///
+/// OSC 8 hyperlinks take priority over regex matches because they carry an
+/// explicit URI that may differ from the visible text.
+pub fn link_at(term: &Term<EventProxy>, point: Point) -> Option<Link> {
+    if let Some(link) = hyperlink_at(term, point) {
+        return Some(link);
+    }
+
+    URL_SEARCH.with(|cell| {
+        let mut regex = cell.borrow_mut();
+        let bounds = url_match_at(term, point, &mut regex)?;
+        let uri = term.bounds_to_string(*bounds.start(), *bounds.end());
+        Some(Link { bounds, uri })
+    })
+}
+
+fn hyperlink_at(term: &Term<EventProxy>, point: Point) -> Option<Link> {
+    let hyperlink = term.grid()[point].hyperlink()?;
+    let grid = term.grid();
+
+    let mut end = point;
+    for cell in grid.iter_from(point) {
+        if cell.hyperlink().is_some_and(|h| h == hyperlink) {
+            end = cell.point;
+        } else {
+            break;
+        }
+    }
+
+    let mut start = point;
+    let mut iter = grid.iter_from(point);
+    while let Some(cell) = iter.prev() {
+        if cell.hyperlink().is_some_and(|h| h == hyperlink) {
+            start = cell.point;
+        } else {
+            break;
+        }
+    }
+
+    Some(Link { bounds: start..=end, uri: hyperlink.uri().to_owned() })
+}
+
+fn url_match_at(term: &Term<EventProxy>, point: Point, regex: &mut RegexSearch) -> Option<Match> {
+    // URLs can wrap, so the scan range is the full logical line that contains
+    // `point` — `line_search_left/right` follow WRAPLINE flags to cover that.
+    let line_start = term.line_search_left(point);
+    let line_end = term.line_search_right(point);
+
+    let regex_match = RegexIter::new(line_start, line_end, Direction::Right, term, regex)
+        .find(|rm| rm.contains(&point))?;
+
+    post_process(term, regex_match, point)
+}
+
+/// Strip trailing punctuation and unbalanced brackets that the regex greedily
+/// includes.  Same heuristic alacritty's `HintPostProcessor` uses so a URL
+/// embedded in prose (`see (https://example.com).`) opens at the right bound.
+fn post_process(term: &Term<EventProxy>, regex_match: Match, point: Point) -> Option<Match> {
+    let mut iter = term.grid().iter_from(*regex_match.start());
+    let end = *regex_match.end();
+    let mut c = iter.cell().c;
+
+    let mut open_parens = 0i32;
+    let mut open_brackets = 0i32;
+    loop {
+        match c {
+            '(' => open_parens += 1,
+            '[' => open_brackets += 1,
+            ')' => {
+                if open_parens == 0 {
+                    iter.prev();
+                    break;
+                }
+                open_parens -= 1;
+            },
+            ']' => {
+                if open_brackets == 0 {
+                    iter.prev();
+                    break;
+                }
+                open_brackets -= 1;
+            },
+            _ => (),
+        }
+
+        if iter.point() == end {
+            break;
+        }
+
+        match iter.next() {
+            Some(indexed) => c = indexed.cell.c,
+            None => break,
+        }
+    }
+
+    let start = *regex_match.start();
+    while iter.point() != start {
+        if !matches!(c, '.' | ',' | ':' | ';' | '?' | '!' | '(' | '[' | '\'') {
+            break;
+        }
+        match iter.prev() {
+            Some(indexed) => c = indexed.cell.c,
+            None => break,
+        }
+    }
+
+    if start > iter.point() {
+        return None;
+    }
+    let trimmed = start..=iter.point();
+    trimmed.contains(&point).then_some(trimmed)
+}
+
+/// Hand the URI to the OS handler — `xdg-open` on Linux/BSDs, `open` on macOS,
+/// `cmd /c start` on Windows — matching alacritty's default URL hint action.
+pub fn open(uri: &str) {
+    let result = spawn(uri);
+    if let Err(err) = result {
+        log::warn!("failed to open link {uri:?}: {err}");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn spawn(uri: &str) -> std::io::Result<()> {
+    Command::new("open")
+        .arg(uri)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+}
+
+#[cfg(target_os = "windows")]
+fn spawn(uri: &str) -> std::io::Result<()> {
+    // `start` treats its first quoted argument as a window title, so pass an
+    // empty title before the URL to keep `cmd` from eating it.
+    Command::new("cmd")
+        .args(["/c", "start", ""])
+        .arg(uri)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn spawn(uri: &str) -> std::io::Result<()> {
+    Command::new("xdg-open")
+        .arg(uri)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+}

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod fonts;
 mod git_status;
 mod input;
+mod links;
 mod projects;
 mod session;
 mod state;

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -3,9 +3,11 @@ use alacritty_terminal::index::{Column, Line, Point, Side};
 use alacritty_terminal::selection::{Selection, SelectionRange, SelectionType};
 use alacritty_terminal::term::Term;
 use alacritty_terminal::term::cell::{Cell, Flags};
+use alacritty_terminal::term::search::Match;
 use alacritty_terminal::vte::ansi::Color as AnsiColor;
 use egui::{
-    Color32, FontFamily, FontId, PointerButton, Pos2, Rect, Response, Sense, Stroke, Ui, Vec2,
+    Color32, CursorIcon, FontFamily, FontId, PointerButton, Pos2, Rect, Response, Sense, Stroke,
+    Ui, Vec2,
 };
 
 use crate::builtin_font::{BuiltinGlyphCache, Metrics, is_builtin_glyph};
@@ -14,6 +16,7 @@ use crate::colors::{background, foreground, resolve, rgb_to_color32};
 use crate::config::Config;
 use crate::fonts::{BOLD_FAMILY, BOLD_ITALIC_FAMILY, ITALIC_FAMILY};
 use crate::input::event_to_bytes;
+use crate::links::{self, Link};
 use crate::session::{EventProxy, Session, TermSize};
 
 pub fn show(
@@ -72,7 +75,22 @@ pub fn show(
 
     let painter = ui.painter_at(rect);
 
-    handle_selection(ui, &response, session, config, rect, cell_w, cell_h, cols, rows);
+    let hovered_link = hovered_link(ui, &response, session, rect, cell_w, cell_h, cols, rows);
+    if hovered_link.is_some() {
+        ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
+    }
+    handle_selection(
+        ui,
+        &response,
+        session,
+        config,
+        rect,
+        cell_w,
+        cell_h,
+        cols,
+        rows,
+        hovered_link.as_ref(),
+    );
     // Built-in renderer expects the *unadjusted* pixel cell size so it can
     // re-apply `font.offset` itself — passing `cell_w * ppp` (which already
     // includes the offset) would double-add it.  Descent is zero here: the
@@ -96,6 +114,7 @@ pub fn show(
         &metrics,
         builtin_glyphs,
         ui.ctx(),
+        hovered_link.as_ref().map(|l| &l.bounds),
     );
 
     if allow_focus && response.has_focus() {
@@ -113,6 +132,34 @@ pub fn show(
     response
 }
 
+/// Resolve the link under the mouse pointer, if any.  Returns `None` when the
+/// pointer is outside the grid, when no link covers that cell, or when the
+/// pointer is being used for an active drag (so click-to-open never fights
+/// with text selection).
+fn hovered_link(
+    ui: &Ui,
+    response: &Response,
+    session: &Session,
+    rect: Rect,
+    cell_w: f32,
+    cell_h: f32,
+    cols: usize,
+    rows: usize,
+) -> Option<Link> {
+    if response.dragged() {
+        return None;
+    }
+    let pos = ui.input(|i| i.pointer.hover_pos())?;
+    if !rect.contains(pos) {
+        return None;
+    }
+    let term = session.term.lock();
+    let display_offset = term.grid().display_offset() as i32;
+    let (point, _) = cell_at_pos(pos, rect, cell_w, cell_h, cols, rows, display_offset);
+    links::link_at(&term, point)
+}
+
+#[allow(clippy::too_many_arguments)]
 fn handle_selection(
     ui: &Ui,
     response: &Response,
@@ -123,6 +170,7 @@ fn handle_selection(
     cell_h: f32,
     cols: usize,
     rows: usize,
+    hovered_link: Option<&Link>,
 ) {
     let primary = PointerButton::Primary;
     let secondary = PointerButton::Secondary;
@@ -209,6 +257,13 @@ fn handle_selection(
     } else if response.drag_stopped_by(primary) {
         copy_active_selection(&session.term.lock(), config);
     } else if response.clicked_by(primary) {
+        // A bare primary click on a link follows it instead of clearing the
+        // selection.  That matches alacritty's default URL hint, which fires
+        // on release without any modifier.
+        if let Some(link) = hovered_link {
+            links::open(&link.uri);
+            return;
+        }
         // Bare click outside an existing drag clears the selection, matching alacritty.
         session.term.lock().selection = None;
     }
@@ -284,8 +339,12 @@ struct Style {
 }
 
 impl Style {
-    fn from_cell(cell: &Cell) -> Self {
-        Self { fg: cell.fg, bg: cell.bg, flags: cell.flags }
+    fn from_cell(cell: &Cell, underline_link: bool) -> Self {
+        let mut flags = cell.flags;
+        if underline_link {
+            flags.insert(Flags::UNDERLINE);
+        }
+        Self { fg: cell.fg, bg: cell.bg, flags }
     }
 }
 
@@ -302,6 +361,7 @@ fn paint_grid(
     metrics: &Metrics,
     builtin_glyphs: &mut BuiltinGlyphCache,
     ctx: &egui::Context,
+    link_bounds: Option<&Match>,
 ) {
     let term = session.term.lock();
     let runtime_palette = term.colors();
@@ -317,6 +377,9 @@ fn paint_grid(
     // Resolve the active selection once per frame; the per-cell range checks
     // are cheap and avoid relocking inside paint_run.
     let selection_range = term.selection.as_ref().and_then(|s| s.to_range(&term));
+    let in_link = |line: Line, column: Column| {
+        link_bounds.is_some_and(|b| b.contains(&Point::new(line, column)))
+    };
 
     for row_idx in 0..screen_lines {
         let line = Line(row_idx - display_offset);
@@ -326,12 +389,12 @@ fn paint_grid(
         let mut col = 0;
         while col < cols {
             let start = col;
-            let style = Style::from_cell(&row[Column(col)]);
+            let style = Style::from_cell(&row[Column(col)], in_link(line, Column(col)));
             let selected = is_selected(selection_range.as_ref(), line, Column(col));
             let mut run = String::new();
             while col < cols {
                 let cell = &row[Column(col)];
-                if Style::from_cell(cell) != style
+                if Style::from_cell(cell, in_link(line, Column(col))) != style
                     || is_selected(selection_range.as_ref(), line, Column(col)) != selected
                 {
                     break;


### PR DESCRIPTION
## Summary
- Detect OSC 8 hyperlinks and `scheme://...` URLs under the mouse pointer using alacritty's URL regex and post-processing heuristics
- Underline the match and switch to a pointing-hand cursor on hover
- A bare primary click hands the URI to `xdg-open` / `open` / `cmd start` instead of clearing the selection — matching alacritty's default URL hint

## Test plan
- [ ] Run `cargo run -p alacritree`, `echo https://example.com`, hover the URL → underline + hand cursor, click → opens in browser
- [ ] Drag-select across a URL still selects text without launching it
- [ ] OSC 8 hyperlink (e.g. `printf '\e]8;;https://example.com\e\\example\e]8;;\e\\\n'`) underlines and opens its URI
- [ ] URL embedded in prose like `see (https://example.com).` opens at the right bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)