### PR TITLE
fix(worktree): detect default branch dynamically

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1845,7 +1845,7 @@ impl AlacritreeApp {
                 ui.label(
                     RichText::new(match default_branch.as_deref() {
                         Some(b) => format!("Branched from origin/{b}"),
-                        None => "No default branch detected — create may fail.".to_string(),
+                        None => "Base branch will be resolved from origin/HEAD.".to_string(),
                     })
                     .color(theme.text_muted)
                     .small(),

--- a/alacritree/src/git_status.rs
+++ b/alacritree/src/git_status.rs
@@ -191,14 +191,9 @@ fn current_branch_name(repo: &Repository) -> Option<String> {
     }
 }
 
+/// Mirrors `projects::detect_default_branch` — see that function for the
+/// rationale behind the ordering.
 fn detect_default_branch(repo: &Repository) -> Option<String> {
-    if let Ok(cfg) = repo.config() {
-        if let Ok(name) = cfg.get_string("init.defaultBranch") {
-            if !name.is_empty() {
-                return Some(name);
-            }
-        }
-    }
     if let Ok(reference) = repo.find_reference("refs/remotes/origin/HEAD") {
         if let Some(target) = reference.symbolic_target() {
             if let Some(name) = target.strip_prefix("refs/remotes/origin/") {
@@ -206,9 +201,18 @@ fn detect_default_branch(repo: &Repository) -> Option<String> {
             }
         }
     }
-    for c in ["main", "master"] {
+    for c in ["main", "master", "trunk", "develop"] {
         if repo.find_reference(&format!("refs/heads/{c}")).is_ok() {
             return Some(c.to_string());
+        }
+    }
+    if let Ok(cfg) = repo.config() {
+        if let Ok(name) = cfg.get_string("init.defaultBranch") {
+            if !name.is_empty()
+                && repo.find_reference(&format!("refs/heads/{name}")).is_ok()
+            {
+                return Some(name);
+            }
         }
     }
     None

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -105,31 +105,38 @@ fn current_branch(repo: &Repository) -> Option<String> {
 
 /// Best-effort detection of the repository's default branch.
 ///
-/// Order: `init.defaultBranch` config → `refs/remotes/origin/HEAD` → presence of
-/// `main` / `master`.  Returns the branch name (without `refs/heads/`) or
-/// `None` if nothing fits.
+/// `refs/remotes/origin/HEAD` is the source of truth when present — it's what
+/// `origin` says the default branch is.  We fall back to common local names
+/// only if the remote ref is missing.  `init.defaultBranch` is checked LAST
+/// and only if it names a branch that actually exists in this repo, because
+/// that config is about what `git init` names new repos — not the default
+/// branch of an already-cloned project (a global `init.defaultBranch=master`
+/// would otherwise hijack repos whose actual default is `main` or anything
+/// else).  Returns the branch name (without `refs/heads/`) or `None`.
 fn detect_default_branch(repo: &Repository) -> Option<String> {
-    if let Ok(cfg) = repo.config() {
-        if let Ok(name) = cfg.get_string("init.defaultBranch") {
-            if !name.is_empty() {
-                return Some(name);
-            }
-        }
-    }
-
     if let Ok(reference) = repo.find_reference("refs/remotes/origin/HEAD") {
         if let Some(target) = reference.symbolic_target() {
-            // Strip the leading "refs/remotes/origin/".
             if let Some(name) = target.strip_prefix("refs/remotes/origin/") {
                 return Some(name.to_string());
             }
         }
     }
 
-    for candidate in ["main", "master"] {
+    for candidate in ["main", "master", "trunk", "develop"] {
         if repo.find_reference(&format!("refs/heads/{candidate}")).is_ok() {
             return Some(candidate.to_string());
         }
     }
+
+    if let Ok(cfg) = repo.config() {
+        if let Ok(name) = cfg.get_string("init.defaultBranch") {
+            if !name.is_empty()
+                && repo.find_reference(&format!("refs/heads/{name}")).is_ok()
+            {
+                return Some(name);
+            }
+        }
+    }
+
     None
 }

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -71,16 +71,19 @@ fn run_create(
         ctx.request_repaint();
     };
 
-    let base =
-        req.default_branch.clone().ok_or_else(|| "no default branch detected".to_string())?;
-
     send("Syncing with remote…");
     if !has_remote(&req.project_root, "origin") {
         return Err("no `origin` remote configured".into());
     }
 
+    // The cached `default_branch` is a hint; if it's missing or stale (e.g.
+    // user has a global `init.defaultBranch=master` but the repo's actual
+    // default is `main`), ask origin what its HEAD really points to.
+    let (base, base_ref) = resolve_base_branch(&req.project_root, req.default_branch.as_deref())
+        .map_err(|attempts| {
+            format!("could not determine base branch (tried: {})", attempts.join(", "))
+        })?;
     send(&format!("Verifying base branch `{base}`"));
-    let base_ref = verify_base_branch(&req.project_root, &base)?;
 
     send("Fetching latest changes…");
     run_git(&req.project_root, &["fetch", "origin", &base])?;
@@ -166,33 +169,88 @@ fn has_remote(cwd: &Path, name: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn verify_base_branch(cwd: &Path, branch: &str) -> Result<String, String> {
-    let remote = format!("origin/{branch}");
-    if Command::new("git")
+/// Resolve the base branch dynamically.  Tries the caller's hint first, then
+/// asks origin via `git ls-remote --symref HEAD` (the authoritative source),
+/// then falls back through common names.  Returns `(branch_name, ref_to_use)`
+/// where `ref_to_use` is what `git worktree add -b … <ref>` should branch
+/// from (prefer `origin/<branch>` so we start from the fetched remote tip).
+/// On total failure, returns the list of names we tried.
+fn resolve_base_branch(cwd: &Path, hint: Option<&str>) -> Result<(String, String), Vec<String>> {
+    let mut tried: Vec<String> = Vec::new();
+
+    let try_branch = |name: &str, tried: &mut Vec<String>| -> Option<(String, String)> {
+        if tried.iter().any(|t| t == name) {
+            return None;
+        }
+        tried.push(name.to_string());
+        if rev_parse_verify(cwd, &format!("origin/{name}")) {
+            return Some((name.to_string(), format!("origin/{name}")));
+        }
+        if rev_parse_verify(cwd, name) {
+            return Some((name.to_string(), name.to_string()));
+        }
+        None
+    };
+
+    if let Some(name) = hint {
+        if let Some(found) = try_branch(name, &mut tried) {
+            return Ok(found);
+        }
+    }
+
+    if let Some(remote_head) = query_origin_head(cwd) {
+        if let Some(found) = try_branch(&remote_head, &mut tried) {
+            return Ok(found);
+        }
+    }
+
+    for candidate in ["main", "master", "trunk", "develop"] {
+        if let Some(found) = try_branch(candidate, &mut tried) {
+            return Ok(found);
+        }
+    }
+
+    Err(tried)
+}
+
+fn rev_parse_verify(cwd: &Path, name: &str) -> bool {
+    Command::new("git")
         .arg("-C")
         .arg(cwd)
-        .args(["rev-parse", "--verify", "--quiet", &remote])
+        .args(["rev-parse", "--verify", "--quiet", name])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
-    {
-        return Ok(remote);
-    }
-    if Command::new("git")
+}
+
+/// Ask origin which branch HEAD points to.  Output looks like:
+///   ref: refs/heads/main\tHEAD
+///   <sha>\tHEAD
+/// We pull the `refs/heads/<name>` from the symref line.
+fn query_origin_head(cwd: &Path) -> Option<String> {
+    let output = Command::new("git")
         .arg("-C")
         .arg(cwd)
-        .args(["rev-parse", "--verify", "--quiet", branch])
-        .stdout(Stdio::null())
+        .args(["ls-remote", "--symref", "origin", "HEAD"])
+        .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-    {
-        return Ok(branch.to_string());
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
     }
-    Err(format!("base branch `{branch}` not found locally or on origin"))
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("ref: ") {
+            let target = rest.split_whitespace().next()?;
+            if let Some(name) = target.strip_prefix("refs/heads/") {
+                return Some(name.to_string());
+            }
+        }
+    }
+    None
 }
 
 /// Worktrees live under `~/.alacritree/worktrees/<project>-<hash>/<branch>` so


### PR DESCRIPTION
## Summary
- Worktree creation no longer fails with \`base branch \`master\` not found locally or on origin\` when the user has a global \`init.defaultBranch=master\` but the repo's actual default is \`main\`/\`alacritree\`/etc.
- \`detect_default_branch\` now consults \`refs/remotes/origin/HEAD\` first, then common local names, and only honors \`init.defaultBranch\` when it points to a real local branch.
- At create time, \`worktree::resolve_base_branch\` adds a runtime fallback that asks origin via \`git ls-remote --symref origin HEAD\`, so a stale or missing local hint can't block creation.

## Test plan
- [ ] On a repo with global \`init.defaultBranch=master\` but \`origin/HEAD -> origin/alacritree\`, create a new worktree — base branch resolves to \`alacritree\`.
- [ ] On a repo where \`refs/remotes/origin/HEAD\` is unset (clone --depth=1), worktree create still succeeds via the \`ls-remote --symref\` fallback.
- [ ] Existing happy path on a \`main\`-defaulted repo is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)