### PR TITLE
[4] fix: answer OSC color and text-area size queries

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1723,7 +1723,7 @@ impl AlacritreeApp {
         let focused = ctx.input(|i| i.viewport().focused).unwrap_or(true);
 
         for idx in 0..self.sessions.len() {
-            let outcome = self.sessions[idx].drain_events();
+            let outcome = self.sessions[idx].drain_events(&self.config.palette);
             // Ahead of the attention early-out: a background session copying
             // with OSC 52 still owns the clipboard.
             for (target, text) in &outcome.clipboard {

--- a/alacritree/src/colors.rs
+++ b/alacritree/src/colors.rs
@@ -50,6 +50,21 @@ pub fn resolve(
     }
 }
 
+/// The color to report for an OSC 4 / 10 / 11 / 12 query.  `None` for a cursor
+/// color the app never set: alacritty leaves that query unanswered rather than
+/// naming a color it doesn't have, and the asking app falls back to its own.
+pub fn query(index: usize, runtime: &Colors, palette: &Palette) -> Option<Rgb> {
+    if let Some(rgb) = runtime[index] {
+        return Some(rgb);
+    }
+    match index {
+        0..=255 => Some(resolve_indexed(index as u8, runtime, palette)),
+        i if i == NamedColor::Foreground as usize => Some(palette.fg),
+        i if i == NamedColor::Background as usize => Some(palette.bg),
+        _ => None,
+    }
+}
+
 fn resolve_indexed(index: u8, runtime: &Colors, palette: &Palette) -> Rgb {
     if let Some(rgb) = runtime[index as usize] {
         return rgb;

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -11,8 +11,12 @@ use alacritty_terminal::sync::FairMutex;
 use alacritty_terminal::term::{ClipboardType, Config as TermConfig, Term};
 use alacritty_terminal::tty::{self, Options as PtyOptions, Shell};
 
+use alacritty_terminal::term::color::Colors;
+use alacritty_terminal::vte::ansi::Rgb;
+
 use crate::clipboard::Target;
-use crate::config::Config;
+use crate::colors;
+use crate::config::{Config, Palette};
 
 #[derive(Clone)]
 pub struct EventProxy {
@@ -145,6 +149,20 @@ pub struct DrainOutcome {
     /// written here so the drain — which runs once per frame for every session
     /// — stays free of OS clipboard access.
     pub clipboard: Vec<(Target, String)>,
+}
+
+/// Bytes answering an OSC colour query, or `None` when the query has no
+/// answer and the sender should be left to its own default.  `format` is the
+/// terminal's own response builder, so the reply carries whatever prefix and
+/// string terminator the query arrived with.
+fn color_query_reply(
+    index: usize,
+    format: &dyn Fn(Rgb) -> String,
+    runtime: &Colors,
+    palette: &Palette,
+) -> Option<Vec<u8>> {
+    let rgb = colors::query(index, runtime, palette)?;
+    Some(format(rgb).into_bytes())
 }
 
 /// Heuristic for "this title looks like a working/spinner state".  Matches
@@ -378,13 +396,34 @@ impl Session {
     /// Pull every pending event out of the PTY channel.  Called once per frame
     /// for every session — including background ones — so bells, title
     /// changes, and child-exits from non-visible sessions don't pile up.
-    pub fn drain_events(&mut self) -> DrainOutcome {
+    pub fn drain_events(&mut self, palette: &Palette) -> DrainOutcome {
         let mut outcome = DrainOutcome::default();
         while let Ok(event) = self.events.try_recv() {
-            if let Some(bytes) =
-                apply_term_event(event, &mut self.title, &mut self.exited, &mut outcome)
-            {
-                self.write(bytes);
+            match event {
+                // OSC 4 / 10 / 11 / 12.  Programs that ask the terminal for its
+                // palette (delta, vim, terminal-colorsaurus) block on the reply,
+                // so leaving the query unanswered costs them a timeout on every
+                // run rather than degrading gracefully.  Answered here rather
+                // than in apply_term_event, which stays free of the term lock
+                // the live palette sits behind.
+                TermEvent::ColorRequest(index, format) => {
+                    let reply = color_query_reply(
+                        index,
+                        format.as_ref(),
+                        self.term.lock().colors(),
+                        palette,
+                    );
+                    if let Some(bytes) = reply {
+                        self.write(bytes);
+                    }
+                },
+                event => {
+                    if let Some(bytes) =
+                        apply_term_event(event, &mut self.title, &mut self.exited, &mut outcome)
+                    {
+                        self.write(bytes);
+                    }
+                },
             }
         }
         outcome
@@ -553,6 +592,8 @@ fn next_session_id() -> SessionId {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use alacritty_terminal::Term;
     use alacritty_terminal::vte::ansi::{Processor, StdSyncHandler};
 
@@ -621,5 +662,70 @@ mod tests {
             "`cmd /c echo ready` took {exited:?}; the console host is stalling on a \
              handshake (the foreign conpty.dll stall is ~3s)"
         );
+    }
+
+    #[derive(Default)]
+    struct Collector(Mutex<Vec<TermEvent>>);
+
+    impl EventListener for &Collector {
+        fn send_event(&self, event: TermEvent) {
+            self.0.lock().unwrap().push(event);
+        }
+    }
+
+    /// Drive `bytes` through a real VT parser and return the reply the session
+    /// would put back on the PTY for the colour query they contain.
+    fn reply_to(bytes: &[u8], palette: &Palette) -> Option<Vec<u8>> {
+        let collector = Collector::default();
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(TermConfig::default(), &size, &collector);
+        Processor::<StdSyncHandler>::new().advance(&mut term, bytes);
+
+        let events = collector.0.lock().unwrap();
+        events.iter().find_map(|event| match event {
+            TermEvent::ColorRequest(index, format) => {
+                Some(color_query_reply(*index, format.as_ref(), term.colors(), palette))
+            },
+            _ => None,
+        })?
+    }
+
+    fn expected(prefix: &str, rgb: Rgb) -> Vec<u8> {
+        format!(
+            "\x1b]{prefix};rgb:{0:02x}{0:02x}/{1:02x}{1:02x}/{2:02x}{2:02x}\x07",
+            rgb.r, rgb.g, rgb.b
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn osc11_background_query_is_answered_from_the_palette() {
+        let palette = Palette::default();
+        assert_eq!(reply_to(b"\x1b]11;?\x07", &palette), Some(expected("11", palette.bg)));
+    }
+
+    #[test]
+    fn osc10_foreground_query_is_answered_from_the_palette() {
+        let palette = Palette::default();
+        assert_eq!(reply_to(b"\x1b]10;?\x07", &palette), Some(expected("10", palette.fg)));
+    }
+
+    #[test]
+    fn osc4_indexed_query_is_answered_from_the_palette() {
+        let palette = Palette::default();
+        assert_eq!(reply_to(b"\x1b]4;1;?\x07", &palette), Some(expected("4;1", palette.normal[1])));
+    }
+
+    #[test]
+    fn a_color_the_app_set_at_runtime_wins_over_the_palette() {
+        let palette = Palette::default();
+        let red = Rgb { r: 0xff, g: 0x00, b: 0x00 };
+        let reply = reply_to(b"\x1b]11;rgb:ff/00/00\x07\x1b]11;?\x07", &palette);
+        assert_eq!(reply, Some(expected("11", red)));
+    }
+
+    #[test]
+    fn an_unset_cursor_color_is_left_unanswered() {
+        assert_eq!(reply_to(b"\x1b]12;?\x07", &Palette::default()), None);
     }
 }

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -165,6 +165,17 @@ fn color_query_reply(
     Some(format(rgb).into_bytes())
 }
 
+/// Bytes answering a CSI 14 t text-area-size query.  Fed the same geometry the
+/// PTY was last resized with, so the pixel answer can't drift from the cell
+/// grid the child already knows about.
+fn text_area_size_reply(
+    format: &dyn Fn(WindowSize) -> String,
+    size: TermSize,
+    cell_size: (f32, f32),
+) -> Vec<u8> {
+    format(window_size(size, cell_size)).into_bytes()
+}
+
 /// Heuristic for "this title looks like a working/spinner state".  Matches
 /// any title containing a Braille glyph (`U+2800..=U+28FF`), which is the
 /// near-universal spinner alphabet (Claude Code, oh-my-posh, ollama, cargo's
@@ -416,6 +427,12 @@ impl Session {
                     if let Some(bytes) = reply {
                         self.write(bytes);
                     }
+                },
+                // CSI 14 t.  Image protocols and TUIs that size themselves in
+                // pixels block on this the same way the color queries do.
+                TermEvent::TextAreaSizeRequest(format) => {
+                    let reply = text_area_size_reply(format.as_ref(), self.size, self.cell_size);
+                    self.write(reply);
                 },
                 event => {
                     if let Some(bytes) =
@@ -696,6 +713,28 @@ mod tests {
             rgb.r, rgb.g, rgb.b
         )
         .into_bytes()
+    }
+
+    /// Drive `bytes` through a real VT parser and return the reply the session
+    /// would put back on the PTY for the text-area-size query they contain.
+    fn size_reply_to(bytes: &[u8], size: TermSize, cell_size: (f32, f32)) -> Option<Vec<u8>> {
+        let collector = Collector::default();
+        let mut term = Term::new(TermConfig::default(), &size, &collector);
+        Processor::<StdSyncHandler>::new().advance(&mut term, bytes);
+
+        let events = collector.0.lock().unwrap();
+        events.iter().find_map(|event| match event {
+            TermEvent::TextAreaSizeRequest(format) => {
+                Some(text_area_size_reply(format.as_ref(), size, cell_size))
+            },
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn csi14t_size_query_is_answered_in_pixels() {
+        let reply = size_reply_to(b"\x1b[14t", TermSize::new(80, 24), (7.0, 15.0));
+        assert_eq!(reply, Some(b"\x1b[4;360;560t".to_vec()));
     }
 
     #[test]

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -8,10 +8,9 @@ use alacritty_terminal::event::{Event as TermEvent, EventListener, Notify, Windo
 use alacritty_terminal::event_loop::{EventLoop, EventLoopSender, Msg, Notifier};
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::sync::FairMutex;
+use alacritty_terminal::term::color::Colors;
 use alacritty_terminal::term::{ClipboardType, Config as TermConfig, Term};
 use alacritty_terminal::tty::{self, Options as PtyOptions, Shell};
-
-use alacritty_terminal::term::color::Colors;
 use alacritty_terminal::vte::ansi::Rgb;
 
 use crate::clipboard::Target;


### PR DESCRIPTION
Programs that ask the terminal a question got no answer. delta queries the background color with OSC 11 to pick a light or dark theme, vim and anything built on terminal-colorsaurus do the same, and image protocols / pixel-aware TUIs send CSI 14 t for the text area's size. `drain_events` dropped all of these in its catch-all, so each caller stalled until its own timeout expired or fell back to wrong colors.

- OSC 4/10/11/12 now get the runtime palette when the app has set one, else the configured colors. An unset cursor color stays unanswered, as in alacritty: better the app falls back to its own default than to a color we invented.
- CSI 14 t gets the geometry the PTY was last resized with, so the pixel answer can't drift from the cell grid the child already knows about.

Same shape as #55: an event that demands an answer, dropped by the same catch-all. Rebased onto master after #55's `apply_term_event` refactor: the query events are answered in `drain_events` itself, since they need the term lock and PTY geometry that `apply_term_event` deliberately stays free of.

**Merge order:** wave-1 item 4 of the submission plan (AbysmalBiscuit/alacritree#1); independent of the other wave-1 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
