### PR TITLE
[12] feat(mouse): report mouse events to mouse-mode apps

### DIFF
--- a/alacritree/src/input.rs
+++ b/alacritree/src/input.rs
@@ -17,7 +17,7 @@ pub fn event_to_bytes(event: &Event) -> Option<Vec<u8>> {
 
 fn key_to_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
     if mods.ctrl && !mods.alt {
-        if let Some(b) = ctrl_byte(key) {
+        if let Some(b) = control_byte(key, mods) {
             return Some(vec![b]);
         }
     }
@@ -63,41 +63,149 @@ fn key_to_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
     }
 }
 
-fn ctrl_byte(key: Key) -> Option<u8> {
-    let b = match key {
-        Key::A => 0x01,
-        Key::B => 0x02,
-        Key::C => 0x03,
-        Key::D => 0x04,
-        Key::E => 0x05,
-        Key::F => 0x06,
-        Key::G => 0x07,
-        Key::H => 0x08,
-        Key::I => 0x09,
-        Key::J => 0x0a,
-        Key::K => 0x0b,
-        Key::L => 0x0c,
-        Key::M => 0x0d,
-        Key::N => 0x0e,
-        Key::O => 0x0f,
-        Key::P => 0x10,
-        Key::Q => 0x11,
-        Key::R => 0x12,
-        Key::S => 0x13,
-        Key::T => 0x14,
-        Key::U => 0x15,
-        Key::V => 0x16,
-        Key::W => 0x17,
-        Key::X => 0x18,
-        Key::Y => 0x19,
-        Key::Z => 0x1a,
-        Key::OpenBracket => 0x1b,
-        Key::Backslash => 0x1c,
-        Key::CloseBracket => 0x1d,
-        Key::Space => 0x00,
+/// Character a printable key produces, as far as byte encoding is concerned.
+/// Letters honor `shift` for case; shifted punctuation already arrives as its
+/// own logical key in egui (`?`, `{`, `|`, …), so those map one-to-one.
+fn key_char(key: Key, shift: bool) -> Option<char> {
+    let c = match key {
+        Key::A => 'a',
+        Key::B => 'b',
+        Key::C => 'c',
+        Key::D => 'd',
+        Key::E => 'e',
+        Key::F => 'f',
+        Key::G => 'g',
+        Key::H => 'h',
+        Key::I => 'i',
+        Key::J => 'j',
+        Key::K => 'k',
+        Key::L => 'l',
+        Key::M => 'm',
+        Key::N => 'n',
+        Key::O => 'o',
+        Key::P => 'p',
+        Key::Q => 'q',
+        Key::R => 'r',
+        Key::S => 's',
+        Key::T => 't',
+        Key::U => 'u',
+        Key::V => 'v',
+        Key::W => 'w',
+        Key::X => 'x',
+        Key::Y => 'y',
+        Key::Z => 'z',
+        Key::Num0 => '0',
+        Key::Num1 => '1',
+        Key::Num2 => '2',
+        Key::Num3 => '3',
+        Key::Num4 => '4',
+        Key::Num5 => '5',
+        Key::Num6 => '6',
+        Key::Num7 => '7',
+        Key::Num8 => '8',
+        Key::Num9 => '9',
+        Key::Space => ' ',
+        Key::Minus => '-',
+        Key::Plus => '+',
+        Key::Equals => '=',
+        Key::Slash => '/',
+        Key::Questionmark => '?',
+        Key::Backslash => '\\',
+        Key::Pipe => '|',
+        Key::OpenBracket => '[',
+        Key::CloseBracket => ']',
+        Key::OpenCurlyBracket => '{',
+        Key::CloseCurlyBracket => '}',
+        Key::Semicolon => ';',
+        Key::Colon => ':',
+        Key::Comma => ',',
+        Key::Period => '.',
+        Key::Backtick => '`',
+        Key::Quote => '\'',
+        Key::Exclamationmark => '!',
         _ => return None,
     };
-    Some(b)
+    Some(if shift && c.is_ascii_alphabetic() { c.to_ascii_uppercase() } else { c })
+}
+
+/// xterm's legacy Ctrl encoding. Upstream alacritty receives these bytes
+/// pre-composed by winit as key text; egui reports only the logical key, so
+/// the byte is derived from the key's character here instead.
+fn control_byte(key: Key, mods: Modifiers) -> Option<u8> {
+    let c = key_char(key, false)?;
+    let byte = match c {
+        ' ' | '2' => 0x00,
+        'a'..='z' => c as u8 & 0x1f,
+        '[' => 0x1b,
+        '\\' => 0x1c,
+        ']' => 0x1d,
+        '6' => 0x1e,
+        '-' | '/' => 0x1f,
+        '?' => 0x7f,
+        _ => return None,
+    };
+    let _ = mods;
+    Some(byte)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use Modifiers as M;
+
+    // egui ships `Modifiers::NONE/CTRL/SHIFT/ALT` constants; combos are
+    // built with struct-update syntax inside test bodies.
+    fn ctrl_shift() -> Modifiers {
+        Modifiers { ctrl: true, shift: true, ..M::NONE }
+    }
+
+    #[test]
+    fn ctrl_slash_sends_unit_separator() {
+        assert_eq!(key_to_bytes(Key::Slash, M::CTRL), Some(vec![0x1f]));
+    }
+
+    #[test]
+    fn ctrl_letters_send_c0_bytes() {
+        assert_eq!(key_to_bytes(Key::A, M::CTRL), Some(vec![0x01]));
+        assert_eq!(key_to_bytes(Key::C, M::CTRL), Some(vec![0x03]));
+        assert_eq!(key_to_bytes(Key::Z, M::CTRL), Some(vec![0x1a]));
+        // Shift+Ctrl+letter sends the same byte as Ctrl+letter.
+        assert_eq!(key_to_bytes(Key::C, ctrl_shift()), Some(vec![0x03]));
+    }
+
+    #[test]
+    fn ctrl_punctuation_matches_xterm() {
+        assert_eq!(key_to_bytes(Key::Space, M::CTRL), Some(vec![0x00]));
+        assert_eq!(key_to_bytes(Key::Num2, M::CTRL), Some(vec![0x00]));
+        assert_eq!(key_to_bytes(Key::OpenBracket, M::CTRL), Some(vec![0x1b]));
+        assert_eq!(key_to_bytes(Key::Backslash, M::CTRL), Some(vec![0x1c]));
+        assert_eq!(key_to_bytes(Key::CloseBracket, M::CTRL), Some(vec![0x1d]));
+        assert_eq!(key_to_bytes(Key::Num6, M::CTRL), Some(vec![0x1e]));
+        assert_eq!(key_to_bytes(Key::Minus, M::CTRL), Some(vec![0x1f]));
+        assert_eq!(key_to_bytes(Key::Questionmark, M::CTRL), Some(vec![0x7f]));
+    }
+
+    #[test]
+    fn ctrl_unmapped_key_sends_nothing() {
+        assert_eq!(key_to_bytes(Key::Quote, M::CTRL), None);
+    }
+
+    #[test]
+    fn plain_named_keys_unchanged() {
+        assert_eq!(key_to_bytes(Key::ArrowUp, M::NONE), Some(b"\x1b[A".to_vec()));
+        assert_eq!(key_to_bytes(Key::Enter, M::NONE), Some(b"\r".to_vec()));
+        assert_eq!(key_to_bytes(Key::Tab, M::NONE), Some(b"\t".to_vec()));
+        assert_eq!(key_to_bytes(Key::Backspace, M::NONE), Some(b"\x7f".to_vec()));
+        assert_eq!(key_to_bytes(Key::F1, M::NONE), Some(b"\x1bOP".to_vec()));
+        assert_eq!(key_to_bytes(Key::F5, M::NONE), Some(b"\x1b[15~".to_vec()));
+    }
+
+    #[test]
+    fn text_event_passes_through() {
+        let ev = Event::Text("é".to_string());
+        assert_eq!(event_to_bytes(&ev), Some("é".as_bytes().to_vec()));
+    }
 }
 
 #[cfg(test)]

--- a/alacritree/src/input.rs
+++ b/alacritree/src/input.rs
@@ -16,13 +16,41 @@ pub fn event_to_bytes(event: &Event) -> Option<Vec<u8>> {
 }
 
 fn key_to_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
-    if mods.ctrl && !mods.alt {
-        if let Some(b) = control_byte(key, mods) {
-            return Some(vec![b]);
-        }
+    // Named keys never produce composed text, so every modifier combination
+    // is safe to encode.
+    if let Some(bytes) = named_key_bytes(key, mods) {
+        return Some(bytes);
     }
 
-    named_key_bytes(key, mods)
+    // winit reports AltGr as Ctrl+Alt.  A printable key carrying both must
+    // stay silent: the composed character arrives via `Event::Text`, and
+    // emitting bytes here too would double the input.
+    if mods.ctrl && mods.alt {
+        return None;
+    }
+
+    if mods.ctrl {
+        return control_byte(key, mods).map(|b| vec![b]);
+    }
+
+    // Plain Alt is meta only where no composed text follows the key event.
+    // Windows delivers no `Event::Text` alongside Alt+<printable>, so the
+    // ESC prefix is safe there. On macOS, Option composes characters
+    // (Option+B is "∫"), and on Linux xkb composes the plain character
+    // regardless of Alt — both arrive via `Event::Text`, so emitting bytes
+    // here as well would double the input. Matches upstream alacritty's
+    // macOS default (`option_as_alt = "None"`: Option composes, not meta).
+    #[cfg(windows)]
+    if mods.alt {
+        // Long-standing meta convention: Alt+char sends ESC + char.
+        let c = key_char(key, mods.shift)?;
+        let mut out = vec![0x1b];
+        let mut buf = [0u8; 4];
+        out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+        return Some(out);
+    }
+
+    None
 }
 
 /// xterm modifier parameter: `1 + (Shift=1 | Alt=2 | Ctrl=4)`, as an ASCII
@@ -175,10 +203,11 @@ fn key_char(key: Key, shift: bool) -> Option<char> {
 /// pre-composed by winit as key text; egui reports only the logical key, so
 /// the byte is derived from the key's character here instead.
 fn control_byte(key: Key, mods: Modifiers) -> Option<u8> {
-    let c = key_char(key, false)?;
+    let c = key_char(key, mods.shift)?;
     let byte = match c {
         ' ' | '2' => 0x00,
         'a'..='z' => c as u8 & 0x1f,
+        'A'..='Z' => c.to_ascii_lowercase() as u8 & 0x1f,
         '[' => 0x1b,
         '\\' => 0x1c,
         ']' => 0x1d,
@@ -187,7 +216,6 @@ fn control_byte(key: Key, mods: Modifiers) -> Option<u8> {
         '?' => 0x7f,
         _ => return None,
     };
-    let _ = mods;
     Some(byte)
 }
 
@@ -288,11 +316,37 @@ mod tests {
         let ctrl_alt = Modifiers { ctrl: true, alt: true, ..Modifiers::NONE };
         assert_eq!(key_to_bytes(Key::ArrowRight, ctrl_alt), Some(b"\x1b[1;7C".to_vec()));
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+    #[cfg(windows)]
+    #[test]
+    fn alt_printables_send_esc_prefixed_char() {
+        assert_eq!(key_to_bytes(Key::B, M::ALT), Some(b"\x1bb".to_vec()));
+        assert_eq!(
+            key_to_bytes(Key::B, Modifiers { alt: true, shift: true, ..Modifiers::NONE }),
+            Some(b"\x1bB".to_vec())
+        );
+        assert_eq!(key_to_bytes(Key::Period, M::ALT), Some(b"\x1b.".to_vec()));
+        assert_eq!(key_to_bytes(Key::Num1, M::ALT), Some(b"\x1b1".to_vec()));
+    }
+
+    /// Off Windows the composed character arrives via `Event::Text`, so the
+    /// key event itself must stay silent (see the cfg in `key_to_bytes`).
+    #[cfg(not(windows))]
+    #[test]
+    fn alt_printables_stay_silent_where_text_composes() {
+        assert_eq!(key_to_bytes(Key::B, M::ALT), None);
+        assert_eq!(key_to_bytes(Key::Period, M::ALT), None);
+    }
+
+    #[test]
+    fn ctrl_alt_printables_stay_silent_for_altgr() {
+        // winit reports AltGr as Ctrl+Alt; the composed character arrives via
+        // Event::Text, so emitting bytes here would double the input.
+        let ctrl_alt = Modifiers { ctrl: true, alt: true, ..Modifiers::NONE };
+        assert_eq!(key_to_bytes(Key::Q, ctrl_alt), None);
+        assert_eq!(key_to_bytes(Key::Num2, ctrl_alt), None);
+        assert_eq!(key_to_bytes(Key::OpenBracket, ctrl_alt), None);
+    }
 
     /// egui's clipboard commands ignore Shift, so Ctrl+Shift+C raises the same
     /// synthetic `Copy` as Ctrl+C.  Encoding it would send the interrupt on the

--- a/alacritree/src/input.rs
+++ b/alacritree/src/input.rs
@@ -22,45 +22,88 @@ fn key_to_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
         }
     }
 
-    let bytes: &[u8] = match key {
-        Key::Enter => b"\r",
-        Key::Tab => b"\t",
-        Key::Backspace => b"\x7f",
-        Key::Escape => b"\x1b",
-        Key::ArrowUp => b"\x1b[A",
-        Key::ArrowDown => b"\x1b[B",
-        Key::ArrowRight => b"\x1b[C",
-        Key::ArrowLeft => b"\x1b[D",
-        Key::Home => b"\x1b[H",
-        Key::End => b"\x1b[F",
-        Key::PageUp => b"\x1b[5~",
-        Key::PageDown => b"\x1b[6~",
-        Key::Insert => b"\x1b[2~",
-        Key::Delete => b"\x1b[3~",
-        Key::F1 => b"\x1bOP",
-        Key::F2 => b"\x1bOQ",
-        Key::F3 => b"\x1bOR",
-        Key::F4 => b"\x1bOS",
-        Key::F5 => b"\x1b[15~",
-        Key::F6 => b"\x1b[17~",
-        Key::F7 => b"\x1b[18~",
-        Key::F8 => b"\x1b[19~",
-        Key::F9 => b"\x1b[20~",
-        Key::F10 => b"\x1b[21~",
-        Key::F11 => b"\x1b[23~",
-        Key::F12 => b"\x1b[24~",
-        _ => return None,
+    named_key_bytes(key, mods)
+}
+
+/// xterm modifier parameter: `1 + (Shift=1 | Alt=2 | Ctrl=4)`, as an ASCII
+/// digit.  `None` when no encodable modifier is held, so callers can emit
+/// the shorter unmodified sequence.
+fn csi_modifier(mods: Modifiers) -> Option<u8> {
+    let m = (mods.shift as u8) | ((mods.alt as u8) << 1) | ((mods.ctrl as u8) << 2);
+    (m != 0).then_some(b'1' + m)
+}
+
+/// Encoding for keys that never produce composed text.  Because no
+/// `Event::Text` follows these, every modifier combination is safe to encode
+/// here — including Ctrl+Alt, which on printables must stay silent (AltGr).
+fn named_key_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
+    // Arrows/Home/End: `ESC [ <final>`, or `ESC [ 1 ; <m> <final>` modified.
+    let csi = |final_byte: u8| match csi_modifier(mods) {
+        Some(m) => vec![0x1b, b'[', b'1', b';', m, final_byte],
+        None => vec![0x1b, b'[', final_byte],
+    };
+    // F1-F4 are SS3 (`ESC O <f>`) unmodified but switch to CSI when modified.
+    let ss3 = |final_byte: u8| match csi_modifier(mods) {
+        Some(m) => vec![0x1b, b'[', b'1', b';', m, final_byte],
+        None => vec![0x1b, b'O', final_byte],
+    };
+    // Editing/function keys: `ESC [ <n> ~`, or `ESC [ <n> ; <m> ~` modified.
+    let tilde = |num: &[u8]| {
+        let mut v = vec![0x1b, b'['];
+        v.extend_from_slice(num);
+        if let Some(m) = csi_modifier(mods) {
+            v.push(b';');
+            v.push(m);
+        }
+        v.push(b'~');
+        v
     };
 
-    if mods.alt {
-        // Long-standing meta convention: Alt+key sends ESC + key.
-        let mut out = Vec::with_capacity(bytes.len() + 1);
-        out.push(0x1b);
-        out.extend_from_slice(bytes);
-        Some(out)
-    } else {
-        Some(bytes.to_vec())
-    }
+    let bytes = match key {
+        Key::ArrowUp => csi(b'A'),
+        Key::ArrowDown => csi(b'B'),
+        Key::ArrowRight => csi(b'C'),
+        Key::ArrowLeft => csi(b'D'),
+        Key::Home => csi(b'H'),
+        Key::End => csi(b'F'),
+        Key::Insert => tilde(b"2"),
+        Key::Delete => tilde(b"3"),
+        Key::PageUp => tilde(b"5"),
+        Key::PageDown => tilde(b"6"),
+        Key::F1 => ss3(b'P'),
+        Key::F2 => ss3(b'Q'),
+        Key::F3 => ss3(b'R'),
+        Key::F4 => ss3(b'S'),
+        Key::F5 => tilde(b"15"),
+        Key::F6 => tilde(b"17"),
+        Key::F7 => tilde(b"18"),
+        Key::F8 => tilde(b"19"),
+        Key::F9 => tilde(b"20"),
+        Key::F10 => tilde(b"21"),
+        Key::F11 => tilde(b"23"),
+        Key::F12 => tilde(b"24"),
+        Key::Tab if mods.shift => vec![0x1b, b'[', b'Z'],
+        Key::Enter | Key::Tab | Key::Backspace | Key::Escape => {
+            let base: &[u8] = match key {
+                Key::Enter => b"\r",
+                Key::Tab => b"\t",
+                Key::Backspace => b"\x7f",
+                Key::Escape => b"\x1b",
+                _ => unreachable!(),
+            };
+            if mods.alt {
+                // Long-standing meta convention: Alt+key sends ESC + key.
+                let mut out = Vec::with_capacity(base.len() + 1);
+                out.push(0x1b);
+                out.extend_from_slice(base);
+                out
+            } else {
+                base.to_vec()
+            }
+        },
+        _ => return None,
+    };
+    Some(bytes)
 }
 
 /// Character a printable key produces, as far as byte encoding is concerned.
@@ -205,6 +248,45 @@ mod tests {
     fn text_event_passes_through() {
         let ev = Event::Text("é".to_string());
         assert_eq!(event_to_bytes(&ev), Some("é".as_bytes().to_vec()));
+    }
+
+    #[test]
+    fn modified_arrows_and_nav_keys_use_csi_modifiers() {
+        assert_eq!(key_to_bytes(Key::ArrowRight, M::CTRL), Some(b"\x1b[1;5C".to_vec()));
+        assert_eq!(key_to_bytes(Key::ArrowLeft, M::ALT), Some(b"\x1b[1;3D".to_vec()));
+        assert_eq!(key_to_bytes(Key::ArrowUp, M::SHIFT), Some(b"\x1b[1;2A".to_vec()));
+        assert_eq!(
+            key_to_bytes(Key::Home, Modifiers { ctrl: true, shift: true, ..Modifiers::NONE }),
+            Some(b"\x1b[1;6H".to_vec())
+        );
+        assert_eq!(key_to_bytes(Key::Delete, M::SHIFT), Some(b"\x1b[3;2~".to_vec()));
+        assert_eq!(key_to_bytes(Key::PageUp, M::CTRL), Some(b"\x1b[5;5~".to_vec()));
+    }
+
+    #[test]
+    fn modified_function_keys() {
+        // Modified F1-F4 switch from SS3 to CSI form.
+        assert_eq!(key_to_bytes(Key::F1, M::SHIFT), Some(b"\x1b[1;2P".to_vec()));
+        assert_eq!(key_to_bytes(Key::F5, M::CTRL), Some(b"\x1b[15;5~".to_vec()));
+    }
+
+    #[test]
+    fn shift_tab_sends_backtab() {
+        assert_eq!(key_to_bytes(Key::Tab, M::SHIFT), Some(b"\x1b[Z".to_vec()));
+    }
+
+    #[test]
+    fn alt_on_simple_named_keys_prefixes_esc() {
+        assert_eq!(key_to_bytes(Key::Enter, M::ALT), Some(b"\x1b\r".to_vec()));
+        assert_eq!(key_to_bytes(Key::Backspace, M::ALT), Some(b"\x1b\x7f".to_vec()));
+    }
+
+    #[test]
+    fn ctrl_alt_on_named_keys_is_encoded_not_suppressed() {
+        // AltGr suppression applies to printables only; arrows never compose
+        // text, so Ctrl+Alt encodes as modifier 7.
+        let ctrl_alt = Modifiers { ctrl: true, alt: true, ..Modifiers::NONE };
+        assert_eq!(key_to_bytes(Key::ArrowRight, ctrl_alt), Some(b"\x1b[1;7C".to_vec()));
     }
 }
 

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -14,6 +14,7 @@ mod input;
 mod ipc;
 mod links;
 mod mcp;
+mod mouse;
 mod paste;
 mod pr_status;
 mod projects;

--- a/alacritree/src/mouse.rs
+++ b/alacritree/src/mouse.rs
@@ -1,38 +1,70 @@
 //! Mouse-report byte encodings, mirroring alacritty's `mouse_report` /
 //! `normal_mouse_report` / `sgr_mouse_report`.  Apps that enable mouse
-//! tracking (vim, htop, TUI agents) receive wheel events as button reports
-//! instead of scrollback movement.
+//! tracking (vim, htop, TUI agents) receive clicks, drags, and wheel ticks as
+//! button reports instead of the terminal handling them locally.
 
 use alacritty_terminal::index::Point;
 use alacritty_terminal::term::TermMode;
 use egui::Modifiers;
+
+pub const BUTTON_LEFT: u8 = 0;
+pub const BUTTON_MIDDLE: u8 = 1;
+pub const BUTTON_RIGHT: u8 = 2;
+
+/// Motion reports add 32 to the held button's code; `MOTION_NONE` is used for
+/// pointer movement with no button down (any-motion tracking).
+pub const MOTION_OFFSET: u8 = 32;
+pub const MOTION_NONE: u8 = 35;
 
 pub const WHEEL_UP: u8 = 64;
 pub const WHEEL_DOWN: u8 = 65;
 pub const WHEEL_LEFT: u8 = 66;
 pub const WHEEL_RIGHT: u8 = 67;
 
-/// Encode one wheel tick at `point` as a mouse report.  Returns `None` when
-/// the pointer is over scrollback history or past the coordinate range the
-/// active encoding can express.
-pub fn wheel_report(mode: TermMode, point: Point, button: u8, mods: Modifiers) -> Option<Vec<u8>> {
+/// xterm modifier bits for mouse reports: Shift +4, Alt +8, Ctrl +16.
+fn modifier_offset(mods: Modifiers) -> u8 {
+    (if mods.shift { 4 } else { 0 })
+        + (if mods.alt { 8 } else { 0 })
+        + (if mods.ctrl { 16 } else { 0 })
+}
+
+/// Encode a mouse button event at `point`.  `button` is the base code (0/1/2
+/// for left/middle/right, `+32` for motion, 64-67 for wheel).  Returns `None`
+/// when the pointer is over scrollback history or past the coordinate range the
+/// active encoding can express.  Mirrors alacritty's `mouse_report`: SGR keeps
+/// the button and marks release with a trailing `m`; the legacy encoding can't
+/// name the button on release, so it reports button 3.
+pub fn mouse_report(
+    mode: TermMode,
+    point: Point,
+    button: u8,
+    pressed: bool,
+    mods: Modifiers,
+) -> Option<Vec<u8>> {
     if point.line < 0 {
         return None;
     }
-
-    // xterm modifier bits for mouse reports: Shift +4, Alt +8, Ctrl +16.
-    let button = button
-        + if mods.shift { 4 } else { 0 }
-        + if mods.alt { 8 } else { 0 }
-        + if mods.ctrl { 16 } else { 0 };
+    let mods = modifier_offset(mods);
 
     if mode.contains(TermMode::SGR_MOUSE) {
-        // Wheel ticks are momentary, so only the press ('M') form is sent.
+        let suffix = if pressed { 'M' } else { 'm' };
         return Some(
-            format!("\x1b[<{};{};{}M", button, point.column.0 + 1, point.line.0 + 1).into_bytes(),
+            format!(
+                "\x1b[<{};{};{}{}",
+                button + mods,
+                point.column.0 + 1,
+                point.line.0 + 1,
+                suffix
+            )
+            .into_bytes(),
         );
     }
 
+    let code = if pressed { button + mods } else { 3 + mods };
+    normal_mouse_report(mode, point, code)
+}
+
+fn normal_mouse_report(mode: TermMode, point: Point, button: u8) -> Option<Vec<u8>> {
     let utf8 = mode.contains(TermMode::UTF8_MOUSE);
     let max_point = if utf8 { 2015 } else { 223 };
     if point.line.0 >= max_point || point.column.0 as i32 >= max_point {
@@ -56,6 +88,12 @@ pub fn wheel_report(mode: TermMode, point: Point, button: u8, mods: Modifiers) -
         msg.push(32 + 1 + point.line.0 as u8);
     }
     Some(msg)
+}
+
+/// Encode one wheel tick.  Wheel ticks are momentary, so they always report as
+/// a press.
+pub fn wheel_report(mode: TermMode, point: Point, button: u8, mods: Modifiers) -> Option<Vec<u8>> {
+    mouse_report(mode, point, button, true, mods)
 }
 
 #[cfg(test)]
@@ -125,6 +163,66 @@ mod tests {
         assert_eq!(
             wheel_report(TermMode::SGR_MOUSE, point(0, 0), WHEEL_RIGHT, Modifiers::NONE),
             Some(b"\x1b[<67;1;1M".to_vec())
+        );
+    }
+
+    #[test]
+    fn sgr_press_and_release_differ_only_by_suffix() {
+        assert_eq!(
+            mouse_report(TermMode::SGR_MOUSE, point(4, 2), BUTTON_LEFT, true, Modifiers::NONE),
+            Some(b"\x1b[<0;3;5M".to_vec())
+        );
+        assert_eq!(
+            mouse_report(TermMode::SGR_MOUSE, point(4, 2), BUTTON_LEFT, false, Modifiers::NONE),
+            Some(b"\x1b[<0;3;5m".to_vec())
+        );
+    }
+
+    #[test]
+    fn sgr_report_keeps_the_button_on_release() {
+        assert_eq!(
+            mouse_report(TermMode::SGR_MOUSE, point(0, 0), BUTTON_RIGHT, false, Modifiers::NONE),
+            Some(b"\x1b[<2;1;1m".to_vec())
+        );
+    }
+
+    #[test]
+    fn legacy_release_reports_button_three() {
+        assert_eq!(
+            mouse_report(TermMode::empty(), point(0, 0), BUTTON_RIGHT, false, Modifiers::NONE),
+            Some(vec![0x1b, b'[', b'M', 32 + 3, 33, 33])
+        );
+    }
+
+    #[test]
+    fn legacy_release_folds_modifiers_into_button_three() {
+        let mods = Modifiers { ctrl: true, ..Modifiers::NONE };
+        assert_eq!(
+            mouse_report(TermMode::empty(), point(0, 0), BUTTON_LEFT, false, mods),
+            Some(vec![0x1b, b'[', b'M', 32 + 3 + 16, 33, 33])
+        );
+    }
+
+    #[test]
+    fn motion_report_uses_the_dragged_button_code() {
+        // Left-drag = button 0 + 32.
+        assert_eq!(
+            mouse_report(
+                TermMode::SGR_MOUSE,
+                point(1, 1),
+                BUTTON_LEFT + MOTION_OFFSET,
+                true,
+                Modifiers::NONE
+            ),
+            Some(b"\x1b[<32;2;2M".to_vec())
+        );
+    }
+
+    #[test]
+    fn scrollback_position_is_not_reported_for_clicks() {
+        assert_eq!(
+            mouse_report(TermMode::SGR_MOUSE, point(-1, 0), BUTTON_LEFT, true, Modifiers::NONE),
+            None
         );
     }
 }

--- a/alacritree/src/mouse.rs
+++ b/alacritree/src/mouse.rs
@@ -1,0 +1,130 @@
+//! Mouse-report byte encodings, mirroring alacritty's `mouse_report` /
+//! `normal_mouse_report` / `sgr_mouse_report`.  Apps that enable mouse
+//! tracking (vim, htop, TUI agents) receive wheel events as button reports
+//! instead of scrollback movement.
+
+use alacritty_terminal::index::Point;
+use alacritty_terminal::term::TermMode;
+use egui::Modifiers;
+
+pub const WHEEL_UP: u8 = 64;
+pub const WHEEL_DOWN: u8 = 65;
+pub const WHEEL_LEFT: u8 = 66;
+pub const WHEEL_RIGHT: u8 = 67;
+
+/// Encode one wheel tick at `point` as a mouse report.  Returns `None` when
+/// the pointer is over scrollback history or past the coordinate range the
+/// active encoding can express.
+pub fn wheel_report(mode: TermMode, point: Point, button: u8, mods: Modifiers) -> Option<Vec<u8>> {
+    if point.line < 0 {
+        return None;
+    }
+
+    // xterm modifier bits for mouse reports: Shift +4, Alt +8, Ctrl +16.
+    let button = button
+        + if mods.shift { 4 } else { 0 }
+        + if mods.alt { 8 } else { 0 }
+        + if mods.ctrl { 16 } else { 0 };
+
+    if mode.contains(TermMode::SGR_MOUSE) {
+        // Wheel ticks are momentary, so only the press ('M') form is sent.
+        return Some(
+            format!("\x1b[<{};{};{}M", button, point.column.0 + 1, point.line.0 + 1).into_bytes(),
+        );
+    }
+
+    let utf8 = mode.contains(TermMode::UTF8_MOUSE);
+    let max_point = if utf8 { 2015 } else { 223 };
+    if point.line.0 >= max_point || point.column.0 as i32 >= max_point {
+        return None;
+    }
+
+    let mut msg = vec![0x1b, b'[', b'M', 32 + button];
+    let mouse_pos_encode = |pos: usize| {
+        let pos = 32 + 1 + pos;
+        [(0xC0 + pos / 64) as u8, (0x80 + (pos & 63)) as u8]
+    };
+
+    if utf8 && point.column.0 >= 95 {
+        msg.extend_from_slice(&mouse_pos_encode(point.column.0));
+    } else {
+        msg.push(32 + 1 + point.column.0 as u8);
+    }
+    if utf8 && point.line.0 >= 95 {
+        msg.extend_from_slice(&mouse_pos_encode(point.line.0 as usize));
+    } else {
+        msg.push(32 + 1 + point.line.0 as u8);
+    }
+    Some(msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use alacritty_terminal::index::{Column, Line, Point};
+
+    use super::*;
+
+    fn point(line: i32, col: usize) -> Point {
+        Point::new(Line(line), Column(col))
+    }
+
+    #[test]
+    fn sgr_wheel_report_uses_one_based_coordinates() {
+        assert_eq!(
+            wheel_report(TermMode::SGR_MOUSE, point(4, 2), WHEEL_UP, Modifiers::NONE),
+            Some(b"\x1b[<64;3;5M".to_vec())
+        );
+    }
+
+    #[test]
+    fn normal_wheel_report_offsets_by_32() {
+        assert_eq!(
+            wheel_report(TermMode::empty(), point(4, 2), WHEEL_DOWN, Modifiers::NONE),
+            Some(vec![0x1b, b'[', b'M', 32 + 65, 32 + 1 + 2, 32 + 1 + 4])
+        );
+    }
+
+    #[test]
+    fn modifiers_offset_the_button_code() {
+        // xterm modifier bits for mouse reports: Shift +4, Alt +8, Ctrl +16.
+        let mods = Modifiers { shift: true, ctrl: true, ..Modifiers::NONE };
+        assert_eq!(
+            wheel_report(TermMode::SGR_MOUSE, point(0, 0), WHEEL_UP, mods),
+            Some(b"\x1b[<84;1;1M".to_vec())
+        );
+    }
+
+    #[test]
+    fn scrollback_position_is_not_reported() {
+        assert_eq!(
+            wheel_report(TermMode::SGR_MOUSE, point(-1, 0), WHEEL_UP, Modifiers::NONE),
+            None
+        );
+    }
+
+    #[test]
+    fn normal_report_drops_out_of_range_coordinates() {
+        assert_eq!(wheel_report(TermMode::empty(), point(0, 230), WHEEL_UP, Modifiers::NONE), None);
+    }
+
+    #[test]
+    fn utf8_mouse_extends_the_coordinate_range() {
+        // Column 200 encodes as 32+1+200 = 233 → 0xC3 0xA9 (UTF-8-style pair).
+        assert_eq!(
+            wheel_report(TermMode::UTF8_MOUSE, point(0, 200), WHEEL_UP, Modifiers::NONE),
+            Some(vec![0x1b, b'[', b'M', 32 + 64, 0xC3, 0xA9, 32 + 1])
+        );
+    }
+
+    #[test]
+    fn wheel_left_right_codes() {
+        assert_eq!(
+            wheel_report(TermMode::SGR_MOUSE, point(0, 0), WHEEL_LEFT, Modifiers::NONE),
+            Some(b"\x1b[<66;1;1M".to_vec())
+        );
+        assert_eq!(
+            wheel_report(TermMode::SGR_MOUSE, point(0, 0), WHEEL_RIGHT, Modifiers::NONE),
+            Some(b"\x1b[<67;1;1M".to_vec())
+        );
+    }
+}

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use alacritty_terminal::event::{Event as TermEvent, EventListener, Notify, WindowSize};
 use alacritty_terminal::event_loop::{EventLoop, EventLoopSender, Msg, Notifier};
 use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::Point;
 use alacritty_terminal::sync::FairMutex;
 use alacritty_terminal::term::color::Colors;
 use alacritty_terminal::term::{ClipboardType, Config as TermConfig, Term};
@@ -93,6 +94,9 @@ pub struct Session {
     /// trackpad pixel-deltas accumulate into whole-line scrolls instead of
     /// being dropped when each frame's delta is smaller than a cell.
     pub accumulated_scroll: (f64, f64),
+    /// Last grid cell reported to a mouse-tracking app, so pointer motion emits
+    /// at most one report per cell crossed instead of one per pixel.
+    pub last_report_cell: Option<Point>,
     /// Shell pid spawned for this PTY.  Used to walk to the foreground
     /// process group when identifying which agent is running.  None on
     /// platforms where we don't yet capture it (Windows).
@@ -391,6 +395,7 @@ impl Session {
             events,
             needs_attention: false,
             accumulated_scroll: (0.0, 0.0),
+            last_report_cell: None,
             shell_pid,
             agent_cache: Cell::new(AgentCache::default()),
             notifier: Notifier(sender.clone()),

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -82,18 +82,27 @@ pub fn show(
     if hovered_link.is_some() {
         ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
     }
-    handle_selection(
-        ui,
-        &response,
-        session,
-        config,
-        rect,
-        cell_w,
-        cell_h,
-        cols,
-        rows,
-        hovered_link.as_ref(),
-    );
+    // Apps that negotiate mouse tracking want the raw button/motion stream, not
+    // local selection — matching alacritty, Shift is the escape hatch that still
+    // selects text while the app is in mouse mode.
+    let mouse_mode = session.term.lock().mode().intersects(TermMode::MOUSE_MODE);
+    let report_mouse = mouse_mode && !ui.input(|i| i.modifiers.shift);
+    if report_mouse {
+        handle_mouse_reporting(ui, session, rect, cell_w, cell_h, cols, rows);
+    } else {
+        handle_selection(
+            ui,
+            &response,
+            session,
+            config,
+            rect,
+            cell_w,
+            cell_h,
+            cols,
+            rows,
+            hovered_link.as_ref(),
+        );
+    }
     handle_wheel_scroll(ui, &response, session, config, rect, cell_w, cell_h, cols, rows);
     // Built-in renderer expects the *unadjusted* pixel cell size so it can
     // re-apply `font.offset` itself — passing `cell_w * ppp` (which already
@@ -292,6 +301,112 @@ fn handle_selection(
         }
         // Bare click outside an existing drag clears the selection, matching alacritty.
         session.term.lock().selection = None;
+    }
+}
+
+/// Forward raw button and motion events to a mouse-tracking app, mirroring
+/// alacritty's `on_mouse_press` / `on_mouse_release` / `mouse_moved`.  Presses
+/// and releases report the clicked cell; motion reports only when the pointer
+/// crosses into a new cell and the app opted into motion (any-motion) or drag
+/// tracking.  Events outside the grid are ignored so sidebar clicks don't leak.
+#[allow(clippy::too_many_arguments)]
+fn handle_mouse_reporting(
+    ui: &Ui,
+    session: &mut Session,
+    rect: Rect,
+    cell_w: f32,
+    cell_h: f32,
+    cols: usize,
+    rows: usize,
+) {
+    let mode = *session.term.lock().mode();
+    let motion_tracked = mode.intersects(TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG);
+
+    enum Raw {
+        Button { pos: Pos2, code: u8, pressed: bool, modifiers: Modifiers },
+        Motion { pos: Pos2, modifiers: Modifiers },
+    }
+
+    let (raws, held) = ui.input(|i| {
+        let held = if i.pointer.primary_down() {
+            Some(mouse::BUTTON_LEFT)
+        } else if i.pointer.middle_down() {
+            Some(mouse::BUTTON_MIDDLE)
+        } else if i.pointer.secondary_down() {
+            Some(mouse::BUTTON_RIGHT)
+        } else {
+            None
+        };
+        let motion_mods = i.modifiers;
+        let raws: Vec<Raw> = i
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                Event::PointerButton { pos, button, pressed, modifiers } => button_code(*button)
+                    .map(|code| Raw::Button {
+                        pos: *pos,
+                        code,
+                        pressed: *pressed,
+                        modifiers: *modifiers,
+                    }),
+                Event::PointerMoved(pos) if motion_tracked => {
+                    Some(Raw::Motion { pos: *pos, modifiers: motion_mods })
+                },
+                _ => None,
+            })
+            .collect();
+        (raws, held)
+    });
+
+    if raws.is_empty() {
+        return;
+    }
+
+    let display_offset = session.term.lock().grid().display_offset() as i32;
+    let mut bytes = Vec::new();
+    for raw in raws {
+        match raw {
+            Raw::Button { pos, code, pressed, modifiers } => {
+                if !rect.contains(pos) {
+                    continue;
+                }
+                let (point, _) = cell_at_pos(pos, rect, cell_w, cell_h, cols, rows, display_offset);
+                session.last_report_cell = Some(point);
+                if let Some(report) = mouse::mouse_report(mode, point, code, pressed, modifiers) {
+                    bytes.extend_from_slice(&report);
+                }
+            },
+            Raw::Motion { pos, modifiers } => {
+                if !rect.contains(pos) {
+                    continue;
+                }
+                let (point, _) = cell_at_pos(pos, rect, cell_w, cell_h, cols, rows, display_offset);
+                if session.last_report_cell == Some(point) {
+                    continue;
+                }
+                session.last_report_cell = Some(point);
+                let base = match held {
+                    Some(button) => button + mouse::MOTION_OFFSET,
+                    None if mode.contains(TermMode::MOUSE_MOTION) => mouse::MOTION_NONE,
+                    None => continue,
+                };
+                if let Some(report) = mouse::mouse_report(mode, point, base, true, modifiers) {
+                    bytes.extend_from_slice(&report);
+                }
+            },
+        }
+    }
+    if !bytes.is_empty() {
+        session.write(bytes);
+    }
+}
+
+fn button_code(button: PointerButton) -> Option<u8> {
+    match button {
+        PointerButton::Primary => Some(mouse::BUTTON_LEFT),
+        PointerButton::Middle => Some(mouse::BUTTON_MIDDLE),
+        PointerButton::Secondary => Some(mouse::BUTTON_RIGHT),
+        _ => None,
     }
 }
 

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -18,6 +18,7 @@ use crate::config::Config;
 use crate::fonts::{BOLD_FAMILY, BOLD_ITALIC_FAMILY, ITALIC_FAMILY};
 use crate::input::event_to_bytes;
 use crate::links::{self, Link};
+use crate::mouse;
 use crate::paste;
 use crate::session::{EventProxy, Session, TermSize};
 
@@ -93,7 +94,7 @@ pub fn show(
         rows,
         hovered_link.as_ref(),
     );
-    handle_wheel_scroll(ui, &response, session, config, cell_w, cell_h);
+    handle_wheel_scroll(ui, &response, session, config, rect, cell_w, cell_h, cols, rows);
     // Built-in renderer expects the *unadjusted* pixel cell size so it can
     // re-apply `font.offset` itself — passing `cell_w * ppp` (which already
     // includes the offset) would double-add it.  Descent is zero here: the
@@ -297,13 +298,17 @@ fn handle_selection(
 /// Mouse-wheel scrolling.  Mirrors alacritty's `scroll_terminal`: accumulate
 /// pixel deltas across frames, divide by cell height for whole-line steps,
 /// and route to the PTY or scrollback depending on terminal mode.
+#[allow(clippy::too_many_arguments)]
 fn handle_wheel_scroll(
     ui: &Ui,
     response: &Response,
     session: &mut Session,
     config: &Config,
+    rect: Rect,
     cell_w: f32,
     cell_h: f32,
+    cols: usize,
+    rows: usize,
 ) {
     if !response.hovered() {
         return;
@@ -320,6 +325,11 @@ fn handle_wheel_scroll(
     if wheels.is_empty() {
         return;
     }
+    // Mouse-tracking apps receive wheel reports addressed to the hovered cell.
+    let pointer_cell = ui.input(|i| i.pointer.hover_pos()).map(|pos| {
+        let display_offset = session.term.lock().grid().display_offset() as i32;
+        cell_at_pos(pos, rect, cell_w, cell_h, cols, rows, display_offset).0
+    });
     let cell_w_pt = cell_w as f64;
     let cell_h_pt = cell_h as f64;
     for (unit, delta, modifiers) in wheels {
@@ -331,10 +341,11 @@ fn handle_wheel_scroll(
                 delta.y as f64 * session.size.screen_lines as f64 * cell_h_pt,
             ),
         };
-        apply_scroll(session, config, dx_pt, dy_pt, cell_w_pt, cell_h_pt, modifiers);
+        apply_scroll(session, config, dx_pt, dy_pt, cell_w_pt, cell_h_pt, modifiers, pointer_cell);
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_scroll(
     session: &mut Session,
     config: &Config,
@@ -343,6 +354,7 @@ fn apply_scroll(
     cell_w_pt: f64,
     cell_h_pt: f64,
     modifiers: Modifiers,
+    pointer_cell: Option<Point>,
 ) {
     let mode = *session.term.lock().mode();
     let mouse_mode = mode.intersects(TermMode::MOUSE_MODE);
@@ -360,9 +372,26 @@ fn apply_scroll(
     let is_up = dy_pt > 0.0;
 
     if mouse_mode {
-        // CSI mouse-wheel reports (codes 64/65) aren't wired up yet; until they
-        // are we leave the wheel alone in mouse-tracking mode so apps that
-        // requested raw mouse input aren't fed garbled scrollback events.
+        // One button report per accumulated line/column tick, addressed to the
+        // hovered cell — alacritty's `scroll_terminal` in mouse mode.
+        if let Some(point) = pointer_cell {
+            let mut bytes = Vec::new();
+            let line_btn = if is_up { mouse::WHEEL_UP } else { mouse::WHEEL_DOWN };
+            for _ in 0..lines {
+                if let Some(report) = mouse::wheel_report(mode, point, line_btn, modifiers) {
+                    bytes.extend_from_slice(&report);
+                }
+            }
+            let column_btn = if dx_pt > 0.0 { mouse::WHEEL_LEFT } else { mouse::WHEEL_RIGHT };
+            for _ in 0..columns {
+                if let Some(report) = mouse::wheel_report(mode, point, column_btn, modifiers) {
+                    bytes.extend_from_slice(&report);
+                }
+            }
+            if !bytes.is_empty() {
+                session.write(bytes);
+            }
+        }
     } else if alt_alt_scroll && !modifiers.shift {
         // Alt-screen apps (vim/less/man) opted into ALTERNATE_SCROLL ask for
         // arrow keys instead of touching the scrollback (which doesn't exist


### PR DESCRIPTION
Apps that negotiate mouse tracking (vim, htop, lazygit) got no mouse input — wheel, click, drag, and motion all stayed local to the egui view. Three commits: wheel reports, button press/release/motion encoding, and click/drag routing. Shift remains the escape hatch that still selects text while the app owns the mouse, matching alacritty.

Merge order: after `[10] fix/key-encoding` — this branch contains its three commits; the effective diff is the last three. Independent of [11]. The conflicts currently shown resolve with a rebase when its turn comes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
