### PR TITLE
feat(sidebar): diff against PR base when a PR exists

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -12,6 +12,7 @@ use crate::colors::rgb_to_color32;
 use crate::config::Config;
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, StatusCache};
 use crate::paste;
+use crate::pr_status::{PrCache, PrInfo};
 use crate::projects::{Project, Worktree};
 use crate::session::{Session, SessionId, SessionKind, TermSize};
 use crate::state::{self, PersistedProject, PersistedState};
@@ -115,6 +116,7 @@ pub struct AlacritreeApp {
     active_session: HashMap<WorkspaceKey, SessionId>,
     projects: Vec<Project>,
     git_status: HashMap<PathBuf, StatusCache>,
+    pr_cache: PrCache,
     config: Config,
     theme: Theme,
     last_error: Option<String>,
@@ -251,6 +253,7 @@ impl AlacritreeApp {
             active_session: HashMap::new(),
             projects,
             git_status: HashMap::new(),
+            pr_cache: PrCache::new(),
             config,
             theme,
             last_error: None,
@@ -933,14 +936,22 @@ impl AlacritreeApp {
                     },
                 };
 
-                let default_branch = self.project_default_branch_for(&path);
+                let project_default = self.project_default_branch_for(&path);
                 let cache = self
                     .git_status
                     .entry(path.clone())
                     .or_insert_with(|| StatusCache::new(path.clone()));
 
                 let mut status = cache.get().clone();
-                if let Some(branch) = default_branch.as_deref() {
+                // Look up the PR base for the checked-out branch.  The lookup
+                // is non-blocking — on a cold cache we get `None` this frame
+                // and the answer arrives on a later repaint.
+                let pr_info = self.pr_cache.poll(&path, status.branch.as_deref(), ctx);
+                // PR base takes precedence over the repo's default branch so
+                // the sidebar diff matches what GitHub will review.
+                let effective_default =
+                    pr_info.as_ref().map(|p| p.base_branch.clone()).or(project_default);
+                if let Some(branch) = effective_default.as_deref() {
                     if status.default_branch.as_deref() != Some(branch) {
                         cache.force_refresh(Some(branch));
                         status = cache.get().clone();
@@ -1016,7 +1027,12 @@ impl AlacritreeApp {
                     if !status.branch_diff.is_empty() {
                         let label = match (&status.default_branch, &status.default_branch_resolved)
                         {
-                            (Some(b), _) => format!("Changes vs {}", b),
+                            (Some(b), _) => match &pr_info {
+                                Some(PrInfo { number, .. }) => {
+                                    format!("Changes vs {} (PR #{})", b, number)
+                                },
+                                None => format!("Changes vs {}", b),
+                            },
                             _ => "Changes vs default".to_string(),
                         };
                         // Prefer the resolved ref (e.g. `refs/remotes/origin/main`) so the

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -12,7 +12,7 @@ use crate::colors::rgb_to_color32;
 use crate::config::Config;
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, StatusCache};
 use crate::paste;
-use crate::pr_status::{PrCache, PrInfo};
+use crate::pr_status::PrCache;
 use crate::projects::{Project, Worktree};
 use crate::session::{Session, SessionId, SessionKind, TermSize};
 use crate::state::{self, PersistedProject, PersistedState};
@@ -1025,15 +1025,9 @@ impl AlacritreeApp {
                     });
 
                     if !status.branch_diff.is_empty() {
-                        let label = match (&status.default_branch, &status.default_branch_resolved)
-                        {
-                            (Some(b), _) => match &pr_info {
-                                Some(PrInfo { number, .. }) => {
-                                    format!("Changes vs {} (PR #{})", b, number)
-                                },
-                                None => format!("Changes vs {}", b),
-                            },
-                            _ => "Changes vs default".to_string(),
+                        let base_label = match &status.default_branch {
+                            Some(b) => format!("Changes vs {b}"),
+                            None => "Changes vs default".to_string(),
                         };
                         // Prefer the resolved ref (e.g. `refs/remotes/origin/main`) so the
                         // sidebar's merge-base diff matches what delta will show.
@@ -1041,23 +1035,46 @@ impl AlacritreeApp {
                             .default_branch_resolved
                             .clone()
                             .or_else(|| status.default_branch.clone());
-                        section(ui, &theme, &label, status.branch_diff.len(), |ui| {
-                            for stat in &status.branch_diff {
-                                let Some(base) = base.clone() else {
-                                    branch_diff_row(ui, stat, &theme, &palette, false);
-                                    continue;
-                                };
-                                let req = DiffRequest {
-                                    file: stat.path.clone(),
-                                    source: DiffSource::Branch { base },
-                                };
-                                let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
-                                if branch_diff_row(ui, stat, &theme, &palette, is_active).clicked()
-                                {
-                                    diff_request.set(Some(req));
-                                }
+                        let count = status.branch_diff.len();
+
+                        // Open-coded section header so the PR number can be a
+                        // hyperlink while the rest stays plain text.
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                RichText::new(&base_label).color(theme.text).strong().small(),
+                            );
+                            if let Some(pr) = &pr_info {
+                                ui.label(
+                                    RichText::new("·").color(theme.text_muted).small(),
+                                );
+                                ui.hyperlink_to(
+                                    RichText::new(format!("PR #{}", pr.number))
+                                        .color(theme.accent)
+                                        .small()
+                                        .strong(),
+                                    &pr.url,
+                                );
                             }
+                            ui.label(
+                                RichText::new(format!("{count}")).color(theme.text_muted).small(),
+                            );
                         });
+                        ui.add_space(2.0);
+                        for stat in &status.branch_diff {
+                            let Some(base) = base.clone() else {
+                                branch_diff_row(ui, stat, &theme, &palette, false);
+                                continue;
+                            };
+                            let req = DiffRequest {
+                                file: stat.path.clone(),
+                                source: DiffSource::Branch { base },
+                            };
+                            let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
+                            if branch_diff_row(ui, stat, &theme, &palette, is_active).clicked() {
+                                diff_request.set(Some(req));
+                            }
+                        }
+                        ui.add_space(10.0);
                     }
                 });
             });

--- a/alacritree/src/git_status.rs
+++ b/alacritree/src/git_status.rs
@@ -208,9 +208,7 @@ fn detect_default_branch(repo: &Repository) -> Option<String> {
     }
     if let Ok(cfg) = repo.config() {
         if let Ok(name) = cfg.get_string("init.defaultBranch") {
-            if !name.is_empty()
-                && repo.find_reference(&format!("refs/heads/{name}")).is_ok()
-            {
+            if !name.is_empty() && repo.find_reference(&format!("refs/heads/{name}")).is_ok() {
                 return Some(name);
             }
         }

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -11,6 +11,7 @@ mod git_status;
 mod input;
 mod links;
 mod paste;
+mod pr_status;
 mod projects;
 mod session;
 mod state;

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -1,0 +1,158 @@
+//! Detect whether the current branch has an open PR on GitHub, and cache
+//! its base branch so the sidebar diff can target the PR's base instead of
+//! the repo's default branch.
+//!
+//! Why shell out to `gh` rather than hit the API directly: it inherits the
+//! user's existing auth and host config (enterprise, multiple accounts), and
+//! we already require `git` on PATH — adding `gh` is a familiar dependency
+//! for anyone who lives in this workflow.  The lookup is best-effort: if
+//! `gh` is missing, unauthenticated, or no PR exists, we silently fall back
+//! to the repo's default branch.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Re-query at most this often.  PR base branches rarely change, and a stale
+/// answer just falls back to the previous diff target — not worth hammering
+/// `gh` on every status refresh.
+const TTL: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Clone)]
+pub struct PrInfo {
+    pub number: u64,
+    pub base_branch: String,
+}
+
+#[derive(Default)]
+pub struct PrCache {
+    entries: HashMap<PathBuf, Entry>,
+}
+
+struct Entry {
+    /// Branch the cached result was queried for.  Switching branches in the
+    /// same worktree invalidates the entry.
+    branch: Option<String>,
+    info: Option<PrInfo>,
+    queried_at: Option<Instant>,
+    /// Set while a background thread is running; drained on the next poll.
+    pending: Option<Receiver<LookupResult>>,
+}
+
+struct LookupResult {
+    branch: Option<String>,
+    info: Option<PrInfo>,
+}
+
+impl PrCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the PR info known for `(path, branch)` right now, kicking off
+    /// a background refresh if the cache is stale or branch-mismatched.
+    /// Never blocks — the caller will see the previous value (or `None`)
+    /// until the worker finishes and the next frame picks up the result.
+    pub fn poll(
+        &mut self,
+        path: &Path,
+        branch: Option<&str>,
+        ctx: &egui::Context,
+    ) -> Option<PrInfo> {
+        let entry = self.entries.entry(path.to_path_buf()).or_insert_with(|| Entry {
+            branch: None,
+            info: None,
+            queried_at: None,
+            pending: None,
+        });
+
+        // Drain any completed background lookup before deciding whether to
+        // refresh — a result that just arrived shouldn't be ignored.
+        if let Some(rx) = entry.pending.as_ref() {
+            if let Ok(result) = rx.try_recv() {
+                entry.branch = result.branch;
+                entry.info = result.info;
+                entry.queried_at = Some(Instant::now());
+                entry.pending = None;
+            }
+        }
+
+        let branch_matches = entry.branch.as_deref() == branch;
+        let fresh = entry.queried_at.map_or(false, |when| when.elapsed() < TTL);
+        let needs_refresh = !branch_matches || !fresh;
+
+        if needs_refresh && entry.pending.is_none() {
+            // Clear stale data immediately on branch switch so we don't show
+            // a PR base that belongs to a different branch.
+            if !branch_matches {
+                entry.info = None;
+            }
+            entry.pending =
+                Some(spawn_lookup(path.to_path_buf(), branch.map(str::to_string), ctx.clone()));
+        }
+
+        entry.info.clone()
+    }
+}
+
+fn spawn_lookup(
+    path: PathBuf,
+    branch: Option<String>,
+    ctx: egui::Context,
+) -> Receiver<LookupResult> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let info = branch.as_deref().and_then(|b| query_gh(&path, b));
+        let _ = tx.send(LookupResult { branch, info });
+        ctx.request_repaint();
+    });
+    rx
+}
+
+/// Ask `gh` for the PR associated with `branch` in `path`.  Returns `None`
+/// on any failure mode (no `gh`, not authenticated, no PR, non-GitHub
+/// remote, ...).  The branch is passed as a positional selector so the
+/// answer is tied to that specific branch rather than whatever ref happens
+/// to be checked out in the worktree.
+fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
+    let output = Command::new("gh")
+        .current_dir(path)
+        .args(["pr", "view", branch, "--json", "number,baseRefName"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_gh_output(&output.stdout)
+}
+
+fn parse_gh_output(stdout: &[u8]) -> Option<PrInfo> {
+    let value: serde_json::Value = serde_json::from_slice(stdout).ok()?;
+    let number = value.get("number")?.as_u64()?;
+    let base = value.get("baseRefName")?.as_str()?.to_string();
+    Some(PrInfo { number, base_branch: base })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_gh_json() {
+        let stdout = br#"{"baseRefName":"main","number":42}"#;
+        let info = parse_gh_output(stdout).unwrap();
+        assert_eq!(info.number, 42);
+        assert_eq!(info.base_branch, "main");
+    }
+
+    #[test]
+    fn rejects_empty_output() {
+        assert!(parse_gh_output(b"").is_none());
+    }
+}

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -25,6 +25,7 @@ const TTL: Duration = Duration::from_secs(300);
 pub struct PrInfo {
     pub number: u64,
     pub base_branch: String,
+    pub url: String,
 }
 
 #[derive(Default)]
@@ -120,7 +121,7 @@ fn spawn_lookup(
 fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
     let output = Command::new("gh")
         .current_dir(path)
-        .args(["pr", "view", branch, "--json", "number,baseRefName"])
+        .args(["pr", "view", branch, "--json", "number,baseRefName,url"])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .stdin(Stdio::null())
@@ -136,7 +137,8 @@ fn parse_gh_output(stdout: &[u8]) -> Option<PrInfo> {
     let value: serde_json::Value = serde_json::from_slice(stdout).ok()?;
     let number = value.get("number")?.as_u64()?;
     let base = value.get("baseRefName")?.as_str()?.to_string();
-    Some(PrInfo { number, base_branch: base })
+    let url = value.get("url")?.as_str()?.to_string();
+    Some(PrInfo { number, base_branch: base, url })
 }
 
 #[cfg(test)]
@@ -145,10 +147,11 @@ mod tests {
 
     #[test]
     fn parses_gh_json() {
-        let stdout = br#"{"baseRefName":"main","number":42}"#;
+        let stdout = br#"{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}"#;
         let info = parse_gh_output(stdout).unwrap();
         assert_eq!(info.number, 42);
         assert_eq!(info.base_branch, "main");
+        assert_eq!(info.url, "https://github.com/o/r/pull/42");
     }
 
     #[test]

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -130,9 +130,7 @@ fn detect_default_branch(repo: &Repository) -> Option<String> {
 
     if let Ok(cfg) = repo.config() {
         if let Ok(name) = cfg.get_string("init.defaultBranch") {
-            if !name.is_empty()
-                && repo.find_reference(&format!("refs/heads/{name}")).is_ok()
-            {
+            if !name.is_empty() && repo.find_reference(&format!("refs/heads/{name}")).is_ok() {
                 return Some(name);
             }
         }


### PR DESCRIPTION
## Summary
- Look up the open GitHub PR for the checked-out branch (`gh pr view <branch> --json number,baseRefName`) and use the PR's base branch as the "Changes vs …" target instead of the repo default. Header becomes `Changes vs <base> (PR #N)` when a PR is detected.
- Lookup runs on a background thread, with a per-worktree cache keyed by branch and a 5-minute TTL — never blocks the UI.
- Silently falls back to the project default branch when `gh` is missing, unauthed, no PR exists, or the remote isn't GitHub.

## Test plan
- [ ] In a worktree with an open PR targeting a non-default branch, confirm the sidebar shows `Changes vs <pr-base> (PR #N)` and the per-file diff opens against the PR base.
- [ ] In a worktree without an open PR, confirm behavior is unchanged (diffs against repo default branch).
- [ ] Switch branches in the same worktree — header updates after the next lookup (≤ TTL).
- [ ] With `gh` uninstalled or unauthenticated, confirm the sidebar still works and falls back to the default branch.
- [ ] `cargo test -p alacritree --bin alacritree pr_status` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)