### PR TITLE
feat(ci): nightly check for upstream alacritty updates

### DIFF
--- a/.github/upstream-sync.toml
+++ b/.github/upstream-sync.toml
@@ -1,0 +1,6 @@
+# Marker tracking the last alacritty/alacritty commit we've reviewed
+# for vendoring sync. Updated automatically by
+# .github/workflows/upstream-sync.yml when it opens a sync PR.
+upstream = "https://github.com/alacritty/alacritty"
+branch   = "master"
+sha      = "0000000000000000000000000000000000000000"

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,122 @@
+name: Check upstream alacritty
+
+# Nightly check against alacritty/alacritty. We don't auto-merge upstream
+# code into the vendored crates — that's a manual review step — but we
+# do open a single PR that bumps a marker SHA whenever upstream advances,
+# so it's visible in the PR list rather than buried in cron logs.
+
+on:
+  schedule:
+    # 03:00 UTC daily. Off-hours and well clear of release/CI traffic.
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: upstream-sync
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.ALACRITREE_BOT_TOKEN }}
+          # We rev-parse upstream/master to compare commit ranges, which
+          # needs the full history rather than the shallow default.
+          fetch-depth: 0
+
+      - name: Check for upstream updates
+        env:
+          GH_TOKEN: ${{ secrets.ALACRITREE_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          marker=.github/upstream-sync.toml
+
+          # Tiny TOML reader — the marker has a fixed 3-line shape so a
+          # full toml parser would be overkill.
+          read_field() {
+            awk -F' *= *' -v k="$1" '$1==k {gsub(/^"|"$/,"",$2); print $2; exit}' "$marker"
+          }
+
+          upstream_repo=$(read_field upstream)
+          upstream_branch=$(read_field branch)
+          current_sha=$(read_field sha)
+
+          git remote add upstream "$upstream_repo" 2>/dev/null || true
+          git fetch upstream "$upstream_branch" --quiet
+          upstream_sha=$(git rev-parse "upstream/$upstream_branch")
+
+          if [[ "$current_sha" == "$upstream_sha" ]]; then
+            echo "Already at upstream $upstream_sha; nothing to do."
+            exit 0
+          fi
+
+          # On the very first run the marker is all zeros; we don't want
+          # to dump the entire upstream history into a PR body. Initialize
+          # the marker silently and let subsequent runs do the comparison.
+          if [[ "$current_sha" =~ ^0+$ ]]; then
+            summary="(initial marker bootstrap — no commit list)"
+          else
+            total=$(git rev-list --count "${current_sha}..${upstream_sha}" || echo 0)
+            summary=$(git log --oneline --no-decorate "${current_sha}..${upstream_sha}" | head -50)
+            if [[ "$total" -gt 50 ]]; then
+              summary="${summary}"$'\n'"… and $((total - 50)) more"
+            fi
+          fi
+
+          sed -i "s|^sha *=.*|sha      = \"${upstream_sha}\"|" "$marker"
+          if git diff --quiet "$marker"; then
+            echo "Marker unchanged after sed (race?); nothing to do."
+            exit 0
+          fi
+
+          # Single long-lived branch — force-pushing keeps exactly one
+          # sync PR open at a time, so daily upstream activity doesn't
+          # accumulate stale PRs.
+          branch=chore/sync-upstream
+          short=$(git rev-parse --short=7 "$upstream_sha")
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -B "$branch"
+          git add "$marker"
+          git commit -m "chore: sync upstream alacritty marker to ${short}"
+          git push --force-with-lease -u origin "$branch"
+
+          body=$(cat <<EOF
+          Upstream [alacritty/alacritty](${upstream_repo}) has advanced
+          since our last review.
+
+          **Commits since \`${current_sha:0:7}\`:**
+
+          \`\`\`
+          ${summary}
+          \`\`\`
+
+          This PR only bumps the sync marker — it does **not** vendor any
+          upstream code into our \`alacritty/\`, \`alacritty_terminal/\`,
+          or \`alacritty_config*/\` crates. Review the commits above and:
+
+          - If nothing in the diff is relevant to our fork, merge as-is.
+          - If something needs vendoring, push the actual sync commits to
+            this branch before merging, or open a separate PR.
+          EOF
+          )
+
+          # Reuse the existing PR if there's one open; otherwise create.
+          if gh pr view "$branch" --json number >/dev/null 2>&1; then
+            gh pr edit "$branch" \
+              --title "chore: sync upstream alacritty marker to ${short}" \
+              --body "$body"
+          else
+            gh pr create \
+              --title "chore: sync upstream alacritty marker to ${short}" \
+              --body "$body" \
+              --base master \
+              --head "$branch"
+          fi


### PR DESCRIPTION
## Summary
- New nightly workflow `.github/workflows/upstream-sync.yml` (cron `0 3 * * *` UTC) that compares `alacritty/alacritty` master against a marker SHA stored in `.github/upstream-sync.toml`
- When upstream has advanced, the workflow force-pushes a single long-lived branch (`chore/sync-upstream`) and opens/edits a PR with a 50-commit summary, so daily upstream activity doesn't accumulate stale PRs
- The PR **only bumps the marker** — it doesn't pull upstream code into the vendored `alacritty/`, `alacritty_terminal/`, `alacritty_config*/` crates. That's a manual review step. Merging the PR signals "I've reviewed these commits"
- Marker bootstraps from all-zeros: the first run won't dump full upstream history into the PR body, it'll just initialize

## Test plan
- [ ] Manually dispatch the workflow (`Actions → Check upstream alacritty → Run workflow`) and confirm the bootstrap PR opens cleanly
- [ ] Re-dispatch without merging — expect "Already at upstream … nothing to do" no-op
- [ ] After merging the bootstrap PR, dispatch again and confirm subsequent runs produce a commit-list summary against the previous marker
- [ ] Confirm the cron schedule fires on the natural midnight-ish boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)