### PR TITLE
fix(worktree): prefer origin's actual HEAD over cached hint

### DIFF
--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -169,9 +169,13 @@ fn has_remote(cwd: &Path, name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Resolve the base branch dynamically.  Tries the caller's hint first, then
-/// asks origin via `git ls-remote --symref HEAD` (the authoritative source),
-/// then falls back through common names.  Returns `(branch_name, ref_to_use)`
+/// Resolve the base branch dynamically.  Asks origin first via
+/// `git ls-remote --symref HEAD` — the only source that reflects the
+/// upstream's *current* default branch.  The caller's hint comes from
+/// `refs/remotes/origin/HEAD`, which can lag if the upstream default was
+/// renamed since the last sync; trusting it would feed a defunct branch
+/// name to `git fetch`.  Falls back to the hint and then to common names
+/// when the remote is unreachable.  Returns `(branch_name, ref_to_use)`
 /// where `ref_to_use` is what `git worktree add -b … <ref>` should branch
 /// from (prefer `origin/<branch>` so we start from the fetched remote tip).
 /// On total failure, returns the list of names we tried.
@@ -192,14 +196,14 @@ fn resolve_base_branch(cwd: &Path, hint: Option<&str>) -> Result<(String, String
         None
     };
 
-    if let Some(name) = hint {
-        if let Some(found) = try_branch(name, &mut tried) {
+    if let Some(remote_head) = query_origin_head(cwd) {
+        if let Some(found) = try_branch(&remote_head, &mut tried) {
             return Ok(found);
         }
     }
 
-    if let Some(remote_head) = query_origin_head(cwd) {
-        if let Some(found) = try_branch(&remote_head, &mut tried) {
+    if let Some(name) = hint {
+        if let Some(found) = try_branch(name, &mut tried) {
             return Ok(found);
         }
     }


### PR DESCRIPTION
## Summary
- Worktree creation failed on this very repo with `git fetch origin alacritree: fatal: couldn't find remote ref alacritree`. The upstream default branch was renamed from `alacritree` to `master`, but the local `refs/remotes/origin/HEAD` still points at the old name and `origin/alacritree` lingers as a stale ref — so `resolve_base_branch` happily verified the hint locally and handed `alacritree` to `git fetch`.
- Reorder `resolve_base_branch` to consult origin first via `git ls-remote --symref HEAD` (the only source that reflects the upstream's *current* default). Hint and common-name fallbacks remain for the offline case.

## Reproduction
1. In any clone whose cached `origin/HEAD` points at a branch the remote no longer advertises (e.g. this repo before the fix), open the "New worktree" modal.
2. Submit. The modal errors out at "Fetching latest changes…" with `couldn't find remote ref <stale-name>`.
3. After the fix, the resolved base follows origin's actual HEAD (`master`), the fetch succeeds, and the worktree is created against `origin/master`.

## Test plan
- [x] `cargo check -p alacritree`
- [x] Manually verified the resolution flow against the live repo: `ls-remote --symref origin HEAD` → `master`; `rev-parse --verify origin/master` succeeds; `git fetch origin master` succeeds.
- [ ] Smoke-test: create a worktree from the UI on this repo (previously failing case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)