### PR TITLE
fix(windows): quote diff-pane argv so git receives the delta pager intact

### DIFF
--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -306,9 +306,14 @@ impl Session {
             working_directory: working_directory.clone(),
             drain_on_exit: false,
             env: config.env.clone(),
-            // `Options` has a Windows-only `escape_args` field; leaning on
-            // `Default` keeps the literal compilable on every target.
-            ..Default::default()
+            // Windows has no argv: alacritty_terminal joins these args into a
+            // single CreateProcess command line, quoting them only when this
+            // is set.  Diff panes pass argv built in code, where an arg with a
+            // space (delta's pager spec, file paths) must survive as one
+            // argument; shell args from alacritty.toml stay raw to match
+            // upstream alacritty.
+            #[cfg(windows)]
+            escape_args: matches!(kind, SessionKind::Diff { .. }),
         };
 
         // alacritty routes OSC 7 / signals by this id, so each session needs its own.


### PR DESCRIPTION
## Why diffs still failed on Windows

#43's follow-up (f4ac7a4c, shipped in v0.2.9) replaced the `sh -c '… | delta'` pipe with `git -c "core.pager=delta --paging=always" diff …`, which is correct — but on Windows `alacritty_terminal` flattens PTY argv into a single `CreateProcess` command line and only quotes arguments when `Options::escape_args` is set. We left it at the default `false`, so the command line came out as:

```
git -c core.pager=delta --paging=always diff -- <file>
```

The pager spec split on its internal space, git rejected `--paging=always` as an unknown global option and exited instantly, and `reap_exited_sessions` closed the pane the same frame — the diff panel "opened" and auto-closed without rendering anything. Any file path containing a space would have split identically.

## Fix

Set `escape_args: true` for diff-pane sessions, whose argv is constructed in code and therefore carries logical arguments that must survive intact. Config-shell args from `alacritty.toml` stay raw (`false`), matching how upstream alacritty treats user-authored shell arguments on Windows.

No behavior change on unix: the field is `#[cfg(windows)]`-gated and unix PTYs exec a real argv.

## Testing

- `cargo check -p alacritree` and `cargo fmt` clean on Linux; the Windows-gated field matches `alacritty_terminal::tty::Options` exactly (same pattern as its own `test_cmdline`, which asserts `escape_args: true` produces `echo "hello world"`).
- Needs a Windows smoke test after merge: click staged/unstaged/untracked files and the branch diff row in the right sidebar; each should open delta in the pane instead of flashing closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)