### PR TITLE
feat(worktree): mirror Doppler scopes into worktrees automatically

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Mutex, OnceLock};
@@ -10,6 +10,7 @@ use crate::bindings::{BindingAction, NamedAction};
 use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
 use crate::config::Config;
+use crate::doppler;
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, StatusCache};
 use crate::paste;
 use crate::pr_status::PrCache;
@@ -126,6 +127,9 @@ pub struct AlacritreeApp {
     quit_dialog_open: bool,
     pending_delete: Option<DeleteRequest>,
     pending_create: Option<CreateState>,
+    /// Worktrees already given a Doppler scope pass this app run, so opening
+    /// more shells there doesn't re-invoke the doppler CLI.
+    doppler_synced: HashSet<PathBuf>,
     notify_rx: Receiver<WorkspaceKey>,
     /// Shared across sessions; auto-invalidated when cell size changes.
     builtin_glyphs: crate::builtin_font::BuiltinGlyphCache,
@@ -263,6 +267,7 @@ impl AlacritreeApp {
             quit_dialog_open: false,
             pending_delete: None,
             pending_create: None,
+            doppler_synced: HashSet::new(),
             notify_rx,
             builtin_glyphs: crate::builtin_font::BuiltinGlyphCache::new(),
         };
@@ -292,6 +297,11 @@ impl AlacritreeApp {
         ctx: &Context,
         working_directory: WorkspaceKey,
     ) -> std::io::Result<SessionId> {
+        // Before the PTY exists, so the shell can't race `doppler run`
+        // against the scope write.
+        if let Some(dir) = &working_directory {
+            self.sync_doppler_scopes(dir.clone());
+        }
         let session = Session::spawn(
             ctx.clone(),
             &self.config,
@@ -303,6 +313,30 @@ impl AlacritreeApp {
         self.sessions.push(session);
         self.active_session.insert(working_directory, id);
         Ok(id)
+    }
+
+    /// Mirror Doppler scopes into a worktree the first time a shell opens
+    /// there.  The create-time hook in `worktree.rs` covers worktrees we
+    /// make; this lazy pass covers ones created outside alacritree, which
+    /// otherwise hit "Doppler Error: You must specify a project".
+    fn sync_doppler_scopes(&mut self, worktree: PathBuf) {
+        if !self.doppler_synced.insert(worktree.clone()) {
+            return;
+        }
+        let main_checkout = self.projects.iter().find_map(|p| {
+            let owns = p.worktrees.iter().any(|wt| !wt.is_main && wt.path == worktree);
+            if !owns {
+                return None;
+            }
+            p.worktrees.iter().find(|wt| wt.is_main).map(|wt| wt.path.clone())
+        });
+        let Some(main_checkout) = main_checkout else {
+            return;
+        };
+        let linked = doppler::mirror_scopes(&main_checkout, &worktree);
+        if linked > 0 {
+            log::info!("linked {linked} doppler scope(s) into {}", worktree.display());
+        }
     }
 
     fn activate_worktree(&mut self, ctx: &Context, path: &Path) {

--- a/alacritree/src/doppler.rs
+++ b/alacritree/src/doppler.rs
@@ -1,0 +1,154 @@
+//! Mirror Doppler CLI scopes from a project's main checkout into its git
+//! worktrees.
+//!
+//! Doppler binds project/config to absolute directory paths (`doppler setup`
+//! writes them under `scoped:` in `~/.doppler/.doppler.yaml`), so a fresh
+//! worktree starts unscoped and `doppler run` fails with "You must specify a
+//! project" even though the main checkout is fully set up.  Copying the main
+//! checkout's scopes — including per-subdirectory scopes in monorepos — to
+//! the equivalent paths inside the worktree makes `doppler run` work there
+//! out of the box.  We go through the doppler CLI instead of editing its
+//! config file so we never fight its on-disk format.  Everything is
+//! best-effort: no doppler binary, or nothing to copy, is a silent no-op.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::command_ext::CommandExt;
+
+/// `enclave.*` is doppler's on-disk spelling of the `project`/`config`
+/// options (a leftover from when the product was called Enclave).
+const PROJECT_KEY: &str = "enclave.project";
+const CONFIG_KEY: &str = "enclave.config";
+
+type Scopes = HashMap<String, HashMap<String, serde_json::Value>>;
+
+/// Copy every scope at or under `main_checkout` to the equivalent path under
+/// `worktree`.  Scopes the worktree already defines are left untouched so a
+/// deliberate per-worktree `doppler setup` (e.g. pointing at a different
+/// config) survives.  Returns how many scopes were written.
+pub fn mirror_scopes(main_checkout: &Path, worktree: &Path) -> usize {
+    let Some(scopes) = all_scopes() else {
+        return 0;
+    };
+    let main = canonical(main_checkout);
+    let worktree = canonical(worktree);
+    if main == worktree {
+        return 0;
+    }
+
+    let mut written = 0;
+    for (scope, options) in &scopes {
+        let Some(project) = options.get(PROJECT_KEY).and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(target) = rebase_scope(scope, &main, &worktree) else {
+            continue;
+        };
+        let already_scoped = scopes
+            .get(target.to_string_lossy().as_ref())
+            .is_some_and(|o| o.contains_key(PROJECT_KEY) || o.contains_key(CONFIG_KEY));
+        if already_scoped {
+            continue;
+        }
+
+        let project_pair = format!("project={project}");
+        let config_pair =
+            options.get(CONFIG_KEY).and_then(|v| v.as_str()).map(|c| format!("config={c}"));
+        let mut args = vec!["configure", "set", &project_pair];
+        if let Some(pair) = &config_pair {
+            args.push(pair);
+        }
+        match run(&args, Some(&target)) {
+            Some(_) => written += 1,
+            None => log::warn!("doppler: failed to set scope for {}", target.display()),
+        }
+    }
+    written
+}
+
+/// Drop the project/config options from every scope at or under `worktree`,
+/// so deleting a worktree doesn't grow doppler's config file forever.  Other
+/// options (tokens, hosts) are preserved; doppler prunes scope entries that
+/// end up empty.  Returns how many scopes were cleaned.
+pub fn forget_scopes(worktree: &Path) -> usize {
+    let Some(scopes) = all_scopes() else {
+        return 0;
+    };
+    let worktree = canonical(worktree);
+
+    let mut cleaned = 0;
+    for (scope, options) in &scopes {
+        if !Path::new(scope).starts_with(&worktree) {
+            continue;
+        }
+        if !options.contains_key(PROJECT_KEY) && !options.contains_key(CONFIG_KEY) {
+            continue;
+        }
+        match run(&["configure", "unset", "project", "config"], Some(Path::new(scope))) {
+            Some(_) => cleaned += 1,
+            None => log::warn!("doppler: failed to unset scope {scope}"),
+        }
+    }
+    cleaned
+}
+
+/// Map a scope path from the main checkout's subtree to the worktree's.
+/// Component-wise, so `/repo-other` never matches a `/repo` prefix.
+fn rebase_scope(scope: &str, main: &Path, worktree: &Path) -> Option<PathBuf> {
+    let rel = Path::new(scope).strip_prefix(main).ok()?;
+    if rel.as_os_str().is_empty() { Some(worktree.to_path_buf()) } else { Some(worktree.join(rel)) }
+}
+
+/// Every scope in doppler's config file, keyed by absolute directory path.
+fn all_scopes() -> Option<Scopes> {
+    let stdout = run(&["configure", "--all", "--json"], None)?;
+    serde_json::from_slice(&stdout).ok()
+}
+
+/// Run doppler with `args`, returning stdout on success and `None` on any
+/// failure — including the binary not being installed, which is the common
+/// case and must stay quiet.
+fn run(args: &[&str], scope: Option<&Path>) -> Option<Vec<u8>> {
+    let mut cmd = Command::new("doppler");
+    cmd.hide_console()
+        .args(args)
+        .arg("--no-check-version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    if let Some(scope) = scope {
+        cmd.arg("--scope").arg(scope);
+    }
+    let output = cmd.output().ok()?;
+    output.status.success().then_some(output.stdout)
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rebases_root_scope_to_worktree_root() {
+        let target = rebase_scope("/repo", Path::new("/repo"), Path::new("/wt"));
+        assert_eq!(target, Some(PathBuf::from("/wt")));
+    }
+
+    #[test]
+    fn rebases_subdirectory_scopes() {
+        let target = rebase_scope("/repo/apps/web", Path::new("/repo"), Path::new("/wt"));
+        assert_eq!(target, Some(PathBuf::from("/wt/apps/web")));
+    }
+
+    #[test]
+    fn ignores_scopes_outside_the_main_checkout() {
+        assert_eq!(rebase_scope("/elsewhere", Path::new("/repo"), Path::new("/wt")), None);
+        // Sibling with a shared string prefix must not match.
+        assert_eq!(rebase_scope("/repo-other", Path::new("/repo"), Path::new("/wt")), None);
+    }
+}

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -7,6 +7,7 @@ mod clipboard;
 mod colors;
 mod command_ext;
 mod config;
+mod doppler;
 mod fonts;
 mod git_status;
 mod input;

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -118,6 +118,11 @@ fn run_create(
         send("Enabled Claude Code terminal bell");
     }
 
+    let linked = crate::doppler::mirror_scopes(&req.project_root, &target);
+    if linked > 0 {
+        send(&format!("Linked {linked} Doppler scope(s)"));
+    }
+
     Ok(target)
 }
 
@@ -363,6 +368,10 @@ pub fn delete_worktree(
     force: bool,
 ) -> Result<(), String> {
     let path_str = worktree_path.to_str().ok_or_else(|| "invalid worktree path".to_string())?;
+    // Resolve before removal: canonicalize needs the directory to still
+    // exist, and the doppler cleanup below runs after git has deleted it.
+    let scope_root =
+        std::fs::canonicalize(worktree_path).unwrap_or_else(|_| worktree_path.to_path_buf());
     let mut args: Vec<&str> = vec!["worktree", "remove"];
     if force {
         args.push("--force");
@@ -372,6 +381,10 @@ pub fn delete_worktree(
     if let Some(branch) = branch {
         // Branch may already be gone (e.g. detached HEAD) — ignore errors here.
         let _ = run_git(project_root, &["branch", "-D", branch]);
+    }
+    let cleaned = crate::doppler::forget_scopes(&scope_root);
+    if cleaned > 0 {
+        log::info!("dropped {cleaned} doppler scope(s) under {}", scope_root.display());
     }
     Ok(())
 }


### PR DESCRIPTION
## Problem

Doppler binds project/config to absolute directory paths in `~/.doppler/.doppler.yaml`, so a fresh git worktree starts unscoped and `doppler run` fails:

```
Doppler Error: You must specify a project
Doppler Error: The fallback file does not exist
error: script "dev" exited with code 1
```

Until now the fix was re-running `doppler setup` by hand in every single worktree.

## What this does

New `doppler.rs` module reads all scopes via `doppler configure --all --json` and mirrors every scope under a project's main checkout to the rebased path inside the worktree — including per-subdirectory scopes in monorepos (e.g. `<main>/apps/web` → `<worktree>/apps/web`), which env-var injection could not express. All writes go through the doppler CLI so we never fight its on-disk format.

Hooked in three places:

- **Worktree creation** — mirrored right after the LLM-config copy, with a "Linked N Doppler scope(s)" step in the create modal, so the worktree works even outside alacritree.
- **First shell in a worktree** — a lazy pass (once per worktree per app run) covers worktrees created outside alacritree that the create hook never saw.
- **Worktree deletion** — drops the mirrored `project`/`config` options under the deleted path so the config file stops accumulating entries for dead paths.

## Safety

- Existing worktree scopes are never overwritten — a deliberate per-worktree `doppler setup` (different config, say `dev` vs `dev_personal`) survives.
- Cleanup only unsets `project`/`config`; tokens and other options are preserved (`doppler configure set` merges and `unset` prunes only emptied entries — verified live against doppler v3.76.0).
- No doppler binary installed → silent no-op everywhere.

## Testing

- 3 unit tests pin the scope-rebasing rules: root scope → worktree root, subdirectory rebase, and no false match of `/repo-other` against a `/repo` prefix (component-wise `strip_prefix`).
- CLI semantics (`--all --json` shape, `set` merge, `unset` token preservation, parent-scope resolution) verified against a live doppler v3.76.0 using an isolated `--config-dir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)