### PR TITLE
fix(ci): retry auto-merge enable on PAT-authored bump PRs

### DIFF
--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -72,5 +72,13 @@ jobs:
             || gh pr edit "$branch" --body "Automated formula bump triggered by the release of \`${TAG}\`."
 
           # Flip auto-merge on so the PR lands itself once required
-          # checks pass. Same setup as scoop-update.yml.
-          gh pr merge "$branch" --auto --squash
+          # checks pass. Same retry behavior as scoop-update.yml — PRs
+          # authored by the PAT trigger `pull_request` CI immediately
+          # and the auto-merge API briefly rejects while UNSTABLE.
+          for attempt in 1 2 3 4 5; do
+            if gh pr merge "$branch" --auto --squash; then
+              break
+            fi
+            echo "auto-merge enable attempt ${attempt} failed; retrying in 10s"
+            sleep 10
+          done

--- a/.github/workflows/scoop-update.yml
+++ b/.github/workflows/scoop-update.yml
@@ -81,4 +81,15 @@ jobs:
           # Flip auto-merge on so the PR lands itself once required checks
           # pass. Repo-level "Allow auto-merge" must be on (it is); branch
           # protection on master decides what counts as ready-to-merge.
-          gh pr merge "$branch" --auto --squash
+          #
+          # Retry loop: PRs authored by our PAT trigger `pull_request` CI
+          # immediately, putting the PR in UNSTABLE state for a few seconds
+          # before any check is reported. GitHub's auto-merge API rejects
+          # while in that transient state, so we back off and retry.
+          for attempt in 1 2 3 4 5; do
+            if gh pr merge "$branch" --auto --squash; then
+              break
+            fi
+            echo "auto-merge enable attempt ${attempt} failed; retrying in 10s"
+            sleep 10
+          done


### PR DESCRIPTION
## Why
v0.2.6's scoop and homebrew bump workflows both failed at the final `gh pr merge --auto --squash` step with:

> GraphQL: Pull request Pull request is in unstable status (enablePullRequestAutoMerge)

The bump PRs themselves were healthy and merged cleanly on a manual retry seconds later.

## Cause
PR #30 switched these workflows' `actions/checkout` to use the `ALACRITREE_BOT_TOKEN` PAT specifically so the resulting PRs would trigger `pull_request` CI (something `GITHUB_TOKEN`-authored PRs deliberately don't do). Trade-off: for the first few seconds after the PR is opened the `mergeStateStatus` is `UNSTABLE` (CI initializing), and GitHub's auto-merge enable API rejects in that transient state.

## Fix
Wrap `gh pr merge --auto --squash` in a 5×10s retry loop in both `scoop-update.yml` and `homebrew-update.yml`. Bails out of the loop on the first success, so the steady-state cost is just one API call.

## Test plan
- [ ] Next release: confirm scoop + homebrew bump workflows complete cleanly without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)