### PR TITLE
chore(packaging): declare delta as a runtime dep across packages

### DIFF
--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -4,6 +4,17 @@ class Alacritree < Formula
   version "0.2.7"
   license "Apache-2.0"
 
+  # Linked dynamically through the `fontconfig` Rust crate (alacritty's font
+  # matching path); freetype is pulled in transitively but listed here too so
+  # `brew uses --recursive` reflects the real link graph.
+  depends_on "fontconfig"
+  depends_on "freetype"
+  # Runtime deps for the sidebar diff view: we shell out to `git diff … | delta`.
+  # macOS preinstalls a system `git` via Command Line Tools, but pinning the
+  # Homebrew one guarantees a recent enough version for the merge-base syntax.
+  depends_on "git"
+  depends_on "git-delta"
+
   # The release workflow only ships aarch64-apple-darwin today; Intel Macs
   # need to build from source until the release matrix grows an x86_64
   # target. The `on_macos` / `on_arm` guard makes the formula install fail

--- a/bucket/alacritree.json
+++ b/bucket/alacritree.json
@@ -10,6 +10,10 @@
         }
     },
     "bin": "alacritree.exe",
+    "depends": [
+        "main/git",
+        "main/delta"
+    ],
     "shortcuts": [
         [
             "alacritree.exe",

--- a/packaging/aur/alacritree-bin/PKGBUILD
+++ b/packaging/aur/alacritree-bin/PKGBUILD
@@ -15,6 +15,9 @@ depends=(
   'libxcb'
   'wayland'
   'libglvnd'
+  # Runtime deps for the sidebar diff view: we shell out to `git diff … | delta`.
+  'git'
+  'git-delta'
 )
 provides=("$_pkgname")
 conflicts=("$_pkgname" 'alacritree-git')

--- a/packaging/aur/alacritree-git/PKGBUILD
+++ b/packaging/aur/alacritree-git/PKGBUILD
@@ -15,6 +15,9 @@ depends=(
   'libxcb'
   'wayland'
   'libglvnd'
+  # Runtime deps for the sidebar diff view: we shell out to `git diff … | delta`.
+  'git'
+  'git-delta'
 )
 makedepends=(
   'git'


### PR DESCRIPTION
The sidebar diff view shells out to `git diff … | delta`. Until now the binary was installed without `delta` declared anywhere, so a fresh install on Arch / macOS / Windows would silently fail the first time a user clicked a file in the git sidebar. Declare `git` and `git-delta` (scoop: `main/delta`) on every package.

Homebrew also gets `fontconfig` and `freetype` — the `fontconfig` Rust crate dlopens libfontconfig at runtime, which macOS doesn't ship.