### PR TITLE
homebrew: bump alacritree to v0.2.6

### DIFF
--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -1,7 +1,7 @@
 class Alacritree < Formula
   desc "Alacritty fork with worktree-aware sidebars"
   homepage "https://github.com/mathix420/alacritree"
-  version "0.0.0"
+  version "0.2.6"
   license "Apache-2.0"
 
   # The release workflow only ships aarch64-apple-darwin today; Intel Macs
@@ -11,7 +11,7 @@ class Alacritree < Formula
   on_macos do
     on_arm do
       url "https://github.com/mathix420/alacritree/releases/download/v#{version}/alacritree-v#{version}-aarch64-macos.tar.gz"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      sha256 "73f7ce75f3b10d6f594c9c5471c0ec81ef2befc72f4557038b68e75e2182a90b"
     end
   end
 


### PR DESCRIPTION
Automated formula bump triggered by the release of `v0.2.6`.