### PR TITLE
scoop: bump alacritree to v0.2.9

### DIFF
--- a/bucket/alacritree.json
+++ b/bucket/alacritree.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.8",
+    "version": "0.2.9",
     "description": "Alacritty fork with worktree-aware sidebars",
     "homepage": "https://github.com/mathix420/alacritree",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mathix420/alacritree/releases/download/v0.2.8/alacritree-v0.2.8-x86_64-windows.zip",
-            "hash": "bff60f15df8324d3505f48eaf330a5ad926d8a4ed3205a05d12f5cc78ba68d84"
+            "url": "https://github.com/mathix420/alacritree/releases/download/v0.2.9/alacritree-v0.2.9-x86_64-windows.zip",
+            "hash": "1132fac67423ce255c328f92271e3ea482cb15eadacf22f83ff49b4e1c27a2b2"
         }
     },
     "bin": "alacritree.exe",


### PR DESCRIPTION
Automated manifest bump triggered by the release of `v0.2.9`.