### PR TITLE
[9] fix(input): route paste through the binding table

### DIFF
--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -528,4 +528,18 @@ mod tests {
             "Ctrl+Shift+C no longer copies: {matched:?}"
         );
     }
+
+    /// Paste is a Ctrl+Shift+V binding; Ctrl+V belongs to the PTY (SYN).
+    #[test]
+    fn ctrl_v_is_not_bound_to_paste() {
+        let bindings = parse_bindings(vec![]);
+        let matched = all_matches(&bindings, Key::V, Modifiers::CTRL);
+        assert!(matched.is_empty(), "Ctrl+V is bound: {matched:?}");
+
+        let matched = all_matches(&bindings, Key::V, Modifiers::CTRL | Modifiers::SHIFT);
+        assert!(
+            matched.iter().any(|a| matches!(a, BindingAction::Named(NamedAction::Paste))),
+            "Ctrl+Shift+V no longer pastes: {matched:?}"
+        );
+    }
 }

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -121,15 +121,8 @@ pub fn show(
     );
 
     if allow_focus && response.has_focus() {
-        let consumed: Vec<ConsumedEvent> = ui.input(|i| {
-            i.events
-                .iter()
-                .filter_map(|e| match e {
-                    Event::Paste(s) => Some(ConsumedEvent::Paste(s.clone())),
-                    _ => event_to_bytes(e).map(ConsumedEvent::Bytes),
-                })
-                .collect()
-        });
+        let consumed: Vec<ConsumedEvent> =
+            ui.input(|i| i.events.iter().filter_map(consumed_event).collect());
         if !consumed.is_empty() {
             // Typing drops the selection and snaps back to the prompt so the
             // user sees their input — matches alacritty's on_terminal_input_start.
@@ -138,7 +131,6 @@ pub fn show(
         for event in consumed {
             match event {
                 ConsumedEvent::Bytes(bytes) => session.write(bytes),
-                ConsumedEvent::Paste(text) => paste::paste(session, &text, true),
             }
         }
     }
@@ -439,7 +431,21 @@ fn cell_at_pos(
 
 enum ConsumedEvent {
     Bytes(Vec<u8>),
-    Paste(String),
+}
+
+/// Classify an input event for the focused terminal.
+///
+/// `Event::Paste` is dropped rather than pasted: egui-winit synthesizes it for
+/// every `command+V` press, Shift included, so acting on it would paste on
+/// Ctrl+V regardless of the binding table and leave the shortcut impossible to
+/// rebind or unbind.  Keyboard paste runs through `NamedAction::Paste`, which
+/// reads the clipboard itself.  Text widgets outside the terminal still consume
+/// the event normally.
+fn consumed_event(event: &Event) -> Option<ConsumedEvent> {
+    match event {
+        Event::Paste(_) => None,
+        _ => event_to_bytes(event).map(ConsumedEvent::Bytes),
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -798,6 +804,7 @@ fn paint_builtin_glyph(
 mod tests {
     use alacritty_terminal::term::Config as TermConfig;
     use alacritty_terminal::vte::ansi::{Processor, StdSyncHandler};
+    use egui::Key;
 
     use super::*;
 
@@ -835,5 +842,29 @@ mod tests {
         let term = term_running(b"$ ");
 
         assert_ne!(cursor_shape(&term), CursorShape::Hidden);
+    }
+
+    /// egui-winit raises `Event::Paste` for every `command+V` press, Shift
+    /// included, so honoring it here would paste on Ctrl+V no matter what the
+    /// binding table says — and leave the shortcut impossible to rebind.
+    #[test]
+    fn paste_event_does_not_reach_the_terminal() {
+        assert!(consumed_event(&Event::Paste("hi".into())).is_none());
+    }
+
+    /// Alacritty sends SYN on Ctrl+V; paste is a Ctrl+Shift+V binding.
+    #[test]
+    fn ctrl_v_sends_the_control_byte() {
+        let press = Event::Key {
+            key: Key::V,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: Modifiers::CTRL,
+        };
+        assert!(
+            matches!(consumed_event(&press), Some(ConsumedEvent::Bytes(ref b)) if b == &vec![0x16]),
+            "Ctrl+V must reach the PTY as 0x16"
+        );
     }
 }

--- a/egui-winit/src/lib.rs
+++ b/egui-winit/src/lib.rs
@@ -773,15 +773,17 @@ impl State {
                 } else if is_copy_command(self.egui_input.modifiers, active_key) {
                     self.egui_input.events.push(egui::Event::Copy);
                 } else if is_paste_command(self.egui_input.modifiers, active_key) {
-                    // alacritree: fall through to Key event when the clipboard
-                    // had no text, so terminal apps still see raw 0x16.
                     if let Some(contents) = self.clipboard.get() {
                         let contents = contents.replace("\r\n", "\n");
                         if !contents.is_empty() {
                             self.egui_input.events.push(egui::Event::Paste(contents));
-                            return;
                         }
                     }
+                    // alacritree: fall through to the Key event as well, like
+                    // cut/copy above.  This command ignores Shift, so Ctrl+V and
+                    // Ctrl+Shift+V raise the same Paste event; without the
+                    // keystroke the binding table cannot tell them apart, and
+                    // terminal apps would never see raw 0x16.
                 }
             }
 


### PR DESCRIPTION
The paste half of #64: egui-winit turns any command+V press into a synthetic `Event::Paste` and returns before emitting the Key event. The check ignores Shift, so Ctrl+V and Ctrl+Shift+V collapse into the same event, and the terminal pasted on it unconditionally — Ctrl+V pasted, the Ctrl+Shift+V *binding* never ran, no config could rebind or unbind either, and Ctrl+V never reached the PTY as SYN the way alacritty sends it.

Falls through to the Key event as the cut/copy branches already do, and lets the terminal ignore `Event::Paste` — keyboard paste runs through `NamedAction::Paste`, which reads the clipboard itself. Text widgets outside the terminal still consume the event, so Ctrl+V keeps pasting into them.

**Merge order:** wave-1 item 9 of the submission plan (AbysmalBiscuit/alacritree#1); merge after #63 and #64 — it shares an `egui-winit` hunk with #64 and a `bindings.rs` tests block with #63. Happy to fold this into #64 if reviewing the two halves together is easier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
