### PR TITLE
fix(windows): keep the DLL loader off PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "windows-sys 0.59.0",
  "xdg",
 ]
 

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -34,6 +34,10 @@ notify-rust = "4"
 # (alacritty's font backend, present in this workspace) pulls in.
 fontconfig = "0.8"
 
+[target.'cfg(windows)'.dependencies]
+# Restricts the DLL search path at startup; see `harden_dll_search_path`.
+windows-sys = { version = "0.59", features = ["Win32_System_LibraryLoader"] }
+
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "3.0.2"
 

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -29,7 +29,36 @@ use app::AlacritreeApp;
 /// what egui only needs at ~256x256.
 const WINDOW_ICON: &[u8] = include_bytes!("../assets/icon-256.png");
 
+/// Drop PATH and the working directory from the DLL search order, leaving the
+/// executable's own directory plus the system directories.
+///
+/// `alacritty_terminal` opens the pseudoconsole by `LoadLibraryW("conpty.dll")`
+/// so a build of OpenConsole shipped alongside the binary can be preferred over
+/// the one in Windows.  Windows has no `conpty.dll` of its own — the API lives
+/// in `kernel32` — so that bare name matches nothing until some *other* app's
+/// install directory is on PATH, at which point every PTY is hosted in a foreign
+/// terminal's console server.  WezTerm's blocks the child process for three
+/// seconds waiting on a device-attributes reply, which shows up as a multi-second
+/// stall opening any pane.
+#[cfg(windows)]
+fn harden_dll_search_path() {
+    use windows_sys::Win32::System::LibraryLoader::{
+        LOAD_LIBRARY_SEARCH_DEFAULT_DIRS, SetDefaultDllDirectories,
+    };
+
+    // Failure only leaves the default search order in place, which is what we
+    // had before, so it is not worth refusing to start over.
+    if unsafe { SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS) } == 0 {
+        log::warn!("failed to restrict the DLL search path: {}", std::io::Error::last_os_error());
+    }
+}
+
+#[cfg(not(windows))]
+fn harden_dll_search_path() {}
+
 fn main() -> eframe::Result<()> {
+    harden_dll_search_path();
+
     // egui_winit warns on every cold X11 clipboard probe even when it recovers.
     let default_filter = "info,egui_winit::clipboard=error";
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default_filter))

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -579,4 +579,47 @@ mod tests {
 
         assert_eq!(outcome.clipboard, vec![(Target::Clipboard, "hello".to_owned())]);
     }
+
+    /// A pane must not wait on the console host's startup handshake.
+    ///
+    /// `harden_dll_search_path` keeps `LoadLibraryW("conpty.dll")` off PATH.  Without
+    /// it, any `conpty.dll` sitting in another terminal's install directory (WezTerm
+    /// ships one) hosts our pseudoconsoles, and WezTerm's blocks the child process
+    /// for three seconds waiting on a device-attributes reply that never satisfies
+    /// it.  The child here prints and exits immediately, so a runtime anywhere near
+    /// that timeout means a foreign console server is back in the loop.
+    #[cfg(windows)]
+    #[test]
+    fn a_pane_runs_its_child_without_a_console_host_handshake() {
+        crate::harden_dll_search_path();
+
+        let start = Instant::now();
+        let mut session = Session::spawn_command(
+            egui::Context::default(),
+            &Config::default(),
+            std::env::current_dir().ok(),
+            TermSize::new(80, 24),
+            (8.0, 16.0),
+            "cmd".to_string(),
+            vec!["/c".to_string(), "echo".to_string(), "ready".to_string()],
+            "probe".to_string(),
+            SessionKind::Shell,
+        )
+        .unwrap();
+
+        let exited = loop {
+            assert!(start.elapsed() < Duration::from_secs(10), "child never exited");
+            match session.events.try_recv() {
+                Ok(TermEvent::ChildExit(_)) => break start.elapsed(),
+                Ok(_) => {},
+                Err(_) => std::thread::sleep(Duration::from_millis(1)),
+            }
+        };
+
+        assert!(
+            exited < Duration::from_secs(2),
+            "`cmd /c echo ready` took {exited:?}; the console host is stalling on a \
+             handshake (the foreign conpty.dll stall is ~3s)"
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes a windows startup bug/delay and potential security hole.

On Windows, alacritty tries to load `conpty.dll` if its available on PATH. If `contpy.dll` isn't found, it loads the builtin one that's provided by the kernel.

Trying to load random `conpty.dll` can cause long startup times for all panes and delta calls. Eg, I have wezterm installed, which comes with a `conpty.dll`, which alacritree tries to load. This adds ~3s of startup time to each pane.

#JustWindowsThings

This PR fixes this by adding a helper function that cleans the PATH. The helper function only gets a body on windows target.
In release profile builds, on non-windows machines, LLVM should remove the helper function as it will be empty.

I could instead add the conditional compilation flags in the functions that call the new helper, but I feel like it makes it less readable.

Let me know if you have a preference!

The rest of the summary is generated by claude.

## Cause

`alacritty_terminal` opens the pseudoconsole with a bare `LoadLibraryW("conpty.dll")` (`alacritty_terminal/src/tty/windows/conpty.rs`) so that an OpenConsole build shipped next to the binary is preferred over the one in Windows. Windows ships no `conpty.dll` of its own — the API lives in `kernel32` — so that bare name matches nothing *until another application's install directory happens to be on PATH*. `C:\Program Files\WezTerm` contains a `conpty.dll`, and WezTerm puts itself on PATH, so every pseudoconsole we open is hosted by WezTerm's console server. It holds the child process for three seconds waiting on a device-attributes reply before giving up and letting the child run.

Answering the query does not help; I tried replying `ESC[?6c` directly at the pipe and the stall stayed at 3.0s. Hosting our terminals in whatever other emulator the user happens to have installed is the bug, not the missing reply.

## Fix

Call `SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)` at startup. That drops PATH and the working directory from the DLL search order, leaving the executable's own directory plus the system directories — so a bundled OpenConsole still loads, and nothing else does. This is also Microsoft's recommended mitigation for DLL preloading attacks. It is scoped to this process: it does not affect child processes, already-loaded or statically-imported DLLs, absolute-path loads, or PATH-based *program* lookup.

## Test

`a_pane_runs_its_child_without_a_console_host_handshake` (`alacritree/src/session.rs`, Windows-only) spawns `cmd /c echo ready` through a real `Session` and asserts `ChildExit` within 2s. Verified RED by reverting the fix: 3.0s, fails. GREEN with it: ~30ms.

Non-Windows is unaffected — the dependency is under `[target.'cfg(windows)'.dependencies]` and the call is a no-op stub elsewhere.

Draft because it wants a second pair of eyes on the `SetDefaultDllDirectories` blast radius, and because it would ideally be fixed upstream in `alacritty_terminal` (the `LoadLibraryW` call there should pass an absolute path or `LOAD_LIBRARY_SEARCH_*` flags); this is the fix that lives in code we own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
