### PR TITLE
scoop: bump alacritree to v0.3.0

### DIFF
--- a/bucket/alacritree.json
+++ b/bucket/alacritree.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.11",
+    "version": "0.3.0",
     "description": "Alacritty fork with worktree-aware sidebars",
     "homepage": "https://github.com/mathix420/alacritree",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mathix420/alacritree/releases/download/v0.2.11/alacritree-v0.2.11-x86_64-windows.zip",
-            "hash": "2e94350fc05c179611f252ec5fff6dff41c7379cf8ec0693764290a31bb0cb3b"
+            "url": "https://github.com/mathix420/alacritree/releases/download/v0.3.0/alacritree-v0.3.0-x86_64-windows.zip",
+            "hash": "65c4c61ac116612c4c67f3e87ea5eee3bf50836b8c6ebffd84f3823958099a1d"
         }
     },
     "bin": "alacritree.exe",


### PR DESCRIPTION
Automated manifest bump triggered by the release of `v0.3.0`.