### PR TITLE
scoop: bump alacritree to v0.2.11

### DIFF
--- a/bucket/alacritree.json
+++ b/bucket/alacritree.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.10",
+    "version": "0.2.11",
     "description": "Alacritty fork with worktree-aware sidebars",
     "homepage": "https://github.com/mathix420/alacritree",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mathix420/alacritree/releases/download/v0.2.10/alacritree-v0.2.10-x86_64-windows.zip",
-            "hash": "2ea34037ef95ed6748f6d92673431b66cc3f84247f416fb634bd7fdcc5025075"
+            "url": "https://github.com/mathix420/alacritree/releases/download/v0.2.11/alacritree-v0.2.11-x86_64-windows.zip",
+            "hash": "2e94350fc05c179611f252ec5fff6dff41c7379cf8ec0693764290a31bb0cb3b"
         }
     },
     "bin": "alacritree.exe",


### PR DESCRIPTION
Automated manifest bump triggered by the release of `v0.2.11`.