### PR TITLE
fix(input): scroll to bottom on keyboard input

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -526,6 +526,7 @@ impl AlacritreeApp {
         match action {
             BindingAction::Chars(bytes) => {
                 if let Some(idx) = self.active_session_index() {
+                    paste::on_terminal_input_start(&self.sessions[idx]);
                     self.sessions[idx].write(bytes);
                 }
             },
@@ -1043,13 +1044,9 @@ impl AlacritreeApp {
                         // Open-coded section header so the PR number can be a
                         // hyperlink while the rest stays plain text.
                         ui.horizontal(|ui| {
-                            ui.label(
-                                RichText::new(&base_label).color(theme.text).strong().small(),
-                            );
+                            ui.label(RichText::new(&base_label).color(theme.text).strong().small());
                             if let Some(pr) = &pr_info {
-                                ui.label(
-                                    RichText::new("·").color(theme.text_muted).small(),
-                                );
+                                ui.label(RichText::new("·").color(theme.text_muted).small());
                                 ui.hyperlink_to(
                                     RichText::new(format!("PR #{}", pr.number))
                                         .color(theme.accent)

--- a/alacritree/src/paste.rs
+++ b/alacritree/src/paste.rs
@@ -52,7 +52,10 @@ pub fn write_selection(term: &Term<EventProxy>, config: &Config, target: Target)
     clipboard::write(target, &text);
 }
 
-fn on_terminal_input_start(session: &Session) {
+/// Mirrors alacritty's `on_terminal_input_start`: any keypress or paste that
+/// reaches the PTY clears the active selection and snaps the view back to the
+/// active line so the user sees what they just typed.
+pub fn on_terminal_input_start(session: &Session) {
     let mut term = session.term.lock();
     let _ = term.selection.take();
     if term.grid().display_offset() != 0 {

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -131,8 +131,9 @@ pub fn show(
                 .collect()
         });
         if !consumed.is_empty() {
-            // Typing should drop any active selection — matches alacritty's UX.
-            session.term.lock().selection = None;
+            // Typing drops the selection and snaps back to the prompt so the
+            // user sees their input — matches alacritty's on_terminal_input_start.
+            paste::on_terminal_input_start(session);
         }
         for event in consumed {
             match event {


### PR DESCRIPTION
## Summary
- Scrolling back through scrollback and then typing (or hitting Shift+Tab via a `Chars` binding) now snaps the view back to the prompt before the bytes hit the PTY, matching alacritty.
- Exposes `paste::on_terminal_input_start` so the keyboard path and the `BindingAction::Chars` path can share the same selection-clear + scroll-to-bottom behaviour that paste already used.

## Test plan
- [ ] `cargo run -p alacritree`, scroll up with the mouse wheel, type a character — view should jump to the bottom.
- [ ] Same flow but trigger Shift+Tab (a `Chars` binding) — view should also jump.
- [ ] Paste still scrolls to bottom (regression check).
- [ ] Mouse-wheel scrolling on the alt screen still emits arrow keys without fighting the scroll-to-bottom (handled by the unchanged ALTERNATE_SCROLL write path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)