### PR TITLE
fix(bindings): fire all matching bindings, honor ReceiveChar

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -464,11 +464,19 @@ impl AlacritreeApp {
             let mut actions = Vec::new();
             i.events.retain(|ev| {
                 if let egui::Event::Key { key, pressed: true, modifiers, .. } = ev {
-                    if let Some(action) =
-                        crate::bindings::matches(&self.config.bindings, *key, *modifiers)
-                    {
-                        actions.push(action.clone());
-                        return false;
+                    let matched = crate::bindings::all_matches(
+                        &self.config.bindings,
+                        *key,
+                        *modifiers,
+                    );
+                    if !matched.is_empty() {
+                        let suppress_chars = matched
+                            .iter()
+                            .all(|a| !matches!(a, BindingAction::Named(NamedAction::ReceiveChar)));
+                        for a in matched {
+                            actions.push(a.clone());
+                        }
+                        return !suppress_chars;
                     }
                 }
                 true
@@ -541,6 +549,7 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::SelectTab(n)) => self.select_tab(n),
             BindingAction::Named(NamedAction::SelectLastTab) => self.select_last_tab(),
             BindingAction::Named(NamedAction::NoOp) => {},
+            BindingAction::Named(NamedAction::ReceiveChar) => {},
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
             },

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -47,6 +47,10 @@ pub enum NamedAction {
     Quit,
     /// Used to unbind a key — consumes the press without acting on it.
     NoOp,
+    /// Alacritty's pass-through marker: the matching binding runs (no-op for
+    /// us) but suppress_chars stays off so the key still reaches the PTY.
+    /// Mirrors `Action::ReceiveChar` in `alacritty/src/input/keyboard.rs`.
+    ReceiveChar,
 }
 
 #[derive(Debug, Deserialize)]
@@ -193,8 +197,16 @@ fn default_bindings() -> Vec<KeyBinding> {
     b
 }
 
-pub fn matches(bindings: &[KeyBinding], key: Key, mods: Modifiers) -> Option<&BindingAction> {
-    bindings.iter().find(|b| b.key == key && mods_match(b.mods, mods)).map(|b| &b.action)
+/// Every binding that fires for `(key, mods)`.  Alacritty runs *all* matching
+/// bindings (see `Processor::process_key_bindings`), so the user's typical
+/// pattern of stacking `ClearLogNotice` + `chars = "\f"` on Ctrl+L works:
+/// the first action is our `Unsupported` no-op, the second writes 0x0c.
+pub fn all_matches(
+    bindings: &[KeyBinding],
+    key: Key,
+    mods: Modifiers,
+) -> Vec<&BindingAction> {
+    bindings.iter().filter(|b| b.key == key && mods_match(b.mods, mods)).map(|b| &b.action).collect()
 }
 
 /// Alacritty semantics: `Control|Shift` does not fire on Ctrl alone even though
@@ -408,6 +420,7 @@ fn parse_action(name: &str) -> BindingAction {
         "SelectLastTab" => BindingAction::Named(SelectLastTab),
         "Quit" => BindingAction::Named(Quit),
         "None" => BindingAction::Named(NoOp),
+        "ReceiveChar" => BindingAction::Named(ReceiveChar),
         other => BindingAction::Unsupported(other.to_string()),
     }
 }


### PR DESCRIPTION
## Summary

- Ctrl+L (and any other key with stacked bindings) was silently swallowed when an unsupported alacritty action sat ahead of the real `chars = "\f"` binding.
- We now iterate **all** matching bindings instead of stopping at the first match, mirroring alacritty's `Processor::process_key_bindings`.
- Added the `ReceiveChar` action: when any matching binding is `ReceiveChar`, the press falls through to the PTY (same `suppress_chars` semantic as upstream).

## Why this matters

A typical `~/.config/alacritty/alacritty.toml` keeps alacritty's defaults verbatim, which puts two entries on Ctrl+L:

```toml
[[keyboard.bindings]]
action = "ClearLogNotice"   # alacritty-only UI, Unsupported in alacritree
key    = "L"
mods   = "Control"

[[keyboard.bindings]]
chars  = "\f"               # this is the one that actually clears the screen
key    = "L"
mods   = "Control"
```

The old matcher returned `Some(Unsupported("ClearLogNotice"))` on the first hit, consumed the event, and never reached the `chars = "\f"` binding — so Ctrl+L did nothing. Alacritty avoids this because it runs every matching binding and only the `Esc("\f")` action writes 0x0c to the PTY.

## Test plan

- [x] `cargo build -p alacritree`
- [x] Launch with a config containing the stacked Ctrl+L bindings shown above and confirm `clear` works
- [ ] (worth a manual check) configs that bind a single key to multiple supported actions still fire them all