### PR TITLE
feat(packaging): add Homebrew tap, consolidate publish workflows on PAT

### DIFF
--- a/.github/workflows/aur-bin-publish.yml
+++ b/.github/workflows/aur-bin-publish.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Stamp PKGBUILD with version and asset hashes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALACRITREE_BOT_TOKEN }}
           TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           set -euo pipefail

--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -1,0 +1,76 @@
+name: Update Homebrew formula
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to bump to (e.g. v0.2.0)"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Push and PR-create with the bot PAT so the auto-merge PR
+          # actually triggers `pull_request` CI checks — GITHUB_TOKEN
+          # PRs don't fire them.
+          token: ${{ secrets.ALACRITREE_BOT_TOKEN }}
+
+      - name: Bump Formula/alacritree.rb
+        env:
+          GH_TOKEN: ${{ secrets.ALACRITREE_BOT_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          asset="alacritree-${TAG}-aarch64-macos.tar.gz"
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${asset}"
+
+          # Bail cleanly if the release exists but doesn't have the macOS
+          # asset attached yet (e.g. while platform support is being
+          # wired up). Avoids opening a broken PR.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+                --json assets --jq '.assets[].name' \
+                | grep -qx "$asset"; then
+            echo "Release $TAG has no $asset asset; skipping Homebrew bump."
+            exit 0
+          fi
+
+          curl --fail --location --output "/tmp/$asset" "$url"
+          hash=$(sha256sum "/tmp/$asset" | cut -d' ' -f1)
+
+          sed -i \
+            -e "s/^  version \".*\"/  version \"${version}\"/" \
+            -e "s/^      sha256 \".*\"/      sha256 \"${hash}\"/" \
+            Formula/alacritree.rb
+
+          if git diff --quiet Formula/alacritree.rb; then
+            echo "Formula already at $TAG; nothing to do."
+            exit 0
+          fi
+
+          branch="homebrew/bump-${TAG}"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$branch"
+          git add Formula/alacritree.rb
+          git commit -m "homebrew: bump alacritree to ${TAG}"
+          git push --force-with-lease -u origin "$branch"
+          gh pr create \
+            --title "homebrew: bump alacritree to ${TAG}" \
+            --body "Automated formula bump triggered by the release of \`${TAG}\`." \
+            --base master \
+            --head "$branch" \
+            || gh pr edit "$branch" --body "Automated formula bump triggered by the release of \`${TAG}\`."
+
+          # Flip auto-merge on so the PR lands itself once required
+          # checks pass. Same setup as scoop-update.yml.
+          gh pr merge "$branch" --auto --squash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,10 @@ jobs:
     if: always() && needs.build.result != 'cancelled'
     needs: build
     permissions:
-      # `actions: write` is required so the final step can dispatch the
-      # scoop-update and aur-bin-publish workflows via `gh workflow run`.
-      contents: write
-      actions: write
+      # We use ALACRITREE_BOT_TOKEN (a PAT) for the release creation, so
+      # this permission block doesn't strictly gate the gh CLI calls — but
+      # `actions/checkout` still needs read access via GITHUB_TOKEN.
+      contents: read
 
     steps:
       - name: Resolve release tag
@@ -145,8 +145,13 @@ jobs:
         run: ls -la dist/
 
       - name: Create or update GitHub release
+        # Authoring the release with a PAT (instead of GITHUB_TOKEN) is what
+        # lets `release: published` cascade to scoop-update / aur-bin-publish
+        # / homebrew-update — events emitted by GITHUB_TOKEN deliberately
+        # don't trigger other workflows, which is why this used to need a
+        # manual fan-out step.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALACRITREE_BOT_TOKEN }}
           TAG: ${{ steps.tag.outputs.value }}
         run: |
           set -euo pipefail
@@ -165,18 +170,3 @@ jobs:
               --generate-notes \
               "${assets[@]}"
           fi
-
-      - name: Fan out to downstream publish workflows
-        # `release: published` events fired by GITHUB_TOKEN don't trigger
-        # other workflows (loop-prevention), so we explicitly dispatch the
-        # scoop and aur-bin bumps here. `workflow_dispatch` is the one
-        # event class that IS allowed to chain.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.value }}
-        run: |
-          set -euo pipefail
-          for wf in scoop-update.yml aur-bin-publish.yml; do
-            echo "Dispatching $wf for $TAG"
-            gh workflow run "$wf" --repo "$GITHUB_REPOSITORY" --ref master -f "tag=$TAG"
-          done

--- a/.github/workflows/scoop-update.yml
+++ b/.github/workflows/scoop-update.yml
@@ -18,10 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Authenticate git operations with the PAT so the push (and the
+          # PR that wraps it) is attributed to ALACRITREE_BOT_TOKEN. This
+          # is what lets the bot's PR trigger `pull_request` CI checks —
+          # PRs opened by GITHUB_TOKEN don't fire them.
+          token: ${{ secrets.ALACRITREE_BOT_TOKEN }}
 
       - name: Bump bucket/alacritree.json
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALACRITREE_BOT_TOKEN }}
           TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           set -euo pipefail

--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -1,0 +1,27 @@
+class Alacritree < Formula
+  desc "Alacritty fork with worktree-aware sidebars"
+  homepage "https://github.com/mathix420/alacritree"
+  version "0.0.0"
+  license "Apache-2.0"
+
+  # The release workflow only ships aarch64-apple-darwin today; Intel Macs
+  # need to build from source until the release matrix grows an x86_64
+  # target. The `on_macos` / `on_arm` guard makes the formula install fail
+  # loudly on unsupported arches instead of silently downloading nothing.
+  on_macos do
+    on_arm do
+      url "https://github.com/mathix420/alacritree/releases/download/v#{version}/alacritree-v#{version}-aarch64-macos.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    bin.install "alacritree"
+  end
+
+  test do
+    # Don't invoke alacritree itself — it's a GUI that would spin up an
+    # egui window during `brew test`. Just assert the binary landed.
+    assert_predicate bin/"alacritree", :executable?
+  end
+end

--- a/README.md
+++ b/README.md
@@ -71,12 +71,29 @@ is bumped automatically when a release is published. Windows binaries are
 not produced yet (see *Status* above); the bucket is wired up and waiting
 for the first cross-platform release.
 
-### macOS (Apple Silicon)
+### macOS (Homebrew, Apple Silicon)
 
-No prebuilt binary yet. Build from source via the [Build](#build) section
-once you've installed `cmake`, `pkg-config`, `fontconfig` and `freetype`
-through Homebrew. Only `aarch64-apple-darwin` is targeted — Intel Macs
-aren't on the release matrix.
+```sh
+brew tap mathix420/alacritree https://github.com/mathix420/alacritree
+brew install alacritree
+```
+
+The formula lives in [`Formula/alacritree.rb`](Formula/alacritree.rb)
+and is bumped automatically on every release. Only `aarch64-apple-darwin`
+is shipped — Intel Macs need to build from source via the
+[Build](#build) section (install `cmake`, `pkg-config`, `fontconfig`
+and `freetype` through Homebrew first).
+
+**Other macOS package managers** — not packaged yet, but if you'd
+rather not use Homebrew:
+
+- **MacPorts** — no port yet; mirror the Homebrew formula with a
+  `Portfile` if you want to contribute one.
+- **Nix / nix-darwin** — `nixpkgs` doesn't have a derivation yet either.
+  A flake build is straightforward (workspace MSRV 1.85, single crate
+  to compile) and would be a welcome PR.
+- **Cargo** — `cargo install --path alacritree --locked` works on any
+  platform with a Rust toolchain, but you lose desktop integration.
 
 ## Build
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,28 @@
+# Homebrew packaging
+
+Alacritree's Homebrew formula lives in **this repo** —
+[`Formula/alacritree.rb`](../../Formula/alacritree.rb) — rather than a
+dedicated `homebrew-alacritree` tap repo. That keeps everything in one
+place at the cost of one extra step for users:
+
+```sh
+brew tap mathix420/alacritree https://github.com/mathix420/alacritree
+brew install alacritree
+```
+
+(Homebrew's auto-tap only fires when the repo is named
+`homebrew-<name>`. Since this repo isn't, users have to tap by URL
+once. After that, `brew upgrade alacritree` Just Works.)
+
+[`.github/workflows/homebrew-update.yml`](../../.github/workflows/homebrew-update.yml)
+bumps the formula via an auto-merging PR on every published release —
+exactly the same shape as `scoop-update.yml`. No Homebrew-specific
+secret is required; the shared `ALACRITREE_BOT_TOKEN` covers it.
+
+## Why a formula, not a cask?
+
+Casks expect a `.app` bundle (or a `.dmg`/`.pkg` containing one).
+Alacritree's macOS release tarball is just the bare binary today — the
+desktop metadata and icons in the release workflow are gated on Linux.
+If/when we start building a proper `Alacritree.app` (à la upstream
+alacritty's `make app`), switching to a cask becomes worthwhile.


### PR DESCRIPTION
## Summary
- New [`Formula/alacritree.rb`](Formula/alacritree.rb) + `homebrew-update.yml` workflow; stamps version/sha256 on release and opens an auto-merge PR (same shape as `scoop-update.yml`)
- Every publish workflow (`release`, `scoop-update`, `aur-bin-publish`, `homebrew-update`) now uses the shared `ALACRITREE_BOT_TOKEN` PAT
- Dropped the manual `gh workflow run` fan-out in `release.yml` — PAT-authored `release: published` events now cascade to scoop/aur-bin/homebrew naturally
- `scoop-update.yml` checks out with the PAT so its auto-merge PR triggers `pull_request` CI checks (which GITHUB_TOKEN-authored PRs don't)
- README documents the install (note: requires explicit `brew tap … URL` because this repo isn't named `homebrew-alacritree`, so Homebrew's auto-tap doesn't trigger)
- `packaging/homebrew/README.md` documents the in-repo-tap rationale

## Why no dedicated `homebrew-alacritree` tap repo?
Homebrew's auto-tap only fires when the repo is named `homebrew-<name>`. A dedicated tap would save the one-time `brew tap` step but doubles the repo count and adds cross-repo push plumbing. We opted for fewer repos.

## Test plan
- [ ] Confirm `ALACRITREE_BOT_TOKEN` is set with Contents+PRs write on this repo
- [ ] Dispatch `Update Homebrew formula` manually against an existing tag with an `aarch64-macos` asset; verify the bot opens an auto-merging PR
- [ ] Cut a fresh tag and confirm scoop/aur-bin/homebrew bumps fire automatically without the fan-out step
- [ ] On an Apple Silicon Mac:
  - [ ] `brew tap mathix420/alacritree https://github.com/mathix420/alacritree`
  - [ ] `brew install alacritree`
  - [ ] Resulting `alacritree` binary launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)