### PR TITLE
fix: repair the test build on master

### DIFF
--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -830,7 +830,7 @@ mod tests {
         crate::harden_dll_search_path();
 
         let start = Instant::now();
-        let mut session = Session::spawn_command(
+        let session = Session::spawn_command(
             egui::Context::default(),
             &Config::default(),
             std::env::current_dir().ok(),

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -383,7 +383,7 @@ fn copy_llm_configs(src_root: &Path, dst_root: &Path) -> usize {
 
 #[cfg(test)]
 #[cfg(windows)]
-mod tests {
+mod windows_tests {
     use super::*;
 
     #[test]

--- a/alacritree/src/wsl.rs
+++ b/alacritree/src/wsl.rs
@@ -167,6 +167,7 @@ pub struct WslDistro {
 }
 
 /// Docker/Rancher register utility distros the user never shells into.
+#[cfg(any(windows, test))]
 fn is_utility_distro(name: &str) -> bool {
     name.starts_with("docker-desktop") || name.starts_with("rancher-desktop")
 }
@@ -236,6 +237,7 @@ fn cli_distros() -> Vec<WslDistro> {
 /// `wsl -l -q` lists the default distro first.  Output is UTF-8 when
 /// WSL_UTF8=1 is honored (WSL 0.64.0+); older versions emit UTF-16LE,
 /// detected by the NUL bytes ASCII names acquire in that encoding.
+#[cfg(any(windows, test))]
 fn parse_distro_list(stdout: &[u8]) -> Vec<WslDistro> {
     let text = if stdout.contains(&0) {
         let units: Vec<u16> =


### PR DESCRIPTION
`cargo test -p alacritree` no longer compiles on master: #68 and #82 each landed a `mod tests` in `worktree.rs` (the cfg(windows) WSL path tests and the unconditional worktree tests), so the test target fails with E0428 on Windows. This renames the windows-only module to `windows_tests`.

Two warning fixes ride along:

- `wsl.rs`'s `is_utility_distro`/`parse_distro_list` are only called from `#[cfg(windows)]` code and the test module, so Linux builds warn dead_code since #81 — they're now gated `#[cfg(any(windows, test))]`.
- A needless `mut` in the console-probe test in `session.rs`.

Tested on Windows (242 passed) and Linux (222 passed); both build warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
