### PR TITLE
[27] feat(sidebar): add per-project display labels

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -149,6 +149,7 @@ pub struct AlacritreeApp {
     quit_dialog_open: bool,
     pending_delete: Option<DeleteRequest>,
     pending_create: Option<CreateState>,
+    pending_rename: Option<RenameState>,
     /// Worktrees already given a Doppler scope pass this app run, so opening
     /// more shells there doesn't re-invoke the doppler CLI.
     doppler_synced: HashSet<PathBuf>,
@@ -185,6 +186,14 @@ enum CreateState {
     Prompt { project_idx: usize, branch: String, error: Option<String> },
     Running { project_idx: usize, branch: String, steps: Vec<String>, rx: Receiver<Progress> },
     Done { project_idx: usize, steps: Vec<String>, result: Result<PathBuf, String> },
+}
+
+/// The rename dialog, keyed by root rather than index: an IPC `remove_project`
+/// can reorder `projects` while the modal is open.
+struct RenameState {
+    root: PathBuf,
+    /// Text being edited; seeded with the current display name.
+    label: String,
 }
 
 /// Which `git diff` flavor a sidebar click should open in delta.
@@ -305,6 +314,7 @@ impl AlacritreeApp {
                 };
                 project.expanded = p.expanded;
                 project.shell_override = p.shell.as_deref().and_then(wsl::ShellChoice::parse);
+                project.label = p.label.clone();
                 project
             })
             .collect();
@@ -335,6 +345,7 @@ impl AlacritreeApp {
             quit_dialog_open: false,
             pending_delete: None,
             pending_create: None,
+            pending_rename: None,
             doppler_synced: HashSet::new(),
             pending_session_close: None,
             notify_rx,
@@ -385,17 +396,40 @@ impl AlacritreeApp {
         let Some(p) = self.projects.iter().find(|p| &p.root == root) else {
             return;
         };
-        let (expanded, shell) =
-            (p.expanded, p.shell_override.as_ref().map(|c| c.to_state_string()));
+        let (expanded, shell, label) =
+            (p.expanded, p.shell_override.as_ref().map(|c| c.to_state_string()), p.label.clone());
         let root = root.to_path_buf();
         state::mutate(move |s| {
             if let Some(ps) = s.projects.iter_mut().find(|ps| ps.root == root) {
                 ps.expanded = expanded;
                 ps.shell = shell;
             } else {
-                s.projects.push(PersistedProject { root, expanded, shell });
+                s.projects.push(PersistedProject { root, expanded, shell, label });
             }
         });
+    }
+
+    fn persist_project_label(&self, root: &Path) {
+        let label = self.projects.iter().find(|p| p.root == *root).and_then(|p| p.label.clone());
+        let root = root.to_path_buf();
+        state::mutate(move |s| {
+            if let Some(p) = s.projects.iter_mut().find(|p| p.root == root) {
+                p.label = label;
+            }
+        });
+    }
+
+    /// Set or clear a project's display label and persist it.  Returns the
+    /// project's index so IPC can reply with its JSON.
+    fn rename_project(&mut self, root: &Path, label: Option<String>) -> Result<usize, String> {
+        let idx = self
+            .projects
+            .iter()
+            .position(|p| p.root == *root)
+            .ok_or_else(|| format!("{} is not a project in the sidebar", root.display()))?;
+        self.projects[idx].label = crate::projects::normalize_label(label);
+        self.persist_project_label(root);
+        Ok(idx)
     }
 
     /// Windows projects re-discover synchronously (git2, fast).  WSL
@@ -421,8 +455,9 @@ impl AlacritreeApp {
     }
 
     /// Adopt completed background discoveries.  Only worktrees and the
-    /// default branch are copied — `expanded` and the shell override are
-    /// user state that survives refreshes (mirrors `Project::refresh`).
+    /// default branch are copied — `expanded`, the shell override, and the
+    /// label are user state that survives refreshes (mirrors
+    /// `Project::refresh`).
     fn poll_project_refreshes(&mut self) {
         let projects = &mut self.projects;
         self.pending_project_refresh.retain(|root, rx| match rx.try_recv() {
@@ -728,6 +763,7 @@ impl AlacritreeApp {
             || self.pending_delete.is_some()
             || self.pending_create.is_some()
             || self.pending_session_close.is_some()
+            || self.pending_rename.is_some()
     }
 
     fn focus_sidebar(&mut self) {
@@ -1235,6 +1271,8 @@ impl AlacritreeApp {
         let profile_names: Vec<String> =
             self.config.profiles.iter().map(|p| p.name.clone()).collect();
         let mut shell_override_changed: Option<PathBuf> = None;
+        let mut label_cleared: Option<PathBuf> = None;
+        let mut rename_request: Option<RenameState> = None;
 
         let panel_resp = SidePanel::left("left_sidebar")
             .resizable(true)
@@ -1311,7 +1349,7 @@ impl AlacritreeApp {
                                 name_resp = Some(
                                     ui.add(
                                         egui::Label::new(
-                                            RichText::new(&project.name)
+                                            RichText::new(project.display_name())
                                                 .color(theme.text)
                                                 .strong()
                                                 .small(),
@@ -1358,13 +1396,27 @@ impl AlacritreeApp {
                             }
                         }
 
-                        // Right-click: choose which shell this project's
-                        // sessions use. Hidden entirely when there is nothing
-                        // to choose (no distros, no profiles) so minimal
-                        // setups see zero new UI.
-                        if !distros.is_empty() || !profile_names.is_empty() {
-                            if let Some(resp) = name_resp {
-                                resp.context_menu(|ui| {
+                        // Right-click: rename the project, and choose which
+                        // shell its sessions use.
+                        if let Some(resp) = name_resp {
+                            resp.context_menu(|ui| {
+                                if ui.button("Rename…").clicked() {
+                                    rename_request = Some(RenameState {
+                                        root: project.root.clone(),
+                                        label: project.display_name().to_string(),
+                                    });
+                                    ui.close_menu();
+                                }
+                                if project.label.is_some() && ui.button("Reset name").clicked() {
+                                    project.label = None;
+                                    label_cleared = Some(project.root.clone());
+                                    ui.close_menu();
+                                }
+                                // The shell picker is hidden when there is
+                                // nothing to choose (no distros, no profiles)
+                                // so minimal setups see only the rename.
+                                if !distros.is_empty() || !profile_names.is_empty() {
+                                    ui.separator();
                                     ui.label(
                                         RichText::new("Open in…").color(theme.text_muted).small(),
                                     );
@@ -1422,8 +1474,8 @@ impl AlacritreeApp {
                                             ui.close_menu();
                                         }
                                     }
-                                });
-                            }
+                                }
+                            });
                         }
 
                         if project.expanded {
@@ -1521,6 +1573,12 @@ impl AlacritreeApp {
         }
         if let Some(root) = shell_override_changed {
             self.persist_project(&root);
+        }
+        if let Some(root) = label_cleared {
+            self.persist_project_label(&root);
+        }
+        if rename_request.is_some() {
+            self.pending_rename = rename_request;
         }
         if home_clicked {
             self.activate_home(ctx);
@@ -2895,6 +2953,85 @@ impl AlacritreeApp {
         self.refresh_project(ctx, req.project_idx);
     }
 
+    fn show_rename_dialog(&mut self, ctx: &Context) {
+        let Some(RenameState { root, mut label }) = self.pending_rename.take() else {
+            return;
+        };
+        // The project can vanish under the modal (IPC remove_project);
+        // nothing is left to rename then.
+        let Some(dir_name) = self.projects.iter().find(|p| p.root == root).map(|p| p.name.clone())
+        else {
+            return;
+        };
+        let theme = self.theme;
+        let (cancel_via_key, confirm_via_key) = consume_modal_keys(ctx);
+        let frame = modal_frame(&theme);
+        let mut rename_clicked = false;
+        let mut cancelled = false;
+
+        let s = theme.ui_scale;
+        let modal = egui::Modal::new(egui::Id::new("alacritree_rename_dialog")).frame(frame).show(
+            ctx,
+            |ui| {
+                ui.set_width(380.0 * s);
+                ui.spacing_mut().item_spacing.y = 6.0 * s;
+                ui.label(RichText::new(format!("Rename `{dir_name}`")).color(theme.text).strong());
+                ui.label(
+                    RichText::new("Sidebar name only — the directory is untouched.")
+                        .color(theme.text_muted)
+                        .small(),
+                );
+                let input_id = egui::Id::new("alacritree_rename_input");
+                let edit = egui::TextEdit::singleline(&mut label)
+                    .id(input_id)
+                    .hint_text(dir_name.as_str())
+                    .desired_width(f32::INFINITY);
+                let resp = ui.add(edit);
+                focus_default(ui.ctx(), input_id);
+                if resp.lost_focus() && resp.ctx.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    rename_clicked = true;
+                }
+                ui.add_space(4.0 * s);
+                ui.horizontal(|ui| {
+                    ui.label(
+                        RichText::new("Enter to rename · Esc to cancel")
+                            .color(theme.text_muted)
+                            .small(),
+                    );
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui
+                            .add(
+                                egui::Button::new(RichText::new("Rename").color(theme.accent))
+                                    .frame(false),
+                            )
+                            .clicked()
+                        {
+                            rename_clicked = true;
+                        }
+                        if ui
+                            .add(
+                                egui::Button::new(RichText::new("Cancel").color(theme.text_dim))
+                                    .frame(false),
+                            )
+                            .clicked()
+                        {
+                            cancelled = true;
+                        }
+                    });
+                });
+            },
+        );
+
+        if cancel_via_key || cancelled || modal.should_close() {
+            return;
+        }
+        if confirm_via_key || rename_clicked {
+            let _ = self.rename_project(&root, Some(label));
+            return;
+        }
+        self.pending_rename = Some(RenameState { root, label });
+    }
+
     fn show_create_dialog(&mut self, ctx: &Context) {
         let Some(state) = self.pending_create.take() else {
             return;
@@ -2942,7 +3079,7 @@ impl AlacritreeApp {
     ) -> Option<CreateState> {
         let theme = self.theme;
         let danger = rgb_to_color32(self.config.palette.normal[1]);
-        let project_name = self.projects[project_idx].name.clone();
+        let project_name = self.projects[project_idx].display_name().to_string();
         let default_branch = self.projects[project_idx].default_branch.clone();
         let project_root = self.projects[project_idx].root.clone();
 
@@ -3046,7 +3183,7 @@ impl AlacritreeApp {
         steps: &[String],
     ) {
         let theme = self.theme;
-        let project_name = self.projects[project_idx].name.clone();
+        let project_name = self.projects[project_idx].display_name().to_string();
         let frame = modal_frame(&theme);
         let s = theme.ui_scale;
         let _ = egui::Modal::new(egui::Id::new("alacritree_create_dialog")).frame(frame).show(
@@ -3086,7 +3223,7 @@ impl AlacritreeApp {
         let theme = self.theme;
         let danger = rgb_to_color32(self.config.palette.normal[1]);
         let ok = rgb_to_color32(self.config.palette.normal[2]);
-        let project_name = self.projects[project_idx].name.clone();
+        let project_name = self.projects[project_idx].display_name().to_string();
         let frame = modal_frame(&theme);
         let mut close = false;
         let (cancel_via_key, confirm_via_key) = consume_modal_keys(ctx);
@@ -3303,6 +3440,10 @@ impl AlacritreeApp {
                     })?;
                 Ok(json!({ "removed": self.remove_project(idx) }))
             },
+            Req::RenameProject { root, label } => {
+                let idx = self.rename_project(&root, label)?;
+                Ok(project_json(&self.projects[idx]))
+            },
             // Dispatched on the IPC connection thread; never forwarded here.
             Req::GitStatus { .. } | Req::CreateWorktree { .. } => {
                 Err("request is handled off the UI thread".to_string())
@@ -3442,6 +3583,9 @@ impl eframe::App for AlacritreeApp {
         }
         if self.pending_session_close.is_some() {
             self.show_close_session_dialog(ctx);
+        }
+        if self.pending_rename.is_some() {
+            self.show_rename_dialog(ctx);
         }
         if self.quit_dialog_open {
             self.show_quit_dialog(ctx);

--- a/alacritree/src/cli/doctor.rs
+++ b/alacritree/src/cli/doctor.rs
@@ -644,7 +644,7 @@ mod tests {
         let path = dir.path().join("state.toml");
         let projects = roots
             .iter()
-            .map(|r| PersistedProject { root: r.clone(), expanded: true, shell: None })
+            .map(|r| PersistedProject { root: r.clone(), expanded: true, shell: None, label: None })
             .collect();
         state::save_to(&path, &PersistedState { projects, ..PersistedState::default() });
         path
@@ -658,6 +658,7 @@ mod tests {
             root: dir.path().join("repo"),
             expanded: true,
             shell: Some(shell.to_string()),
+            label: None,
         };
         let state = PersistedState { projects: vec![project], ..PersistedState::default() };
         state::save_to(&path, &state);

--- a/alacritree/src/cli/mod.rs
+++ b/alacritree/src/cli/mod.rs
@@ -88,6 +88,17 @@ enum ProjectCommand {
     Remove { root: PathBuf },
     /// Re-scan a project's worktrees and default branch.
     Refresh { root: PathBuf },
+    /// Set a project's display label.  Display only — the directory on disk
+    /// is untouched.
+    Rename {
+        root: PathBuf,
+        /// The new sidebar name.
+        #[arg(required_unless_present = "clear", conflicts_with = "clear")]
+        label: Option<String>,
+        /// Drop the label and show the directory name again.
+        #[arg(long)]
+        clear: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -209,6 +220,9 @@ fn to_request(command: Command) -> IpcRequest {
             ProjectCommand::Add { path } => IpcRequest::AddProject { path: absolute(path) },
             ProjectCommand::Remove { root } => IpcRequest::RemoveProject { root: absolute(root) },
             ProjectCommand::Refresh { root } => IpcRequest::RefreshProject { root: absolute(root) },
+            ProjectCommand::Rename { root, label, .. } => {
+                IpcRequest::RenameProject { root: absolute(root), label }
+            },
         },
         Command::Session { command } => match command {
             SessionCommand::List => IpcRequest::ListSessions,
@@ -296,6 +310,25 @@ mod tests {
             request_for(&["alacritree", "worktree", "create", ".", "topic"]),
             IpcRequest::CreateWorktree { branch, .. } if branch == "topic"
         ));
+        assert!(matches!(
+            request_for(&["alacritree", "project", "rename", ".", "Work"]),
+            IpcRequest::RenameProject { label: Some(label), .. } if label == "Work"
+        ));
+    }
+
+    /// Dropping a label takes an explicit `--clear`: a rename with no new name
+    /// is more likely a slip than a request, so it must not clear silently.
+    #[test]
+    fn rename_requires_a_label_or_an_explicit_clear() {
+        assert!(matches!(
+            request_for(&["alacritree", "project", "rename", ".", "--clear"]),
+            IpcRequest::RenameProject { label: None, .. }
+        ));
+        assert!(Cli::try_parse_from(["alacritree", "project", "rename", "."]).is_err());
+        assert!(
+            Cli::try_parse_from(["alacritree", "project", "rename", ".", "Work", "--clear"])
+                .is_err()
+        );
     }
 
     /// The shell hands us argv verbatim, so a user who writes `'ls\r'` sends a

--- a/alacritree/src/cli/offline.rs
+++ b/alacritree/src/cli/offline.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use serde_json::{Value, json};
 
 use crate::ipc::{IpcRequest, IpcResult};
-use crate::projects::{Project, project_json};
+use crate::projects::{self, Project, project_json};
 use crate::state::{self, PersistedProject, PersistedState};
 use crate::worktree::{self as wt, CreateRequest};
 use crate::{git_status, ipc};
@@ -38,6 +38,14 @@ fn handle_at(state_path: &Path, request: &IpcRequest) -> IpcResult {
         IpcRequest::RemoveProject { root } => {
             remove(state_path, root)?;
             Ok(json!({ "removed": root }))
+        },
+        IpcRequest::RenameProject { root, label } => {
+            rename(state_path, root, label.clone())?;
+            let renamed = discover_all(state_path)
+                .into_iter()
+                .find(|p| p.root == *root)
+                .ok_or_else(|| not_a_project(root))?;
+            Ok(project_json(&renamed))
         },
         // Nothing is cached without an app, so a refresh is just a fresh look —
         // but it still has to fail on a root the sidebar does not have, or it
@@ -68,7 +76,7 @@ fn add(state_path: &Path, path: &Path) -> Project {
     let root = path.to_path_buf();
     state::mutate_at(state_path, |s| {
         if !s.projects.iter().any(|p| p.root == root) {
-            s.projects.push(PersistedProject { root, expanded: true, shell: None });
+            s.projects.push(PersistedProject { root, expanded: true, shell: None, label: None });
         }
     });
     Project::discover(path.to_path_buf())
@@ -85,6 +93,22 @@ fn remove(state_path: &Path, root: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn rename(state_path: &Path, root: &Path, label: Option<String>) -> Result<(), String> {
+    // Same shape as `remove`: the existence check happens against the file
+    // because the mutation closure cannot fail.
+    if !state::load_from(state_path).projects.iter().any(|p| p.root == root) {
+        return Err(not_a_project(root));
+    }
+    let label = projects::normalize_label(label);
+    let root = root.to_path_buf();
+    state::mutate_at(state_path, move |s| {
+        if let Some(p) = s.projects.iter_mut().find(|p| p.root == root) {
+            p.label = label;
+        }
+    });
+    Ok(())
+}
+
 fn discover_all(state_path: &Path) -> Vec<Project> {
     let PersistedState { projects, .. } = state::load_from(state_path);
     projects
@@ -92,6 +116,7 @@ fn discover_all(state_path: &Path) -> Vec<Project> {
         .map(|p| {
             let mut project = Project::discover(p.root);
             project.expanded = p.expanded;
+            project.label = p.label;
             project
         })
         .collect()
@@ -179,6 +204,74 @@ mod tests {
         handle_at(&state, &IpcRequest::RemoveProject { root: project.clone() }).expect("remove");
 
         assert!(roots(&list_projects(&state)).is_empty());
+    }
+
+    fn rename_project(state_path: &Path, root: &Path, label: Option<&str>) -> IpcResult {
+        handle_at(
+            state_path,
+            &IpcRequest::RenameProject {
+                root: root.to_path_buf(),
+                label: label.map(str::to_string),
+            },
+        )
+    }
+
+    /// The label is display state in `state.toml`, so it must stick — and
+    /// persist — without a window.
+    #[test]
+    fn renaming_a_project_changes_its_listed_name() {
+        let dir = TempDir::new().unwrap();
+        let state = state_file(&dir);
+        let project = dir.path().join("repo");
+        std::fs::create_dir(&project).unwrap();
+        add_project(&state, &project).expect("add");
+
+        let renamed = rename_project(&state, &project, Some("Work")).expect("rename");
+        assert_eq!(renamed["name"], "Work");
+
+        assert_eq!(list_projects(&state)["projects"][0]["name"], "Work");
+    }
+
+    /// No label means back to the directory name — the same request clears,
+    /// so no second verb is needed anywhere on the surface.
+    #[test]
+    fn renaming_without_a_label_restores_the_directory_name() {
+        let dir = TempDir::new().unwrap();
+        let state = state_file(&dir);
+        let project = dir.path().join("repo");
+        std::fs::create_dir(&project).unwrap();
+        add_project(&state, &project).expect("add");
+        rename_project(&state, &project, Some("Work")).expect("rename");
+
+        let cleared = rename_project(&state, &project, None).expect("clear");
+
+        assert_eq!(cleared["name"], "repo");
+        assert_eq!(cleared["label"], Value::Null);
+    }
+
+    /// Whitespace is not a name; a blank label behaves like no label at all.
+    #[test]
+    fn a_blank_label_falls_back_to_the_directory_name() {
+        let dir = TempDir::new().unwrap();
+        let state = state_file(&dir);
+        let project = dir.path().join("repo");
+        std::fs::create_dir(&project).unwrap();
+        add_project(&state, &project).expect("add");
+
+        let renamed = rename_project(&state, &project, Some("   ")).expect("rename");
+
+        assert_eq!(renamed["name"], "repo");
+        assert_eq!(renamed["label"], Value::Null);
+    }
+
+    #[test]
+    fn renaming_an_unknown_project_is_an_error() {
+        let dir = TempDir::new().unwrap();
+        let state = state_file(&dir);
+
+        let result = rename_project(&state, &PathBuf::from("/nowhere"), Some("Work"));
+
+        assert!(result.is_err(), "renaming a project that was never added reported success");
     }
 
     /// A typo'd path must not report success; the caller has to learn the

--- a/alacritree/src/cli/render.rs
+++ b/alacritree/src/cli/render.rs
@@ -11,7 +11,9 @@ use crate::ipc::IpcRequest;
 pub fn human(request: &IpcRequest, value: &Value) {
     match request {
         IpcRequest::ListProjects => projects(value),
-        IpcRequest::AddProject { .. } | IpcRequest::RefreshProject { .. } => project(value),
+        IpcRequest::AddProject { .. }
+        | IpcRequest::RefreshProject { .. }
+        | IpcRequest::RenameProject { .. } => project(value),
         IpcRequest::RemoveProject { .. } => {
             println!("removed {}", text(&value["removed"]));
         },

--- a/alacritree/src/ipc.rs
+++ b/alacritree/src/ipc.rs
@@ -79,6 +79,11 @@ pub enum IpcRequest {
     RemoveProject {
         root: PathBuf,
     },
+    RenameProject {
+        root: PathBuf,
+        #[serde(default)]
+        label: Option<String>,
+    },
     GitStatus {
         path: PathBuf,
     },

--- a/alacritree/src/mcp.rs
+++ b/alacritree/src/mcp.rs
@@ -234,6 +234,18 @@ fn tool_definitions() -> Value {
             },
         },
         {
+            "name": "rename_project",
+            "description": "Set a project's display label in alacritree's sidebar. Display only — the directory on disk is untouched. Omit label (or pass an empty string) to restore the directory name.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "root": { "type": "string", "description": "Project root path from list_projects." },
+                    "label": { "type": "string", "description": "New sidebar name; omit to restore the directory name." },
+                },
+                "required": ["root"],
+            },
+        },
+        {
             "name": "remove_project",
             "description": "Remove a project from alacritree's sidebar. Only the sidebar entry is removed — no files, worktrees, or branches are touched. Sessions already open in its worktrees keep running.",
             "inputSchema": {
@@ -272,6 +284,7 @@ mod tests {
             IpcRequest::RefreshProject { root: repo() },
             IpcRequest::AddProject { path: repo() },
             IpcRequest::RemoveProject { root: repo() },
+            IpcRequest::RenameProject { root: repo(), label: None },
         ]
     }
 
@@ -289,6 +302,7 @@ mod tests {
             IpcRequest::RefreshProject { .. } => "refresh_project",
             IpcRequest::AddProject { .. } => "add_project",
             IpcRequest::RemoveProject { .. } => "remove_project",
+            IpcRequest::RenameProject { .. } => "rename_project",
         }
     }
 

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -10,7 +10,12 @@ use crate::wsl;
 #[derive(Debug, Clone)]
 pub struct Project {
     pub root: PathBuf,
+    /// Derived from the root's directory name; never stored.
     pub name: String,
+    /// User-set display label, shown instead of `name` when present.  Like
+    /// `expanded` and `shell_override`, this is user state: discovery never
+    /// sets it, and refreshes must not lose it.
+    pub label: Option<String>,
     pub default_branch: Option<String>,
     pub worktrees: Vec<Worktree>,
     pub expanded: bool,
@@ -60,6 +65,7 @@ impl Project {
             }],
             root,
             name,
+            label: None,
             default_branch: None,
             expanded: true,
             shell_override: None,
@@ -115,6 +121,7 @@ impl Project {
             worktrees,
             root,
             name,
+            label: None,
             expanded: true,
             shell_override: None,
         }
@@ -159,9 +166,16 @@ impl Project {
             worktrees,
             root,
             name,
+            label: None,
             expanded: true,
             shell_override: None,
         }
+    }
+
+    /// The sidebar name: the user's label when set, the directory name
+    /// otherwise.
+    pub fn display_name(&self) -> &str {
+        self.label.as_deref().unwrap_or(&self.name)
     }
 
     pub fn refresh(&mut self) {
@@ -175,7 +189,8 @@ impl Project {
 /// app-less path so a client cannot tell which one answered it.
 pub fn project_json(project: &Project) -> Value {
     json!({
-        "name": project.name,
+        "name": project.display_name(),
+        "label": project.label,
         "root": project.root,
         "default_branch": project.default_branch,
         "worktrees": project
@@ -247,6 +262,12 @@ fn detect_default_branch(repo: &Repository) -> Option<String> {
     }
 
     None
+}
+
+/// A label is user text: trimmed, with an empty result meaning "no label", so
+/// clearing the rename field falls back to the directory name.
+pub fn normalize_label(label: Option<String>) -> Option<String> {
+    label.map(|l| l.trim().to_string()).filter(|l| !l.is_empty())
 }
 
 fn display_name(root: &std::path::Path) -> String {
@@ -381,6 +402,30 @@ mod tests {
         let project = Project::discover(repo_dir);
         assert!(project.worktrees[0].is_main);
         assert!(!project.worktrees[0].prunable);
+    }
+
+    #[test]
+    fn the_label_overrides_the_directory_name_for_display() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_dir = tmp.path().join("repo");
+        init_repo(&repo_dir);
+
+        let mut project = Project::discover(repo_dir);
+        assert_eq!(project.display_name(), "repo");
+
+        project.label = Some("Work".to_string());
+        assert_eq!(project.display_name(), "Work");
+        let encoded = project_json(&project);
+        assert_eq!(encoded["name"], "Work");
+        assert_eq!(encoded["label"], "Work");
+    }
+
+    #[test]
+    fn a_blank_label_normalizes_to_none() {
+        assert_eq!(normalize_label(Some("  ".to_string())), None);
+        assert_eq!(normalize_label(Some(String::new())), None);
+        assert_eq!(normalize_label(Some(" Work ".to_string())), Some("Work".to_string()));
+        assert_eq!(normalize_label(None), None);
     }
 
     #[test]

--- a/alacritree/src/sidebar_nav.rs
+++ b/alacritree/src/sidebar_nav.rs
@@ -81,6 +81,7 @@ mod tests {
         Project {
             root: PathBuf::from(root),
             name: root.to_string(),
+            label: None,
             default_branch: None,
             worktrees: worktrees
                 .iter()

--- a/alacritree/src/state.rs
+++ b/alacritree/src/state.rs
@@ -37,6 +37,10 @@ pub struct PersistedProject {
     /// Absent = auto by project location.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shell: Option<String>,
+    /// Display label shown instead of the directory name.  Absent = derive
+    /// the name from the root, as before the field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -151,7 +155,7 @@ mod tests {
     use super::*;
 
     fn project(root: &str) -> PersistedProject {
-        PersistedProject { root: PathBuf::from(root), expanded: true, shell: None }
+        PersistedProject { root: PathBuf::from(root), expanded: true, shell: None, label: None }
     }
 
     fn state_file(dir: &TempDir) -> PathBuf {
@@ -280,11 +284,33 @@ mod tests {
                 root: PathBuf::from("C:/x"),
                 expanded: true,
                 shell: Some("wsl:kali-linux".to_string()),
+                label: None,
             }],
             ..Default::default()
         };
         let text = toml::to_string_pretty(&state).unwrap();
         let back: PersistedState = toml::from_str(&text).unwrap();
         assert_eq!(back.projects[0].shell.as_deref(), Some("wsl:kali-linux"));
+    }
+
+    #[test]
+    fn label_field_is_optional_and_round_trips() {
+        // Old state files (no `label`) still parse.
+        let old = "[[projects]]\nroot = 'C:/x'\n";
+        let state: PersistedState = toml::from_str(old).unwrap();
+        assert_eq!(state.projects[0].label, None);
+
+        let state = PersistedState {
+            projects: vec![PersistedProject {
+                root: PathBuf::from("C:/x"),
+                expanded: true,
+                shell: None,
+                label: Some("Work".to_string()),
+            }],
+            ..Default::default()
+        };
+        let text = toml::to_string_pretty(&state).unwrap();
+        let back: PersistedState = toml::from_str(&text).unwrap();
+        assert_eq!(back.projects[0].label.as_deref(), Some("Work"));
     }
 }


### PR DESCRIPTION
Item 27 of the submission plan (AbysmalBiscuit/alacritree#1) — the last two items now that the queue has merged.

The sidebar name is always derived from the root's directory name, so projects whose roots share a basename (worktree layouts, generic names like `app`) cannot be told apart. This stores an optional label in `state.toml` next to the shell override and shows it instead of the directory name when set. Like `expanded` and the shell override, the label is user state: discovery never sets it and refreshes preserve it. A new `rename_project` IPC request exposes it as an MCP tool and a `project rename` CLI command (`--clear` drops it, and works offline), and the project's right-click menu gains Rename…/Reset name backed by a prefilled modal. A blank label normalizes to none, falling back to the directory name.

Merge order: after the test-build fix PR (`fix/test-build`), whose commits this branch includes — its diff shrinks to one commit once that merges. Independent of item 26, but if item 26 merges first, this branch's rebase needs a one-line `label: None` added to `state_pinned_to` in `cli/doctor.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
