### PR TITLE
[13] fix(ime): route IME composition to the terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
  "xdg",
 ]

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 toml = { workspace = true }
 xdg = "3.0.0"
 home = "0.5.5"
+unicode-width = "0.2.0"
 fontdb = { version = "0.23", default-features = false, features = ["fontconfig", "memmap"] }
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
 png = "0.17"

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -140,6 +140,7 @@ pub struct AlacritreeApp {
     _ipc_socket: Option<ipc::SocketHandle>,
     /// Shared across sessions; auto-invalidated when cell size changes.
     builtin_glyphs: crate::builtin_font::BuiltinGlyphCache,
+    ime: crate::ime::Ime,
 }
 
 struct DeleteRequest {
@@ -239,6 +240,11 @@ impl AlacritreeApp {
         }
         cc.egui_ctx.set_style(style);
 
+        // Terminal IME hint — matches alacritty's set_ime_purpose.
+        cc.egui_ctx.send_viewport_cmd(egui::ViewportCommand::IMEPurpose(
+            egui::viewport::IMEPurpose::Terminal,
+        ));
+
         alacritty_terminal::tty::setup_env();
 
         // Before the first PTY spawn so children inherit ALACRITREE_SOCKET.
@@ -295,6 +301,7 @@ impl AlacritreeApp {
             ipc_rx,
             _ipc_socket: ipc_socket,
             builtin_glyphs: crate::builtin_font::BuiltinGlyphCache::new(),
+            ime: crate::ime::Ime::default(),
         };
 
         if let Err(e) = app.spawn_session(&cc.egui_ctx, None) {
@@ -2388,12 +2395,14 @@ impl eframe::App for AlacritreeApp {
                     return;
                 };
                 let session = &mut self.sessions[idx];
+                let ime = &mut self.ime;
                 let _ = terminal_view::show(
                     ui,
                     session,
                     &self.config,
                     !modal_open,
                     &mut self.builtin_glyphs,
+                    ime,
                 );
             });
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2345,7 +2345,10 @@ impl eframe::App for AlacritreeApp {
 
     fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
         let modal_open = self.is_modal_open();
-        if !modal_open {
+        // Keys pressed mid-composition drive the IME's candidate window,
+        // not the app — alacritty's key_input returns early the same way,
+        // above binding dispatch.
+        if !modal_open && self.ime.preedit().is_none() {
             self.handle_shortcuts(ctx);
         }
         self.process_notification_actions(ctx);

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2379,6 +2379,10 @@ impl eframe::App for AlacritreeApp {
                 self.show_tab_strip(ui);
 
                 if let Some(err) = self.last_error.as_deref() {
+                    // A preedit can only be finalized or cancelled by the terminal
+                    // view's event drain, so without a session view to run it the
+                    // preedit would go stale and keep shortcuts suppressed forever.
+                    self.ime.clear();
                     ui.label(
                         RichText::new(err)
                             .color(rgb_to_color32(self.config.palette.normal[1]))
@@ -2392,6 +2396,9 @@ impl eframe::App for AlacritreeApp {
                 }
 
                 let Some(idx) = self.active_session_index() else {
+                    // Same rationale as the last_error branch above: without an
+                    // active session view, no code path can advance the preedit.
+                    self.ime.clear();
                     ui.label(
                         RichText::new("no session — Ctrl+T to open one").color(theme.text_dim),
                     );

--- a/alacritree/src/ime.rs
+++ b/alacritree/src/ime.rs
@@ -1,0 +1,122 @@
+//! IME composition state.  Mirrors alacritty's `display::Ime`
+//! (alacritty/src/display/mod.rs) minus what egui makes unreachable:
+//! enablement is output-driven (`PlatformOutput::ime`), and egui-winit
+//! drops winit's preedit cursor offset, so the caret is always at the
+//! end of the composition.
+
+use egui::ImeEvent;
+
+use crate::session::SessionId;
+
+#[derive(Default)]
+pub struct Ime {
+    /// In-progress composition; `Some` suppresses key input to the PTY.
+    preedit: Option<String>,
+    /// Session the composition targets.  Composition belongs to the
+    /// window's focused terminal, so a session switch orphans it.
+    owner: Option<SessionId>,
+}
+
+impl Ime {
+    pub fn preedit(&self) -> Option<&str> {
+        self.preedit.as_deref()
+    }
+
+    /// Drop any active composition (focus loss; the IME's `Disabled`
+    /// event arrives only while we are still draining input).
+    pub fn clear(&mut self) {
+        self.preedit = None;
+    }
+
+    /// Point the composition at the currently shown session, dropping it
+    /// if the session changed mid-composition.
+    pub fn retarget(&mut self, session: SessionId) {
+        if self.owner != Some(session) {
+            self.preedit = None;
+            self.owner = Some(session);
+        }
+    }
+
+    /// Apply an IME event; returns text to write to the PTY on commit.
+    pub fn process(&mut self, event: &ImeEvent) -> Option<String> {
+        match event {
+            ImeEvent::Enabled | ImeEvent::Disabled => {
+                self.preedit = None;
+                None
+            },
+            ImeEvent::Preedit(text) => {
+                self.preedit = (!text.is_empty()).then(|| text.clone());
+                None
+            },
+            ImeEvent::Commit(text) => {
+                self.preedit = None;
+                // Confirming a composition can emit a bare newline commit
+                // on some platforms; egui's TextEdit ignores those, and a
+                // terminal must too or Enter doubles.
+                (!text.is_empty() && text != "\n" && text != "\r").then(|| text.clone())
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use egui::ImeEvent;
+
+    #[test]
+    fn preedit_tracks_composition() {
+        let mut ime = Ime::default();
+        assert_eq!(ime.process(&ImeEvent::Enabled), None);
+        assert_eq!(ime.process(&ImeEvent::Preedit("あ".into())), None);
+        assert_eq!(ime.preedit(), Some("あ"));
+        assert_eq!(ime.process(&ImeEvent::Preedit("あい".into())), None);
+        assert_eq!(ime.preedit(), Some("あい"));
+    }
+
+    #[test]
+    fn empty_preedit_clears() {
+        let mut ime = Ime::default();
+        ime.process(&ImeEvent::Preedit("あ".into()));
+        ime.process(&ImeEvent::Preedit(String::new()));
+        assert_eq!(ime.preedit(), None);
+    }
+
+    #[test]
+    fn commit_returns_text_and_clears_preedit() {
+        let mut ime = Ime::default();
+        ime.process(&ImeEvent::Preedit("あ".into()));
+        assert_eq!(ime.process(&ImeEvent::Commit("愛".into())), Some("愛".into()));
+        assert_eq!(ime.preedit(), None);
+    }
+
+    #[test]
+    fn bare_newline_and_empty_commits_are_dropped() {
+        let mut ime = Ime::default();
+        assert_eq!(ime.process(&ImeEvent::Commit("\n".into())), None);
+        assert_eq!(ime.process(&ImeEvent::Commit("\r".into())), None);
+        assert_eq!(ime.process(&ImeEvent::Commit(String::new())), None);
+    }
+
+    #[test]
+    fn enabled_and_disabled_clear_preedit() {
+        let mut ime = Ime::default();
+        ime.process(&ImeEvent::Preedit("あ".into()));
+        ime.process(&ImeEvent::Disabled);
+        assert_eq!(ime.preedit(), None);
+        ime.process(&ImeEvent::Preedit("い".into()));
+        ime.process(&ImeEvent::Enabled);
+        assert_eq!(ime.preedit(), None);
+    }
+
+    #[test]
+    fn retarget_clears_only_on_session_change() {
+        let mut ime = Ime::default();
+        ime.retarget(1);
+        ime.process(&ImeEvent::Preedit("あ".into()));
+        ime.retarget(1);
+        assert_eq!(ime.preedit(), Some("あ"));
+        ime.retarget(2);
+        assert_eq!(ime.preedit(), None);
+    }
+}

--- a/alacritree/src/ime.rs
+++ b/alacritree/src/ime.rs
@@ -5,6 +5,7 @@
 //! end of the composition.
 
 use egui::ImeEvent;
+use unicode_width::UnicodeWidthChar;
 
 use crate::session::SessionId;
 
@@ -57,6 +58,37 @@ impl Ime {
             },
         }
     }
+}
+
+/// Terminal cell width of one char.  Control/zero-width chars count 1 so a
+/// malformed preedit still advances and stays visible.
+pub fn char_cells(c: char) -> usize {
+    c.width().unwrap_or(1).max(1)
+}
+
+pub struct PreeditLayout<'a> {
+    pub start_col: usize,
+    pub visible: &'a str,
+    pub width: usize,
+}
+
+/// Where the preedit overlay sits on the grid.  Mirrors alacritty's
+/// `draw_ime_preview` placement rule: the *end* of the composition (where
+/// the caret is) stays visible — right-aligned against the grid edge when
+/// the cursor is too far right, truncated from the left (whole chars) when
+/// wider than the grid.
+pub fn preedit_layout(text: &str, cursor_col: usize, cols: usize) -> PreeditLayout<'_> {
+    let mut width: usize = text.chars().map(char_cells).sum();
+    let mut start_byte = 0;
+    let mut chars = text.char_indices();
+    while width > cols {
+        let Some((idx, c)) = chars.next() else { break };
+        width -= char_cells(c);
+        start_byte = idx + c.len_utf8();
+    }
+    let visible = &text[start_byte..];
+    let end = (cursor_col + width).min(cols);
+    PreeditLayout { start_col: end.saturating_sub(width), visible, width }
 }
 
 #[cfg(test)]
@@ -118,5 +150,40 @@ mod tests {
         assert_eq!(ime.preedit(), Some("あ"));
         ime.retarget(2);
         assert_eq!(ime.preedit(), None);
+    }
+
+    #[test]
+    fn layout_ascii_at_cursor() {
+        let l = preedit_layout("abc", 5, 80);
+        assert_eq!((l.start_col, l.visible, l.width), (5, "abc", 3));
+    }
+
+    #[test]
+    fn layout_wide_chars_take_two_cells() {
+        let l = preedit_layout("あい", 5, 80);
+        assert_eq!((l.start_col, l.visible, l.width), (5, "あい", 4));
+    }
+
+    #[test]
+    fn layout_right_aligns_at_grid_edge() {
+        // Cursor at col 78 of 80: a 4-cell preedit must end at the last
+        // column, so it starts at 76.
+        let l = preedit_layout("あい", 78, 80);
+        assert_eq!((l.start_col, l.width), (76, 4));
+    }
+
+    #[test]
+    fn layout_truncates_from_the_left_keeping_the_end() {
+        // 6 cells of text in a 4-column grid: the first wide char drops.
+        let l = preedit_layout("あいう", 0, 4);
+        assert_eq!((l.start_col, l.visible, l.width), (0, "いう", 4));
+    }
+
+    #[test]
+    fn layout_empty_and_degenerate_grid() {
+        let l = preedit_layout("", 3, 80);
+        assert_eq!((l.start_col, l.visible, l.width), (3, "", 0));
+        let l = preedit_layout("あ", 0, 0);
+        assert_eq!((l.visible, l.width), ("", 0));
     }
 }

--- a/alacritree/src/input.rs
+++ b/alacritree/src/input.rs
@@ -17,7 +17,7 @@ pub fn event_to_bytes(event: &Event) -> Option<Vec<u8>> {
 
 fn key_to_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
     if mods.ctrl && !mods.alt {
-        if let Some(b) = ctrl_byte(key) {
+        if let Some(b) = control_byte(key, mods) {
             return Some(vec![b]);
         }
     }
@@ -63,41 +63,149 @@ fn key_to_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
     }
 }
 
-fn ctrl_byte(key: Key) -> Option<u8> {
-    let b = match key {
-        Key::A => 0x01,
-        Key::B => 0x02,
-        Key::C => 0x03,
-        Key::D => 0x04,
-        Key::E => 0x05,
-        Key::F => 0x06,
-        Key::G => 0x07,
-        Key::H => 0x08,
-        Key::I => 0x09,
-        Key::J => 0x0a,
-        Key::K => 0x0b,
-        Key::L => 0x0c,
-        Key::M => 0x0d,
-        Key::N => 0x0e,
-        Key::O => 0x0f,
-        Key::P => 0x10,
-        Key::Q => 0x11,
-        Key::R => 0x12,
-        Key::S => 0x13,
-        Key::T => 0x14,
-        Key::U => 0x15,
-        Key::V => 0x16,
-        Key::W => 0x17,
-        Key::X => 0x18,
-        Key::Y => 0x19,
-        Key::Z => 0x1a,
-        Key::OpenBracket => 0x1b,
-        Key::Backslash => 0x1c,
-        Key::CloseBracket => 0x1d,
-        Key::Space => 0x00,
+/// Character a printable key produces, as far as byte encoding is concerned.
+/// Letters honor `shift` for case; shifted punctuation already arrives as its
+/// own logical key in egui (`?`, `{`, `|`, …), so those map one-to-one.
+fn key_char(key: Key, shift: bool) -> Option<char> {
+    let c = match key {
+        Key::A => 'a',
+        Key::B => 'b',
+        Key::C => 'c',
+        Key::D => 'd',
+        Key::E => 'e',
+        Key::F => 'f',
+        Key::G => 'g',
+        Key::H => 'h',
+        Key::I => 'i',
+        Key::J => 'j',
+        Key::K => 'k',
+        Key::L => 'l',
+        Key::M => 'm',
+        Key::N => 'n',
+        Key::O => 'o',
+        Key::P => 'p',
+        Key::Q => 'q',
+        Key::R => 'r',
+        Key::S => 's',
+        Key::T => 't',
+        Key::U => 'u',
+        Key::V => 'v',
+        Key::W => 'w',
+        Key::X => 'x',
+        Key::Y => 'y',
+        Key::Z => 'z',
+        Key::Num0 => '0',
+        Key::Num1 => '1',
+        Key::Num2 => '2',
+        Key::Num3 => '3',
+        Key::Num4 => '4',
+        Key::Num5 => '5',
+        Key::Num6 => '6',
+        Key::Num7 => '7',
+        Key::Num8 => '8',
+        Key::Num9 => '9',
+        Key::Space => ' ',
+        Key::Minus => '-',
+        Key::Plus => '+',
+        Key::Equals => '=',
+        Key::Slash => '/',
+        Key::Questionmark => '?',
+        Key::Backslash => '\\',
+        Key::Pipe => '|',
+        Key::OpenBracket => '[',
+        Key::CloseBracket => ']',
+        Key::OpenCurlyBracket => '{',
+        Key::CloseCurlyBracket => '}',
+        Key::Semicolon => ';',
+        Key::Colon => ':',
+        Key::Comma => ',',
+        Key::Period => '.',
+        Key::Backtick => '`',
+        Key::Quote => '\'',
+        Key::Exclamationmark => '!',
         _ => return None,
     };
-    Some(b)
+    Some(if shift && c.is_ascii_alphabetic() { c.to_ascii_uppercase() } else { c })
+}
+
+/// xterm's legacy Ctrl encoding. Upstream alacritty receives these bytes
+/// pre-composed by winit as key text; egui reports only the logical key, so
+/// the byte is derived from the key's character here instead.
+fn control_byte(key: Key, mods: Modifiers) -> Option<u8> {
+    let c = key_char(key, false)?;
+    let byte = match c {
+        ' ' | '2' => 0x00,
+        'a'..='z' => c as u8 & 0x1f,
+        '[' => 0x1b,
+        '\\' => 0x1c,
+        ']' => 0x1d,
+        '6' => 0x1e,
+        '-' | '/' => 0x1f,
+        '?' => 0x7f,
+        _ => return None,
+    };
+    let _ = mods;
+    Some(byte)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use Modifiers as M;
+
+    // egui ships `Modifiers::NONE/CTRL/SHIFT/ALT` constants; combos are
+    // built with struct-update syntax inside test bodies.
+    fn ctrl_shift() -> Modifiers {
+        Modifiers { ctrl: true, shift: true, ..M::NONE }
+    }
+
+    #[test]
+    fn ctrl_slash_sends_unit_separator() {
+        assert_eq!(key_to_bytes(Key::Slash, M::CTRL), Some(vec![0x1f]));
+    }
+
+    #[test]
+    fn ctrl_letters_send_c0_bytes() {
+        assert_eq!(key_to_bytes(Key::A, M::CTRL), Some(vec![0x01]));
+        assert_eq!(key_to_bytes(Key::C, M::CTRL), Some(vec![0x03]));
+        assert_eq!(key_to_bytes(Key::Z, M::CTRL), Some(vec![0x1a]));
+        // Shift+Ctrl+letter sends the same byte as Ctrl+letter.
+        assert_eq!(key_to_bytes(Key::C, ctrl_shift()), Some(vec![0x03]));
+    }
+
+    #[test]
+    fn ctrl_punctuation_matches_xterm() {
+        assert_eq!(key_to_bytes(Key::Space, M::CTRL), Some(vec![0x00]));
+        assert_eq!(key_to_bytes(Key::Num2, M::CTRL), Some(vec![0x00]));
+        assert_eq!(key_to_bytes(Key::OpenBracket, M::CTRL), Some(vec![0x1b]));
+        assert_eq!(key_to_bytes(Key::Backslash, M::CTRL), Some(vec![0x1c]));
+        assert_eq!(key_to_bytes(Key::CloseBracket, M::CTRL), Some(vec![0x1d]));
+        assert_eq!(key_to_bytes(Key::Num6, M::CTRL), Some(vec![0x1e]));
+        assert_eq!(key_to_bytes(Key::Minus, M::CTRL), Some(vec![0x1f]));
+        assert_eq!(key_to_bytes(Key::Questionmark, M::CTRL), Some(vec![0x7f]));
+    }
+
+    #[test]
+    fn ctrl_unmapped_key_sends_nothing() {
+        assert_eq!(key_to_bytes(Key::Quote, M::CTRL), None);
+    }
+
+    #[test]
+    fn plain_named_keys_unchanged() {
+        assert_eq!(key_to_bytes(Key::ArrowUp, M::NONE), Some(b"\x1b[A".to_vec()));
+        assert_eq!(key_to_bytes(Key::Enter, M::NONE), Some(b"\r".to_vec()));
+        assert_eq!(key_to_bytes(Key::Tab, M::NONE), Some(b"\t".to_vec()));
+        assert_eq!(key_to_bytes(Key::Backspace, M::NONE), Some(b"\x7f".to_vec()));
+        assert_eq!(key_to_bytes(Key::F1, M::NONE), Some(b"\x1bOP".to_vec()));
+        assert_eq!(key_to_bytes(Key::F5, M::NONE), Some(b"\x1b[15~".to_vec()));
+    }
+
+    #[test]
+    fn text_event_passes_through() {
+        let ev = Event::Text("é".to_string());
+        assert_eq!(event_to_bytes(&ev), Some("é".as_bytes().to_vec()));
+    }
 }
 
 #[cfg(test)]

--- a/alacritree/src/input.rs
+++ b/alacritree/src/input.rs
@@ -16,13 +16,41 @@ pub fn event_to_bytes(event: &Event) -> Option<Vec<u8>> {
 }
 
 fn key_to_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
-    if mods.ctrl && !mods.alt {
-        if let Some(b) = control_byte(key, mods) {
-            return Some(vec![b]);
-        }
+    // Named keys never produce composed text, so every modifier combination
+    // is safe to encode.
+    if let Some(bytes) = named_key_bytes(key, mods) {
+        return Some(bytes);
     }
 
-    named_key_bytes(key, mods)
+    // winit reports AltGr as Ctrl+Alt.  A printable key carrying both must
+    // stay silent: the composed character arrives via `Event::Text`, and
+    // emitting bytes here too would double the input.
+    if mods.ctrl && mods.alt {
+        return None;
+    }
+
+    if mods.ctrl {
+        return control_byte(key, mods).map(|b| vec![b]);
+    }
+
+    // Plain Alt is meta only where no composed text follows the key event.
+    // Windows delivers no `Event::Text` alongside Alt+<printable>, so the
+    // ESC prefix is safe there. On macOS, Option composes characters
+    // (Option+B is "∫"), and on Linux xkb composes the plain character
+    // regardless of Alt — both arrive via `Event::Text`, so emitting bytes
+    // here as well would double the input. Matches upstream alacritty's
+    // macOS default (`option_as_alt = "None"`: Option composes, not meta).
+    #[cfg(windows)]
+    if mods.alt {
+        // Long-standing meta convention: Alt+char sends ESC + char.
+        let c = key_char(key, mods.shift)?;
+        let mut out = vec![0x1b];
+        let mut buf = [0u8; 4];
+        out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+        return Some(out);
+    }
+
+    None
 }
 
 /// xterm modifier parameter: `1 + (Shift=1 | Alt=2 | Ctrl=4)`, as an ASCII
@@ -175,10 +203,11 @@ fn key_char(key: Key, shift: bool) -> Option<char> {
 /// pre-composed by winit as key text; egui reports only the logical key, so
 /// the byte is derived from the key's character here instead.
 fn control_byte(key: Key, mods: Modifiers) -> Option<u8> {
-    let c = key_char(key, false)?;
+    let c = key_char(key, mods.shift)?;
     let byte = match c {
         ' ' | '2' => 0x00,
         'a'..='z' => c as u8 & 0x1f,
+        'A'..='Z' => c.to_ascii_lowercase() as u8 & 0x1f,
         '[' => 0x1b,
         '\\' => 0x1c,
         ']' => 0x1d,
@@ -187,7 +216,6 @@ fn control_byte(key: Key, mods: Modifiers) -> Option<u8> {
         '?' => 0x7f,
         _ => return None,
     };
-    let _ = mods;
     Some(byte)
 }
 
@@ -288,11 +316,37 @@ mod tests {
         let ctrl_alt = Modifiers { ctrl: true, alt: true, ..Modifiers::NONE };
         assert_eq!(key_to_bytes(Key::ArrowRight, ctrl_alt), Some(b"\x1b[1;7C".to_vec()));
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+    #[cfg(windows)]
+    #[test]
+    fn alt_printables_send_esc_prefixed_char() {
+        assert_eq!(key_to_bytes(Key::B, M::ALT), Some(b"\x1bb".to_vec()));
+        assert_eq!(
+            key_to_bytes(Key::B, Modifiers { alt: true, shift: true, ..Modifiers::NONE }),
+            Some(b"\x1bB".to_vec())
+        );
+        assert_eq!(key_to_bytes(Key::Period, M::ALT), Some(b"\x1b.".to_vec()));
+        assert_eq!(key_to_bytes(Key::Num1, M::ALT), Some(b"\x1b1".to_vec()));
+    }
+
+    /// Off Windows the composed character arrives via `Event::Text`, so the
+    /// key event itself must stay silent (see the cfg in `key_to_bytes`).
+    #[cfg(not(windows))]
+    #[test]
+    fn alt_printables_stay_silent_where_text_composes() {
+        assert_eq!(key_to_bytes(Key::B, M::ALT), None);
+        assert_eq!(key_to_bytes(Key::Period, M::ALT), None);
+    }
+
+    #[test]
+    fn ctrl_alt_printables_stay_silent_for_altgr() {
+        // winit reports AltGr as Ctrl+Alt; the composed character arrives via
+        // Event::Text, so emitting bytes here would double the input.
+        let ctrl_alt = Modifiers { ctrl: true, alt: true, ..Modifiers::NONE };
+        assert_eq!(key_to_bytes(Key::Q, ctrl_alt), None);
+        assert_eq!(key_to_bytes(Key::Num2, ctrl_alt), None);
+        assert_eq!(key_to_bytes(Key::OpenBracket, ctrl_alt), None);
+    }
 
     /// egui's clipboard commands ignore Shift, so Ctrl+Shift+C raises the same
     /// synthetic `Copy` as Ctrl+C.  Encoding it would send the interrupt on the

--- a/alacritree/src/input.rs
+++ b/alacritree/src/input.rs
@@ -22,45 +22,88 @@ fn key_to_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
         }
     }
 
-    let bytes: &[u8] = match key {
-        Key::Enter => b"\r",
-        Key::Tab => b"\t",
-        Key::Backspace => b"\x7f",
-        Key::Escape => b"\x1b",
-        Key::ArrowUp => b"\x1b[A",
-        Key::ArrowDown => b"\x1b[B",
-        Key::ArrowRight => b"\x1b[C",
-        Key::ArrowLeft => b"\x1b[D",
-        Key::Home => b"\x1b[H",
-        Key::End => b"\x1b[F",
-        Key::PageUp => b"\x1b[5~",
-        Key::PageDown => b"\x1b[6~",
-        Key::Insert => b"\x1b[2~",
-        Key::Delete => b"\x1b[3~",
-        Key::F1 => b"\x1bOP",
-        Key::F2 => b"\x1bOQ",
-        Key::F3 => b"\x1bOR",
-        Key::F4 => b"\x1bOS",
-        Key::F5 => b"\x1b[15~",
-        Key::F6 => b"\x1b[17~",
-        Key::F7 => b"\x1b[18~",
-        Key::F8 => b"\x1b[19~",
-        Key::F9 => b"\x1b[20~",
-        Key::F10 => b"\x1b[21~",
-        Key::F11 => b"\x1b[23~",
-        Key::F12 => b"\x1b[24~",
-        _ => return None,
+    named_key_bytes(key, mods)
+}
+
+/// xterm modifier parameter: `1 + (Shift=1 | Alt=2 | Ctrl=4)`, as an ASCII
+/// digit.  `None` when no encodable modifier is held, so callers can emit
+/// the shorter unmodified sequence.
+fn csi_modifier(mods: Modifiers) -> Option<u8> {
+    let m = (mods.shift as u8) | ((mods.alt as u8) << 1) | ((mods.ctrl as u8) << 2);
+    (m != 0).then_some(b'1' + m)
+}
+
+/// Encoding for keys that never produce composed text.  Because no
+/// `Event::Text` follows these, every modifier combination is safe to encode
+/// here — including Ctrl+Alt, which on printables must stay silent (AltGr).
+fn named_key_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
+    // Arrows/Home/End: `ESC [ <final>`, or `ESC [ 1 ; <m> <final>` modified.
+    let csi = |final_byte: u8| match csi_modifier(mods) {
+        Some(m) => vec![0x1b, b'[', b'1', b';', m, final_byte],
+        None => vec![0x1b, b'[', final_byte],
+    };
+    // F1-F4 are SS3 (`ESC O <f>`) unmodified but switch to CSI when modified.
+    let ss3 = |final_byte: u8| match csi_modifier(mods) {
+        Some(m) => vec![0x1b, b'[', b'1', b';', m, final_byte],
+        None => vec![0x1b, b'O', final_byte],
+    };
+    // Editing/function keys: `ESC [ <n> ~`, or `ESC [ <n> ; <m> ~` modified.
+    let tilde = |num: &[u8]| {
+        let mut v = vec![0x1b, b'['];
+        v.extend_from_slice(num);
+        if let Some(m) = csi_modifier(mods) {
+            v.push(b';');
+            v.push(m);
+        }
+        v.push(b'~');
+        v
     };
 
-    if mods.alt {
-        // Long-standing meta convention: Alt+key sends ESC + key.
-        let mut out = Vec::with_capacity(bytes.len() + 1);
-        out.push(0x1b);
-        out.extend_from_slice(bytes);
-        Some(out)
-    } else {
-        Some(bytes.to_vec())
-    }
+    let bytes = match key {
+        Key::ArrowUp => csi(b'A'),
+        Key::ArrowDown => csi(b'B'),
+        Key::ArrowRight => csi(b'C'),
+        Key::ArrowLeft => csi(b'D'),
+        Key::Home => csi(b'H'),
+        Key::End => csi(b'F'),
+        Key::Insert => tilde(b"2"),
+        Key::Delete => tilde(b"3"),
+        Key::PageUp => tilde(b"5"),
+        Key::PageDown => tilde(b"6"),
+        Key::F1 => ss3(b'P'),
+        Key::F2 => ss3(b'Q'),
+        Key::F3 => ss3(b'R'),
+        Key::F4 => ss3(b'S'),
+        Key::F5 => tilde(b"15"),
+        Key::F6 => tilde(b"17"),
+        Key::F7 => tilde(b"18"),
+        Key::F8 => tilde(b"19"),
+        Key::F9 => tilde(b"20"),
+        Key::F10 => tilde(b"21"),
+        Key::F11 => tilde(b"23"),
+        Key::F12 => tilde(b"24"),
+        Key::Tab if mods.shift => vec![0x1b, b'[', b'Z'],
+        Key::Enter | Key::Tab | Key::Backspace | Key::Escape => {
+            let base: &[u8] = match key {
+                Key::Enter => b"\r",
+                Key::Tab => b"\t",
+                Key::Backspace => b"\x7f",
+                Key::Escape => b"\x1b",
+                _ => unreachable!(),
+            };
+            if mods.alt {
+                // Long-standing meta convention: Alt+key sends ESC + key.
+                let mut out = Vec::with_capacity(base.len() + 1);
+                out.push(0x1b);
+                out.extend_from_slice(base);
+                out
+            } else {
+                base.to_vec()
+            }
+        },
+        _ => return None,
+    };
+    Some(bytes)
 }
 
 /// Character a printable key produces, as far as byte encoding is concerned.
@@ -205,6 +248,45 @@ mod tests {
     fn text_event_passes_through() {
         let ev = Event::Text("é".to_string());
         assert_eq!(event_to_bytes(&ev), Some("é".as_bytes().to_vec()));
+    }
+
+    #[test]
+    fn modified_arrows_and_nav_keys_use_csi_modifiers() {
+        assert_eq!(key_to_bytes(Key::ArrowRight, M::CTRL), Some(b"\x1b[1;5C".to_vec()));
+        assert_eq!(key_to_bytes(Key::ArrowLeft, M::ALT), Some(b"\x1b[1;3D".to_vec()));
+        assert_eq!(key_to_bytes(Key::ArrowUp, M::SHIFT), Some(b"\x1b[1;2A".to_vec()));
+        assert_eq!(
+            key_to_bytes(Key::Home, Modifiers { ctrl: true, shift: true, ..Modifiers::NONE }),
+            Some(b"\x1b[1;6H".to_vec())
+        );
+        assert_eq!(key_to_bytes(Key::Delete, M::SHIFT), Some(b"\x1b[3;2~".to_vec()));
+        assert_eq!(key_to_bytes(Key::PageUp, M::CTRL), Some(b"\x1b[5;5~".to_vec()));
+    }
+
+    #[test]
+    fn modified_function_keys() {
+        // Modified F1-F4 switch from SS3 to CSI form.
+        assert_eq!(key_to_bytes(Key::F1, M::SHIFT), Some(b"\x1b[1;2P".to_vec()));
+        assert_eq!(key_to_bytes(Key::F5, M::CTRL), Some(b"\x1b[15;5~".to_vec()));
+    }
+
+    #[test]
+    fn shift_tab_sends_backtab() {
+        assert_eq!(key_to_bytes(Key::Tab, M::SHIFT), Some(b"\x1b[Z".to_vec()));
+    }
+
+    #[test]
+    fn alt_on_simple_named_keys_prefixes_esc() {
+        assert_eq!(key_to_bytes(Key::Enter, M::ALT), Some(b"\x1b\r".to_vec()));
+        assert_eq!(key_to_bytes(Key::Backspace, M::ALT), Some(b"\x1b\x7f".to_vec()));
+    }
+
+    #[test]
+    fn ctrl_alt_on_named_keys_is_encoded_not_suppressed() {
+        // AltGr suppression applies to printables only; arrows never compose
+        // text, so Ctrl+Alt encodes as modifier 7.
+        let ctrl_alt = Modifiers { ctrl: true, alt: true, ..Modifiers::NONE };
+        assert_eq!(key_to_bytes(Key::ArrowRight, ctrl_alt), Some(b"\x1b[1;7C".to_vec()));
     }
 }
 

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod doppler;
 mod fonts;
 mod git_status;
+mod ime;
 mod input;
 mod ipc;
 mod links;

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -146,7 +146,11 @@ pub fn show(
                 // While composing, candidate-window navigation
                 // (Space/Enter/arrows/Backspace/Escape) arrives as ordinary
                 // key events; none of it may reach the PTY.  Mirrors
-                // alacritty's early return in `key_input`.
+                // alacritty's early return in `key_input`. That early return
+                // also runs before alacritty dispatches keyboard-triggered
+                // clipboard paste, so a keyboard paste shortcut is likewise
+                // dropped while composing (alacritty/src/input/keyboard.rs,
+                // alacritty/src/input/mod.rs `key_input`).
                 _ if ime.preedit().is_some() => {},
                 ConsumedEvent::Bytes(bytes) => {
                     // Typing drops the selection and snaps back to the prompt
@@ -169,9 +173,34 @@ pub fn show(
             o.ime = Some(egui::output::IMEOutput { rect: caret, cursor_rect: caret });
         });
     } else {
+        // IMEs commonly auto-commit an in-progress composition when focus
+        // moves away (winit pairs the `Commit` with an immediate
+        // `Disabled`, both landing in the same event batch as the focus
+        // loss). If a composition was in progress, drain Ime events one
+        // more time so that commit still reaches the PTY instead of being
+        // silently discarded. An unfocused terminal with no composition in
+        // flight must never consume Ime events — they belong to whatever
+        // widget (e.g. a modal dialog's text field) is focused instead.
+        if ime.preedit().is_some() {
+            let events: Vec<ImeEvent> = ui.input(|i| {
+                i.events
+                    .iter()
+                    .filter_map(|e| match e {
+                        Event::Ime(ev) => Some(ev.clone()),
+                        _ => None,
+                    })
+                    .collect()
+            });
+            for ev in events {
+                if let Some(text) = ime.process(&ev) {
+                    paste::paste(session, &text, text.chars().count() > 1);
+                }
+            }
+        }
         // The IME's `Disabled` event arrives only while input is still
-        // drained; on focus loss it never lands, so drop the composition
-        // here or the painted preedit sticks.
+        // drained; a composition abandoned without any terminal Ime event
+        // (e.g. the OS cancels it outright) never sends one, so this is the
+        // backstop that drops the painted preedit either way.
         ime.clear();
     }
 

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -7,8 +7,8 @@ use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::term::search::Match;
 use alacritty_terminal::vte::ansi::{Color as AnsiColor, CursorShape};
 use egui::{
-    Color32, CursorIcon, Event, FontFamily, FontId, Modifiers, MouseWheelUnit, PointerButton, Pos2,
-    Rect, Response, Sense, Stroke, Ui, Vec2,
+    Color32, CursorIcon, Event, FontFamily, FontId, ImeEvent, Modifiers, MouseWheelUnit,
+    PointerButton, Pos2, Rect, Response, Sense, Stroke, Ui, Vec2,
 };
 
 use crate::builtin_font::{BuiltinGlyphCache, Metrics, is_builtin_glyph};
@@ -27,6 +27,7 @@ pub fn show(
     config: &Config,
     allow_focus: bool,
     builtin_glyphs: &mut BuiltinGlyphCache,
+    ime: &mut crate::ime::Ime,
 ) -> Response {
     let font_id = FontId::monospace(config.font.egui_size());
     let (cell_w_pt, cell_h_pt) = ui.ctx().fonts(|f| {
@@ -74,6 +75,7 @@ pub fn show(
     if allow_focus && !response.has_focus() {
         response.request_focus();
     }
+    ime.retarget(session.id);
 
     let painter = ui.painter_at(rect);
 
@@ -125,22 +127,52 @@ pub fn show(
             i.events
                 .iter()
                 .filter_map(|e| match e {
+                    Event::Ime(ev) => Some(ConsumedEvent::Ime(ev.clone())),
                     Event::Paste(s) => Some(ConsumedEvent::Paste(s.clone())),
                     _ => event_to_bytes(e).map(ConsumedEvent::Bytes),
                 })
                 .collect()
         });
-        if !consumed.is_empty() {
-            // Typing drops the selection and snaps back to the prompt so the
-            // user sees their input — matches alacritty's on_terminal_input_start.
-            paste::on_terminal_input_start(session);
-        }
         for event in consumed {
             match event {
-                ConsumedEvent::Bytes(bytes) => session.write(bytes),
+                ConsumedEvent::Ime(ev) => {
+                    if let Some(text) = ime.process(&ev) {
+                        // Mirrors alacritty: single-char commits skip
+                        // bracketed paste (event.rs "Don't use bracketed
+                        // paste for single char input").
+                        paste::paste(session, &text, text.chars().count() > 1);
+                    }
+                },
+                // While composing, candidate-window navigation
+                // (Space/Enter/arrows/Backspace/Escape) arrives as ordinary
+                // key events; none of it may reach the PTY.  Mirrors
+                // alacritty's early return in `key_input`.
+                _ if ime.preedit().is_some() => {},
+                ConsumedEvent::Bytes(bytes) => {
+                    // Typing drops the selection and snaps back to the prompt
+                    // so the user sees their input — matches alacritty's
+                    // on_terminal_input_start.
+                    paste::on_terminal_input_start(session);
+                    session.write(bytes);
+                },
                 ConsumedEvent::Paste(text) => paste::paste(session, &text, true),
             }
         }
+        // Setting `PlatformOutput::ime` is what makes egui-winit call
+        // `set_ime_allowed(true)` — without it the OS IME never engages.
+        // The rect drives `set_ime_cursor_area`, so the candidate window
+        // follows the caret like alacritty's `update_ime_position`
+        // (TextEdit passes its whole widget rect there, which for a
+        // fullscreen terminal would pin the popup to the window corner).
+        let caret = cursor_cell_rect(session, rect, cell_w, cell_h).unwrap_or(rect);
+        ui.ctx().output_mut(|o| {
+            o.ime = Some(egui::output::IMEOutput { rect: caret, cursor_rect: caret });
+        });
+    } else {
+        // The IME's `Disabled` event arrives only while input is still
+        // drained; on focus loss it never lands, so drop the composition
+        // here or the painted preedit sticks.
+        ime.clear();
     }
 
     response
@@ -440,6 +472,23 @@ fn cell_at_pos(
 enum ConsumedEvent {
     Bytes(Vec<u8>),
     Paste(String),
+    Ime(ImeEvent),
+}
+
+/// Viewport rect of the terminal cursor's cell; `None` while the cursor is
+/// scrolled out of view.
+fn cursor_cell_rect(session: &Session, rect: Rect, cell_w: f32, cell_h: f32) -> Option<Rect> {
+    let term = session.term.lock();
+    let grid = term.grid();
+    let cursor = grid.cursor.point;
+    let line = cursor.line.0 + grid.display_offset() as i32;
+    if line < 0 || line >= grid.screen_lines() as i32 {
+        return None;
+    }
+    Some(Rect::from_min_size(
+        Pos2::new(rect.min.x + cursor.column.0 as f32 * cell_w, rect.min.y + line as f32 * cell_h),
+        Vec2::new(cell_w, cell_h),
+    ))
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -120,7 +120,15 @@ pub fn show(
         builtin_glyphs,
         ui.ctx(),
         hovered_link.as_ref().map(|l| &l.bounds),
+        // The preedit overlay replaces the cursor while composing
+        // (alacritty hides it the same way, display/content.rs).
+        ime.preedit().is_some(),
     );
+
+    let preedit_caret = ime
+        .preedit()
+        .map(|p| p.to_owned())
+        .and_then(|p| paint_preedit(&painter, rect, session, config, &font_id, cell_w, cell_h, &p));
 
     if allow_focus && response.has_focus() {
         let consumed: Vec<ConsumedEvent> = ui.input(|i| {
@@ -168,7 +176,9 @@ pub fn show(
         // follows the caret like alacritty's `update_ime_position`
         // (TextEdit passes its whole widget rect there, which for a
         // fullscreen terminal would pin the popup to the window corner).
-        let caret = cursor_cell_rect(session, rect, cell_w, cell_h).unwrap_or(rect);
+        let caret = preedit_caret
+            .or_else(|| cursor_cell_rect(session, rect, cell_w, cell_h))
+            .unwrap_or(rect);
         ui.ctx().output_mut(|o| {
             o.ime = Some(egui::output::IMEOutput { rect: caret, cursor_rect: caret });
         });
@@ -551,6 +561,7 @@ fn paint_grid(
     builtin_glyphs: &mut BuiltinGlyphCache,
     ctx: &egui::Context,
     link_bounds: Option<&Match>,
+    cursor_hidden: bool,
 ) {
     let term = session.term.lock();
     let runtime_palette = term.colors();
@@ -619,7 +630,7 @@ fn paint_grid(
         }
     }
 
-    if cursor_visible_line >= 0 && cursor_visible_line < screen_lines {
+    if !cursor_hidden && cursor_visible_line >= 0 && cursor_visible_line < screen_lines {
         let cursor_shape = cursor_shape(&term);
         paint_cursor(
             painter,
@@ -846,6 +857,68 @@ fn paint_cursor(
             glyph_color,
         );
     }
+}
+
+/// Draw the in-progress IME composition at the cursor, mirroring alacritty's
+/// `draw_ime_preview`: default foreground on default background, underlined,
+/// with a beam caret after the last char (egui-winit drops the preedit
+/// cursor offset, so the caret can only sit at the end).  Returns the caret
+/// cell rect so the candidate window can follow it.
+#[allow(clippy::too_many_arguments)]
+fn paint_preedit(
+    painter: &egui::Painter,
+    rect: Rect,
+    session: &Session,
+    config: &Config,
+    font_id: &FontId,
+    cell_w: f32,
+    cell_h: f32,
+    preedit: &str,
+) -> Option<Rect> {
+    let (cursor_col, line, cols) = {
+        let term = session.term.lock();
+        let grid = term.grid();
+        let line = grid.cursor.point.line.0 + grid.display_offset() as i32;
+        if line < 0 || line >= grid.screen_lines() as i32 {
+            return None;
+        }
+        (grid.cursor.point.column.0, line, grid.columns())
+    };
+
+    let layout = crate::ime::preedit_layout(preedit, cursor_col, cols);
+    let fg = foreground(&config.palette);
+    let bg = background(&config.palette);
+    let y = rect.min.y + line as f32 * cell_h;
+    let x = rect.min.x + layout.start_col as f32 * cell_w;
+    let width_pt = layout.width as f32 * cell_w;
+
+    painter.rect_filled(Rect::from_min_size(Pos2::new(x, y), Vec2::new(width_pt, cell_h)), 0.0, bg);
+
+    let mut col = layout.start_col;
+    let mut buf = [0u8; 4];
+    for ch in layout.visible.chars() {
+        painter.text(
+            Pos2::new(rect.min.x + col as f32 * cell_w, y),
+            egui::Align2::LEFT_TOP,
+            ch.encode_utf8(&mut buf).to_string(),
+            font_id.clone(),
+            fg,
+        );
+        col += crate::ime::char_cells(ch);
+    }
+
+    let uy = y + cell_h - 1.5;
+    painter.line_segment([Pos2::new(x, uy), Pos2::new(x + width_pt, uy)], Stroke::new(1.0, fg));
+
+    // Beam caret on the cell the next char lands in, clamped to the grid.
+    let caret_col = (layout.start_col + layout.width).min(cols.saturating_sub(1));
+    let caret_x = rect.min.x + caret_col as f32 * cell_w;
+    painter.rect_filled(
+        Rect::from_min_size(Pos2::new(caret_x, y), Vec2::new(2.0, cell_h)),
+        0.0,
+        fg,
+    );
+    Some(Rect::from_min_size(Pos2::new(caret_x, y), Vec2::new(cell_w, cell_h)))
 }
 
 /// Place the cached pixel-space glyph into the cell.  alacritty positions


### PR DESCRIPTION
IME input (CJK composition, dead keys) end to end: enables IME and routes commits to the PTY, renders the preedit overlay at the cursor, finalizes a pending commit on focus loss, clears stale preedit, and suppresses shortcuts while composing — candidate-window navigation (Space/Enter/arrows) must not reach the PTY, mirroring alacritty's early return in `key_input`.

Merge order: after `[10] fix/key-encoding` — this branch contains its three commits; the effective diff is the seven IME commits. Independent of [11] and [12]. The conflicts currently shown resolve with a rebase when its turn comes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
