### PR TITLE
[8] fix(input): stop ctrl+shift+c from sending the interrupt

### DIFF
--- a/alacritree/src/input.rs
+++ b/alacritree/src/input.rs
@@ -8,15 +8,9 @@ pub fn event_to_bytes(event: &Event) -> Option<Vec<u8>> {
             key_to_bytes(*key, *modifiers)
         },
         // `Event::Paste` is handled by the caller via `paste::paste` so it
-        // gets bracketed-paste wrapping and newline normalization.
-        // egui_winit eats Ctrl+C / Ctrl+X and re-emits them as Copy/Cut without a
-        // matching Key event, so the PTY would otherwise never see ETX/CAN.
-        // Skip on macOS where the gesture is Cmd+C (Ctrl+C still flows as a Key
-        // event there, so we don't want Cmd+C hijacked into SIGINT).
-        #[cfg(not(target_os = "macos"))]
-        Event::Copy => Some(vec![0x03]),
-        #[cfg(not(target_os = "macos"))]
-        Event::Cut => Some(vec![0x18]),
+        // gets bracketed-paste wrapping and newline normalization.  `Copy` and
+        // `Cut` carry no modifiers, so they can't tell Ctrl+C from Ctrl+Shift+C
+        // and must not be encoded here; the Key event alongside them does it.
         _ => None,
     }
 }
@@ -104,4 +98,33 @@ fn ctrl_byte(key: Key) -> Option<u8> {
         _ => return None,
     };
     Some(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// egui's clipboard commands ignore Shift, so Ctrl+Shift+C raises the same
+    /// synthetic `Copy` as Ctrl+C.  Encoding it would send the interrupt on the
+    /// copy shortcut; the Key event emitted alongside it carries the modifiers
+    /// and is what the binding table and the encoder act on.
+    #[test]
+    fn synthetic_clipboard_events_send_nothing() {
+        assert_eq!(event_to_bytes(&Event::Copy), None);
+        assert_eq!(event_to_bytes(&Event::Cut), None);
+    }
+
+    /// The interrupt still has to reach the PTY off the Key event.
+    #[test]
+    fn ctrl_c_still_sends_sigint() {
+        let ctrl = Modifiers { ctrl: true, ..Modifiers::NONE };
+        let event = Event::Key {
+            key: Key::C,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: ctrl,
+        };
+        assert_eq!(event_to_bytes(&event), Some(vec![0x03]));
+    }
 }

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -765,10 +765,13 @@ impl State {
             if pressed {
                 if is_cut_command(self.egui_input.modifiers, active_key) {
                     self.egui_input.events.push(egui::Event::Cut);
-                    return;
+                    // alacritree: fall through to the Key event as well.  These
+                    // commands ignore Shift, so Ctrl+Shift+C matches them just
+                    // like Ctrl+C; swallowing the keystroke would leave the
+                    // binding table unable to tell the copy shortcut apart from
+                    // the interrupt, and terminal apps would never see ETX/CAN.
                 } else if is_copy_command(self.egui_input.modifiers, active_key) {
                     self.egui_input.events.push(egui::Event::Copy);
-                    return;
                 } else if is_paste_command(self.egui_input.modifiers, active_key) {
                     // alacritree: fall through to Key event when the clipboard
                     // had no text, so terminal apps still see raw 0x16.


### PR DESCRIPTION
egui's clipboard commands test only the command modifier and a layout-normalized key, so Ctrl+Shift+C satisfies `is_copy_command` exactly like Ctrl+C. egui-winit pushed a synthetic `Copy` and returned without emitting the Key event, so the binding table never saw the keystroke and could not run the Copy action, while `input.rs` encoded the bare `Copy` as ETX — the copy shortcut interrupted the foreground process instead of copying, and the text that did land on the clipboard came from copy-on-select.

Emits the Key event alongside Copy and Cut, the same fall-through already vendored for Paste, so the modifiers survive: Ctrl+Shift+C now matches its binding and Ctrl+C still encodes ETX off the Key event. Encoding Copy/Cut directly is therefore both unnecessary and wrong — they carry no modifiers and cannot tell the two chords apart — so those arms are dropped.

Patching the vendored `egui-winit` follows the precedent of #16.

**Merge order:** wave-1 item 8 of the submission plan (AbysmalBiscuit/alacritree#1); merge after #63. The paste half of the same defect follows as item 9 and edits the same `State::on_keyboard_input` hunk, so the two must land in order — or be folded into one PR if reviewing the halves together is easier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
