### PR TITLE
homebrew: bump alacritree to v0.2.9

### DIFF
--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -1,7 +1,7 @@
 class Alacritree < Formula
   desc "Alacritty fork with worktree-aware sidebars"
   homepage "https://github.com/mathix420/alacritree"
-  version "0.2.8"
+  version "0.2.9"
   license "Apache-2.0"
 
   # Linked dynamically through the `fontconfig` Rust crate (alacritty's font
@@ -22,7 +22,7 @@ class Alacritree < Formula
   on_macos do
     on_arm do
       url "https://github.com/mathix420/alacritree/releases/download/v#{version}/alacritree-v#{version}-aarch64-macos.tar.gz"
-      sha256 "3fa1fe61de8b5d8b360dc33e9a675e0edeb63eab443e77135708d2b404c3b772"
+      sha256 "cdefaf877bb85961db55b18136099032fd2f5dcd732883f6fe080ac81b3240aa"
     end
   end
 


### PR DESCRIPTION
Automated formula bump triggered by the release of `v0.2.9`.