### PR TITLE
homebrew: bump alacritree to v0.2.11

### DIFF
--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -1,7 +1,7 @@
 class Alacritree < Formula
   desc "Alacritty fork with worktree-aware sidebars"
   homepage "https://github.com/mathix420/alacritree"
-  version "0.2.10"
+  version "0.2.11"
   license "Apache-2.0"
 
   # Linked dynamically through the `fontconfig` Rust crate (alacritty's font
@@ -22,7 +22,7 @@ class Alacritree < Formula
   on_macos do
     on_arm do
       url "https://github.com/mathix420/alacritree/releases/download/v#{version}/alacritree-v#{version}-aarch64-macos.tar.gz"
-      sha256 "b1ca4e3a448216ef9861fa9c089c1c2e91ebc26cf4a63c4cc119505c3143c882"
+      sha256 "3fa5076c8ee147123e2afdcfe8e7895aa2b8f44e59fb5ccde6c6866693b1c417"
     end
   end
 


### PR DESCRIPTION
Automated formula bump triggered by the release of `v0.2.11`.