### PR TITLE
ci: scope clippy to the fork with --no-deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,10 @@ jobs:
       - name: Test
         run: cargo test -p alacritree --locked
 
+      # --no-deps keeps clippy on our own crate. The vendored alacritty_terminal
+      # is #![deny(clippy::all)], so a newer toolchain that adds a lint (e.g.
+      # question_mark) turns it into a hard error we can't fix without editing a
+      # read-only dependency. Linting the fork's code, not upstream's, is what we
+      # want anyway.
       - name: Clippy
-        run: cargo clippy -p alacritree --all-targets --locked
+        run: cargo clippy -p alacritree --all-targets --locked --no-deps


### PR DESCRIPTION
## Problem

CI's clippy step (`cargo clippy -p alacritree --all-targets --locked`) also lints the vendored `alacritty_terminal`, which is `#![deny(clippy::all)]`. When a GitHub runner image ships a **newer clippy** that adds a lint, that deny turns the new lint into a hard **error** on a crate we treat as read-only.

Concretely: the July 2026 `ubuntu-24.04` image (`20260714`) started flagging `clippy::question_mark` at `alacritty_terminal/src/tty/unix.rs:135/143/151`, failing CI. It's **non-deterministic** — a job that lands on the older image (`20260705`) still passes, so `master` is one runner-image roll away from going red for no code reason. (Surfaced on #89, whose job happened to land on the newer image.)

## Fix

Add `--no-deps` so clippy runs only on `alacritree` — the code this fork owns and the only code these lints should gate. No change to the vendored crate.

Verified locally: `cargo clippy -p alacritree --all-targets --locked --no-deps` finishes clean (skips `alacritty_terminal`, still lints alacritree). alacritree has no `deny(warnings)`, so its own stylistic lints stay non-fatal, matching current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)