### PR TITLE
fix(ui): keep sidebar border below modals

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -92,8 +92,11 @@ fn lighten(c: Color32, amount: f32) -> Color32 {
 }
 
 fn paint_panel_border(ctx: &Context, x: f32, y_range: egui::Rangef, color: Color32) {
+    // `Middle` keeps the line above the panel content (`Background`) but below
+    // modals, popups, and tooltips (`Foreground`/`Tooltip`) — otherwise the
+    // border bleeds through whatever modal is open.
     let layer =
-        egui::LayerId::new(egui::Order::Foreground, egui::Id::new(("sidebar_border", x.to_bits())));
+        egui::LayerId::new(egui::Order::Middle, egui::Id::new(("sidebar_border", x.to_bits())));
     ctx.layer_painter(layer).vline(x, y_range, Stroke::new(1.0, color));
 }
 


### PR DESCRIPTION
## Summary
- The sidebar's vertical border line painted at `Order::Foreground`, the same layer egui uses for modals — so the line drew on top of any open dialog at the sidebar boundary (visible as a thin vertical line cutting into the delete/create/quit modals).
- Drop the border to `Order::Middle`: above panel content (`Background`), below modals, popups, and tooltips. No visual change when no modal is open.

## Test plan
- [x] `cargo check -p alacritree`
- [ ] Open the delete-worktree modal with both sidebars visible — border should no longer slice through the dialog.
- [ ] Same check with the create-worktree and quit dialogs, and with only one sidebar visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)