### PR TITLE
homebrew: bump alacritree to v0.2.10

### DIFF
--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -1,7 +1,7 @@
 class Alacritree < Formula
   desc "Alacritty fork with worktree-aware sidebars"
   homepage "https://github.com/mathix420/alacritree"
-  version "0.2.9"
+  version "0.2.10"
   license "Apache-2.0"
 
   # Linked dynamically through the `fontconfig` Rust crate (alacritty's font
@@ -22,7 +22,7 @@ class Alacritree < Formula
   on_macos do
     on_arm do
       url "https://github.com/mathix420/alacritree/releases/download/v#{version}/alacritree-v#{version}-aarch64-macos.tar.gz"
-      sha256 "cdefaf877bb85961db55b18136099032fd2f5dcd732883f6fe080ac81b3240aa"
+      sha256 "b1ca4e3a448216ef9861fa9c089c1c2e91ebc26cf4a63c4cc119505c3143c882"
     end
   end
 


### PR DESCRIPTION
Automated formula bump triggered by the release of `v0.2.10`.