### PR TITLE
feat(git-sidebar): open file diffs in delta on click

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1233,6 +1233,7 @@ fn file_row(
 ) -> egui::Response {
     let bg_idx = ui.painter().add(egui::Shape::Noop);
     let panel_x = ui.max_rect().x_range();
+    let row_h = ui.spacing().interact_size.y;
     let color = match change.kind {
         ChangeKind::Added | ChangeKind::Untracked => rgb_to_color32(palette.normal[2]),
         ChangeKind::Modified => rgb_to_color32(palette.normal[3]),
@@ -1241,14 +1242,27 @@ fn file_row(
         ChangeKind::Conflicted => rgb_to_color32(palette.bright[1]),
     };
     let path_color = if is_active { theme.text } else { theme.text_dim };
+    // `ui.horizontal` sizes its response rect to the (often short) path text,
+    // leaving most of the row's width as a dead zone — and short labels make
+    // the row barely taller than the text, so vertical misses are easy too.
+    // Allocate an explicit interact-sized row and pad it out so the click hit
+    // box spans the full panel width and the row's full height.
     let resp = ui
-        .horizontal(|ui| {
-            ui.label(RichText::new(change.kind.glyph()).color(color).monospace().small());
-            ui.add(
-                egui::Label::new(RichText::new(&change.path).color(path_color).monospace().small())
+        .allocate_ui_with_layout(
+            egui::vec2(ui.available_width(), row_h),
+            egui::Layout::left_to_right(egui::Align::Center),
+            |ui| {
+                ui.set_min_height(row_h);
+                ui.label(RichText::new(change.kind.glyph()).color(color).monospace().small());
+                ui.add(
+                    egui::Label::new(
+                        RichText::new(&change.path).color(path_color).monospace().small(),
+                    )
                     .truncate(),
-            );
-        })
+                );
+                fill_row(ui);
+            },
+        )
         .response
         .interact(egui::Sense::click());
     paint_row_bg(ui, &resp, bg_idx, panel_x, theme, is_active);
@@ -1264,49 +1278,68 @@ fn branch_diff_row(
 ) -> egui::Response {
     let bg_idx = ui.painter().add(egui::Shape::Noop);
     let panel_x = ui.max_rect().x_range();
+    let row_h = ui.spacing().interact_size.y;
     let added = rgb_to_color32(palette.normal[2]);
     let removed = rgb_to_color32(palette.normal[1]);
     let path_color = if is_active { theme.text } else { theme.text_dim };
 
-    // Mirror row_with_trailing's layout (right_to_left wrapping a left_to_right)
-    // so the path truncates cleanly while the +/- counts pin to the right edge.
-    let row_size = egui::vec2(ui.available_width(), ui.spacing().interact_size.y);
+    // Same shape as row_with_trailing (right_to_left wrapping a left_to_right)
+    // so +/- counts pin to the right edge while the path truncates cleanly;
+    // `set_min_height` + `fill_row` push the hit box to the full row size.
     let resp = ui
-        .allocate_ui_with_layout(row_size, egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            if stat.deletions > 0 {
-                ui.label(
-                    RichText::new(format!("-{}", stat.deletions))
-                        .color(removed)
-                        .small()
-                        .monospace(),
-                );
-            }
-            if stat.additions > 0 {
-                ui.label(
-                    RichText::new(format!("+{}", stat.additions)).color(added).small().monospace(),
-                );
-            }
-            let remaining = ui.available_width();
-            if remaining > 0.0 {
-                let row_h = ui.available_height();
-                ui.allocate_ui_with_layout(
-                    egui::vec2(remaining, row_h),
-                    egui::Layout::left_to_right(egui::Align::Center),
-                    |ui| {
-                        ui.add(
-                            egui::Label::new(
-                                RichText::new(&stat.path).color(path_color).monospace().small(),
-                            )
-                            .truncate(),
-                        );
-                    },
-                );
-            }
-        })
+        .allocate_ui_with_layout(
+            egui::vec2(ui.available_width(), row_h),
+            egui::Layout::right_to_left(egui::Align::Center),
+            |ui| {
+                ui.set_min_height(row_h);
+                if stat.deletions > 0 {
+                    ui.label(
+                        RichText::new(format!("-{}", stat.deletions))
+                            .color(removed)
+                            .small()
+                            .monospace(),
+                    );
+                }
+                if stat.additions > 0 {
+                    ui.label(
+                        RichText::new(format!("+{}", stat.additions))
+                            .color(added)
+                            .small()
+                            .monospace(),
+                    );
+                }
+                let remaining = ui.available_width();
+                if remaining > 0.0 {
+                    ui.allocate_ui_with_layout(
+                        egui::vec2(remaining, row_h),
+                        egui::Layout::left_to_right(egui::Align::Center),
+                        |ui| {
+                            ui.set_min_height(row_h);
+                            ui.add(
+                                egui::Label::new(
+                                    RichText::new(&stat.path).color(path_color).monospace().small(),
+                                )
+                                .truncate(),
+                            );
+                            fill_row(ui);
+                        },
+                    );
+                }
+            },
+        )
         .response
         .interact(egui::Sense::click());
     paint_row_bg(ui, &resp, bg_idx, panel_x, theme, is_active);
     resp
+}
+
+/// Extend a row's bounding rect to its parent's full width so the response
+/// covers the empty space past short labels, instead of just the content.
+fn fill_row(ui: &mut egui::Ui) {
+    let remaining = ui.available_width();
+    if remaining > 0.0 {
+        ui.allocate_space(egui::vec2(remaining, 0.0));
+    }
 }
 
 fn paint_row_bg(

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1253,12 +1253,23 @@ fn file_row(
             egui::Layout::left_to_right(egui::Align::Center),
             |ui| {
                 ui.set_min_height(row_h);
-                ui.label(RichText::new(change.kind.glyph()).color(color).monospace().small());
+                // Labels default to `Sense::click_and_drag` for text selection;
+                // hit testing picks the smallest covering widget, so a clickable
+                // label inside our row would eat clicks before the row sees
+                // them.  Opt out of selection on every label that lives inside
+                // a clickable row so the click falls through.
+                ui.add(
+                    egui::Label::new(
+                        RichText::new(change.kind.glyph()).color(color).monospace().small(),
+                    )
+                    .selectable(false),
+                );
                 ui.add(
                     egui::Label::new(
                         RichText::new(&change.path).color(path_color).monospace().small(),
                     )
-                    .truncate(),
+                    .truncate()
+                    .selectable(false),
                 );
                 fill_row(ui);
             },
@@ -1293,19 +1304,25 @@ fn branch_diff_row(
             |ui| {
                 ui.set_min_height(row_h);
                 if stat.deletions > 0 {
-                    ui.label(
-                        RichText::new(format!("-{}", stat.deletions))
-                            .color(removed)
-                            .small()
-                            .monospace(),
+                    ui.add(
+                        egui::Label::new(
+                            RichText::new(format!("-{}", stat.deletions))
+                                .color(removed)
+                                .small()
+                                .monospace(),
+                        )
+                        .selectable(false),
                     );
                 }
                 if stat.additions > 0 {
-                    ui.label(
-                        RichText::new(format!("+{}", stat.additions))
-                            .color(added)
-                            .small()
-                            .monospace(),
+                    ui.add(
+                        egui::Label::new(
+                            RichText::new(format!("+{}", stat.additions))
+                                .color(added)
+                                .small()
+                                .monospace(),
+                        )
+                        .selectable(false),
                     );
                 }
                 let remaining = ui.available_width();
@@ -1319,7 +1336,8 @@ fn branch_diff_row(
                                 egui::Label::new(
                                     RichText::new(&stat.path).color(path_color).monospace().small(),
                                 )
-                                .truncate(),
+                                .truncate()
+                                .selectable(false),
                             );
                             fill_row(ui);
                         },

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -12,7 +12,7 @@ use crate::colors::rgb_to_color32;
 use crate::config::Config;
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, StatusCache};
 use crate::projects::{Project, Worktree};
-use crate::session::{Session, SessionId, TermSize};
+use crate::session::{Session, SessionId, SessionKind, TermSize};
 use crate::state::{self, PersistedProject, PersistedState};
 use crate::terminal_view;
 use crate::worktree::{self as wt, CreateRequest, Progress};
@@ -137,6 +137,36 @@ enum CreateState {
     Prompt { project_idx: usize, branch: String, error: Option<String> },
     Running { project_idx: usize, branch: String, steps: Vec<String>, rx: Receiver<Progress> },
     Done { project_idx: usize, steps: Vec<String>, result: Result<PathBuf, String> },
+}
+
+/// Which `git diff` flavor a sidebar click should open in delta.
+enum DiffSource {
+    Staged,
+    Worktree,
+    Untracked,
+    /// Triple-dot diff against this base ref (merge-base, matching the
+    /// `Changes vs <branch>` sidebar section).
+    Branch {
+        base: String,
+    },
+}
+
+struct DiffRequest {
+    file: String,
+    source: DiffSource,
+}
+
+/// Stable identifier for "the diff this click would open" — matched against
+/// the active diff session's `SessionKind::Diff { key }` to highlight the
+/// originating row and toggle the pane off when clicked again.
+fn diff_key(req: &DiffRequest) -> String {
+    let tag = match &req.source {
+        DiffSource::Staged => "staged",
+        DiffSource::Worktree => "worktree",
+        DiffSource::Untracked => "untracked",
+        DiffSource::Branch { .. } => "branch",
+    };
+    format!("{tag}:{}", req.file)
 }
 
 impl AlacritreeApp {
@@ -464,11 +494,8 @@ impl AlacritreeApp {
             let mut actions = Vec::new();
             i.events.retain(|ev| {
                 if let egui::Event::Key { key, pressed: true, modifiers, .. } = ev {
-                    let matched = crate::bindings::all_matches(
-                        &self.config.bindings,
-                        *key,
-                        *modifiers,
-                    );
+                    let matched =
+                        crate::bindings::all_matches(&self.config.bindings, *key, *modifiers);
                     if !matched.is_empty() {
                         let suppress_chars = matched
                             .iter()
@@ -873,6 +900,8 @@ impl AlacritreeApp {
     fn show_git_sidebar(&mut self, ctx: &Context, panel_frame: Frame) -> egui::Rect {
         let theme = self.theme;
         let palette = self.config.palette.clone();
+        let active_diff_key = self.active_diff_key();
+        let diff_request: std::cell::Cell<Option<DiffRequest>> = std::cell::Cell::new(None);
         let panel_resp = SidePanel::right("right_sidebar")
             .resizable(true)
             .default_width(300.0 * theme.ui_scale)
@@ -958,13 +987,27 @@ impl AlacritreeApp {
 
                     section(ui, &theme, "Staged", status.staged.len(), |ui| {
                         for f in &status.staged {
-                            file_row(ui, f, &theme, &palette);
+                            let req =
+                                DiffRequest { file: f.path.clone(), source: DiffSource::Staged };
+                            let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
+                            if file_row(ui, f, &theme, &palette, is_active).clicked() {
+                                diff_request.set(Some(req));
+                            }
                         }
                     });
 
                     section(ui, &theme, "Unstaged", status.unstaged.len(), |ui| {
                         for f in &status.unstaged {
-                            file_row(ui, f, &theme, &palette);
+                            let source = if f.kind == ChangeKind::Untracked {
+                                DiffSource::Untracked
+                            } else {
+                                DiffSource::Worktree
+                            };
+                            let req = DiffRequest { file: f.path.clone(), source };
+                            let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
+                            if file_row(ui, f, &theme, &palette, is_active).clicked() {
+                                diff_request.set(Some(req));
+                            }
                         }
                     });
 
@@ -974,49 +1017,121 @@ impl AlacritreeApp {
                             (Some(b), _) => format!("Changes vs {}", b),
                             _ => "Changes vs default".to_string(),
                         };
-                        let added = rgb_to_color32(palette.normal[2]);
-                        let removed = rgb_to_color32(palette.normal[1]);
+                        // Prefer the resolved ref (e.g. `refs/remotes/origin/main`) so the
+                        // sidebar's merge-base diff matches what delta will show.
+                        let base = status
+                            .default_branch_resolved
+                            .clone()
+                            .or_else(|| status.default_branch.clone());
                         section(ui, &theme, &label, status.branch_diff.len(), |ui| {
                             for stat in &status.branch_diff {
-                                row_with_trailing(
-                                    ui,
-                                    |ui| {
-                                        ui.add(
-                                            egui::Label::new(
-                                                RichText::new(&stat.path)
-                                                    .color(theme.text_dim)
-                                                    .monospace()
-                                                    .small(),
-                                            )
-                                            .truncate(),
-                                        );
-                                    },
-                                    |ui| {
-                                        if stat.deletions > 0 {
-                                            ui.label(
-                                                RichText::new(format!("-{}", stat.deletions))
-                                                    .color(removed)
-                                                    .small()
-                                                    .monospace(),
-                                            );
-                                        }
-                                        if stat.additions > 0 {
-                                            ui.label(
-                                                RichText::new(format!("+{}", stat.additions))
-                                                    .color(added)
-                                                    .small()
-                                                    .monospace(),
-                                            );
-                                        }
-                                    },
-                                );
+                                let Some(base) = base.clone() else {
+                                    branch_diff_row(ui, stat, &theme, &palette, false);
+                                    continue;
+                                };
+                                let req = DiffRequest {
+                                    file: stat.path.clone(),
+                                    source: DiffSource::Branch { base },
+                                };
+                                let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
+                                if branch_diff_row(ui, stat, &theme, &palette, is_active).clicked()
+                                {
+                                    diff_request.set(Some(req));
+                                }
                             }
                         });
                     }
                 });
             });
+        if let Some(req) = diff_request.take() {
+            self.open_diff(ctx, req);
+        }
         panel_resp.response.rect
     }
+
+    /// Clicking a sidebar row either opens, replaces, or closes the workspace's
+    /// single diff pane:
+    /// - row matches the active diff → toggle off (close)
+    /// - row matches a different diff → drop the old pane, open this one
+    /// - no active diff → open a new pane
+    /// Dropping the old `Session` runs `Drop`, which sends `Msg::Shutdown` to
+    /// the event loop and exits delta cleanly.
+    fn open_diff(&mut self, ctx: &Context, req: DiffRequest) {
+        let Some(workspace) = self.current_workspace.clone() else {
+            return;
+        };
+        let new_key = diff_key(&req);
+        let already_showing = self.sessions.iter().any(|s| {
+            s.working_directory.as_deref() == Some(&workspace)
+                && matches!(&s.kind, SessionKind::Diff { key } if key == &new_key)
+        });
+        self.sessions.retain(|s| {
+            !(matches!(s.kind, SessionKind::Diff { .. })
+                && s.working_directory.as_deref() == Some(&workspace))
+        });
+        if already_showing {
+            // Active-session fallback to the workspace's shell happens next
+            // frame: `active_session_index()` returns None for the stale id, and
+            // `ensure_active_session` picks up an existing shell or spawns one.
+            return;
+        }
+
+        let (program, args) = build_diff_command(&req);
+        let title = format!("diff: {}", req.file);
+        match Session::spawn_command(
+            ctx.clone(),
+            &self.config,
+            Some(workspace.clone()),
+            TermSize::new(80, 24),
+            (8.0, 16.0),
+            program,
+            args,
+            title,
+            SessionKind::Diff { key: new_key },
+        ) {
+            Ok(session) => {
+                let id = session.id;
+                self.sessions.push(session);
+                self.active_session.insert(Some(workspace), id);
+            },
+            Err(e) => {
+                self.last_error = Some(format!("failed to open diff: {e}"));
+            },
+        }
+    }
+
+    /// Key of the diff currently displayed in this workspace, if any.  Used by
+    /// the sidebar to highlight the originating row so the toggle-on-reclick
+    /// behavior is discoverable.
+    fn active_diff_key(&self) -> Option<String> {
+        self.sessions.iter().find_map(|s| {
+            if s.working_directory != self.current_workspace {
+                return None;
+            }
+            if let SessionKind::Diff { key } = &s.kind { Some(key.clone()) } else { None }
+        })
+    }
+}
+
+/// Pipe `git diff` for the clicked file through delta. Positional args via
+/// `sh -c '…' name "$1" "$2"` keep path/branch names out of the script body so
+/// no shell metacharacter in the file name can be interpreted.
+fn build_diff_command(req: &DiffRequest) -> (String, Vec<String>) {
+    let script: &str = match &req.source {
+        DiffSource::Staged => r#"git diff --cached -- "$1" | delta --paging=always"#,
+        DiffSource::Worktree => r#"git diff -- "$1" | delta --paging=always"#,
+        // `--no-index` is git's "diff arbitrary files" mode; against /dev/null it
+        // shows the untracked file as a pure addition. Exits non-zero by design.
+        DiffSource::Untracked => r#"git diff --no-index -- /dev/null "$1" | delta --paging=always"#,
+        // Triple-dot diff = "from merge-base to HEAD" — matches the sidebar's
+        // `Changes vs <branch>` stat semantics in git_status.rs.
+        DiffSource::Branch { .. } => r#"git diff "$2"... -- "$1" | delta --paging=always"#,
+    };
+    let mut args = vec!["-c".to_string(), script.to_string(), "sh".to_string(), req.file.clone()];
+    if let DiffSource::Branch { base } = &req.source {
+        args.push(base.clone());
+    }
+    ("sh".to_string(), args)
 }
 
 fn dirty_warning(counts: &DirtyCounts) -> Option<String> {
@@ -1114,21 +1229,103 @@ fn file_row(
     change: &FileChange,
     theme: &Theme,
     palette: &crate::config::Palette,
+    is_active: bool,
+) -> egui::Response {
+    let bg_idx = ui.painter().add(egui::Shape::Noop);
+    let panel_x = ui.max_rect().x_range();
+    let color = match change.kind {
+        ChangeKind::Added | ChangeKind::Untracked => rgb_to_color32(palette.normal[2]),
+        ChangeKind::Modified => rgb_to_color32(palette.normal[3]),
+        ChangeKind::Deleted => rgb_to_color32(palette.normal[1]),
+        ChangeKind::Renamed => rgb_to_color32(palette.normal[4]),
+        ChangeKind::Conflicted => rgb_to_color32(palette.bright[1]),
+    };
+    let path_color = if is_active { theme.text } else { theme.text_dim };
+    let resp = ui
+        .horizontal(|ui| {
+            ui.label(RichText::new(change.kind.glyph()).color(color).monospace().small());
+            ui.add(
+                egui::Label::new(RichText::new(&change.path).color(path_color).monospace().small())
+                    .truncate(),
+            );
+        })
+        .response
+        .interact(egui::Sense::click());
+    paint_row_bg(ui, &resp, bg_idx, panel_x, theme, is_active);
+    resp
+}
+
+fn branch_diff_row(
+    ui: &mut egui::Ui,
+    stat: &crate::git_status::DiffStat,
+    theme: &Theme,
+    palette: &crate::config::Palette,
+    is_active: bool,
+) -> egui::Response {
+    let bg_idx = ui.painter().add(egui::Shape::Noop);
+    let panel_x = ui.max_rect().x_range();
+    let added = rgb_to_color32(palette.normal[2]);
+    let removed = rgb_to_color32(palette.normal[1]);
+    let path_color = if is_active { theme.text } else { theme.text_dim };
+
+    // Mirror row_with_trailing's layout (right_to_left wrapping a left_to_right)
+    // so the path truncates cleanly while the +/- counts pin to the right edge.
+    let row_size = egui::vec2(ui.available_width(), ui.spacing().interact_size.y);
+    let resp = ui
+        .allocate_ui_with_layout(row_size, egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if stat.deletions > 0 {
+                ui.label(
+                    RichText::new(format!("-{}", stat.deletions))
+                        .color(removed)
+                        .small()
+                        .monospace(),
+                );
+            }
+            if stat.additions > 0 {
+                ui.label(
+                    RichText::new(format!("+{}", stat.additions)).color(added).small().monospace(),
+                );
+            }
+            let remaining = ui.available_width();
+            if remaining > 0.0 {
+                let row_h = ui.available_height();
+                ui.allocate_ui_with_layout(
+                    egui::vec2(remaining, row_h),
+                    egui::Layout::left_to_right(egui::Align::Center),
+                    |ui| {
+                        ui.add(
+                            egui::Label::new(
+                                RichText::new(&stat.path).color(path_color).monospace().small(),
+                            )
+                            .truncate(),
+                        );
+                    },
+                );
+            }
+        })
+        .response
+        .interact(egui::Sense::click());
+    paint_row_bg(ui, &resp, bg_idx, panel_x, theme, is_active);
+    resp
+}
+
+fn paint_row_bg(
+    ui: &mut egui::Ui,
+    resp: &egui::Response,
+    bg_idx: egui::layers::ShapeIdx,
+    panel_x: egui::Rangef,
+    theme: &Theme,
+    is_active: bool,
 ) {
-    ui.horizontal(|ui| {
-        let color = match change.kind {
-            ChangeKind::Added | ChangeKind::Untracked => rgb_to_color32(palette.normal[2]),
-            ChangeKind::Modified => rgb_to_color32(palette.normal[3]),
-            ChangeKind::Deleted => rgb_to_color32(palette.normal[1]),
-            ChangeKind::Renamed => rgb_to_color32(palette.normal[4]),
-            ChangeKind::Conflicted => rgb_to_color32(palette.bright[1]),
-        };
-        ui.label(RichText::new(change.kind.glyph()).color(color).monospace().small());
-        ui.add(
-            egui::Label::new(RichText::new(&change.path).color(theme.text_dim).monospace().small())
-                .truncate(),
-        );
-    });
+    let bg = if is_active {
+        theme.row_active_bg
+    } else if resp.hovered() {
+        theme.row_hover_bg
+    } else {
+        return;
+    };
+    let rect = egui::Rect::from_x_y_ranges(panel_x, resp.rect.y_range());
+    ui.painter().set(bg_idx, egui::Shape::rect_filled(rect, 0.0, bg));
 }
 
 /// Lay out a row whose `trailing` widgets pin to the right edge while `leading`

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -201,12 +201,12 @@ fn default_bindings() -> Vec<KeyBinding> {
 /// bindings (see `Processor::process_key_bindings`), so the user's typical
 /// pattern of stacking `ClearLogNotice` + `chars = "\f"` on Ctrl+L works:
 /// the first action is our `Unsupported` no-op, the second writes 0x0c.
-pub fn all_matches(
-    bindings: &[KeyBinding],
-    key: Key,
-    mods: Modifiers,
-) -> Vec<&BindingAction> {
-    bindings.iter().filter(|b| b.key == key && mods_match(b.mods, mods)).map(|b| &b.action).collect()
+pub fn all_matches(bindings: &[KeyBinding], key: Key, mods: Modifiers) -> Vec<&BindingAction> {
+    bindings
+        .iter()
+        .filter(|b| b.key == key && mods_match(b.mods, mods))
+        .map(|b| &b.action)
+        .collect()
 }
 
 /// Alacritty semantics: `Control|Shift` does not fire on Ctrl alone even though

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -61,12 +61,24 @@ impl Dimensions for TermSize {
 
 pub type SessionId = u64;
 
+/// What this session is showing.  Shells are persistent; Diff panes are
+/// throwaway — replaced when the user clicks a different file in the git
+/// sidebar, and reaped on the user's `q` inside delta.  The key disambiguates
+/// (file, source) so the sidebar can highlight the active row and toggle the
+/// pane closed on a repeat click.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum SessionKind {
+    Shell,
+    Diff { key: String },
+}
+
 /// PTY child + parsed terminal state.  The read/write loop is on its own
 /// thread and survives workspace switches, so running processes aren't killed.
 pub struct Session {
     pub id: SessionId,
     pub title: String,
     pub working_directory: Option<PathBuf>,
+    pub kind: SessionKind,
     pub size: TermSize,
     pub cell_size: (f32, f32),
     pub term: Arc<FairMutex<Term<EventProxy>>>,
@@ -223,6 +235,59 @@ impl Session {
         size: TermSize,
         cell_size: (f32, f32),
     ) -> std::io::Result<Self> {
+        let shell = config.shell.as_ref().map(|s| Shell::new(s.program.clone(), s.args.clone()));
+        let title = working_directory
+            .as_ref()
+            .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| "shell".to_string());
+        Self::spawn_with(
+            ctx,
+            config,
+            working_directory,
+            size,
+            cell_size,
+            shell,
+            title,
+            SessionKind::Shell,
+        )
+    }
+
+    /// Spawn a session running `program args` instead of the user's shell.
+    /// Used by the git sidebar to drop into `delta` for an inline diff view —
+    /// once the command exits, `reap_exited_sessions` removes the tab.
+    pub fn spawn_command(
+        ctx: egui::Context,
+        config: &Config,
+        working_directory: Option<PathBuf>,
+        size: TermSize,
+        cell_size: (f32, f32),
+        program: String,
+        args: Vec<String>,
+        title: String,
+        kind: SessionKind,
+    ) -> std::io::Result<Self> {
+        Self::spawn_with(
+            ctx,
+            config,
+            working_directory,
+            size,
+            cell_size,
+            Some(Shell::new(program, args)),
+            title,
+            kind,
+        )
+    }
+
+    fn spawn_with(
+        ctx: egui::Context,
+        config: &Config,
+        working_directory: Option<PathBuf>,
+        size: TermSize,
+        cell_size: (f32, f32),
+        shell: Option<Shell>,
+        title: String,
+        kind: SessionKind,
+    ) -> std::io::Result<Self> {
         let window_size = window_size(size, cell_size);
 
         let (proxy, events) = EventProxy::new(ctx);
@@ -237,7 +302,7 @@ impl Session {
         let term = Arc::new(FairMutex::new(term));
 
         let pty_options = PtyOptions {
-            shell: config.shell.as_ref().map(|s| Shell::new(s.program.clone(), s.args.clone())),
+            shell,
             working_directory: working_directory.clone(),
             drain_on_exit: false,
             env: config.env.clone(),
@@ -255,15 +320,11 @@ impl Session {
         let sender = event_loop.channel();
         event_loop.spawn();
 
-        let title = working_directory
-            .as_ref()
-            .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()))
-            .unwrap_or_else(|| "shell".to_string());
-
         Ok(Self {
             id: next_session_id(),
             title,
             working_directory,
+            kind,
             size,
             cell_size,
             term,


### PR DESCRIPTION
## Summary
- Click a file in the git sidebar to open its diff via [delta](https://github.com/dandavison/delta) as a pane in the active workspace.
- Each workspace holds at most one diff pane: a click on another row replaces it; a click on the same row toggles it closed. The active row is highlighted in the sidebar.
- Pressing `q` inside delta exits the pane via PTY exit, falling back to the workspace's shell.

Sources used:
- Staged → `git diff --cached -- <file>`
- Worktree (modified/deleted/renamed) → `git diff -- <file>`
- Untracked → `git diff --no-index -- /dev/null <file>`
- Branch-diff section → `git diff <base>... -- <file>` (triple-dot, matching the sidebar's merge-base stats)

Implementation notes:
- `Session` gains a `SessionKind { Shell, Diff { key } }`. The key is `"<source>:<file>"` so the same file's staged/branch-diff rows toggle independently.
- `Session::spawn_command` runs an arbitrary program in a fresh PTY session; refactored common setup into `spawn_with`.
- Diff command is dispatched as `sh -c '…' sh "\$1" ["\$2"]`, so file paths and branch names ride in as positional args — no shell metacharacters expanded into the script body.
- `delta` must be on `\$PATH`; if missing, the pane shows `delta: command not found` alongside the raw `git diff` output, which then exits and is reaped.

## Test plan
- [ ] Click an unstaged modified file → delta opens; press \`q\` → returns to shell.
- [ ] Click a staged file → diff shows \`--cached\` view.
- [ ] Click an untracked file → diff shows it as a pure addition.
- [ ] Click a file in the "Changes vs <branch>" section → diff matches the merge-base stat.
- [ ] Click file A, then file B → only one diff tab exists in the workspace at a time.
- [ ] Click the currently-open diff row again → diff closes and shell is restored.
- [ ] Switch workspaces and verify each workspace tracks its own diff pane independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)