### PR TITLE
fix(sidebar): expand Home row click area to full panel width

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1484,20 +1484,19 @@ fn home_row(
     let panel_x = ui.max_rect().x_range();
 
     let frame = Frame::default().inner_margin(Margin { left: 6, right: 6, top: 3, bottom: 3 });
-    let resp = frame
-        .show(ui, |ui| {
-            ui.horizontal(|ui| {
-                paint_row_status_icon(ui, theme, attention, agent_glyph, "⌂", is_active);
-                ui.label(
-                    RichText::new("Home")
-                        .color(if is_active { theme.text } else { theme.text_dim })
-                        .strong()
-                        .small(),
-                );
-            });
-        })
-        .response
-        .interact(egui::Sense::click());
+    let inner_resp = frame.show(ui, |ui| {
+        ui.horizontal(|ui| {
+            paint_row_status_icon(ui, theme, attention, agent_glyph, "⌂", is_active);
+            ui.label(
+                RichText::new("Home")
+                    .color(if is_active { theme.text } else { theme.text_dim })
+                    .strong()
+                    .small(),
+            );
+        });
+    });
+    let hit_rect = egui::Rect::from_x_y_ranges(panel_x, inner_resp.response.rect.y_range());
+    let resp = ui.interact(hit_rect, inner_resp.response.id, egui::Sense::click());
 
     let bg = if is_active {
         theme.row_active_bg
@@ -1507,8 +1506,7 @@ fn home_row(
         Color32::TRANSPARENT
     };
     if bg != Color32::TRANSPARENT {
-        let rect = egui::Rect::from_x_y_ranges(panel_x, resp.rect.y_range());
-        ui.painter().set(bg_idx, egui::Shape::rect_filled(rect, 0.0, bg));
+        ui.painter().set(bg_idx, egui::Shape::rect_filled(hit_rect, 0.0, bg));
     }
     resp
 }


### PR DESCRIPTION
## Summary
- `home_row` only sensed clicks inside the inner horizontal layout, so the empty area to the right of "Home" was unresponsive even though the hover background spanned the full panel.
- Reuse the `panel_x` rect (already used to paint the hover bg) for hit-testing via `ui.interact`, so the clickable area matches the visible row.

## Test plan
- [ ] Run `cargo run -p alacritree`, click anywhere along the Home row — including the empty space right of the label — and confirm the home workspace activates.