### PR TITLE
fix(sidebar): stop the git panel from growing to fit long branch names

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1726,26 +1726,41 @@ impl AlacritreeApp {
                         .truncate(),
                     );
                     if let Some(branch) = &status.branch {
-                        ui.horizontal(|ui| {
-                            ui.label(RichText::new("on").color(theme.text_muted).small());
-                            ui.add(
-                                egui::Label::new(
-                                    RichText::new(branch).color(theme.accent).small().strong(),
-                                )
-                                .truncate(),
-                            );
-                            if let Some(default) = &status.default_branch {
-                                if Some(branch) != Some(default) {
-                                    ui.label(RichText::new("vs").color(theme.text_muted).small());
+                        // A greedy `truncate()` label in a plain `horizontal` row
+                        // consumes all the width, shoving any trailing widgets past
+                        // the panel edge. Since the right sidebar's `ScrollArea`
+                        // grows to fit its content, that overflow ratchets the whole
+                        // panel wider every frame until the full branch name fits.
+                        // Pin `vs <default>` to the right and let the current branch
+                        // truncate in the space that's left, so the row can't overflow.
+                        let default = status
+                            .default_branch
+                            .as_deref()
+                            .filter(|default| *default != branch.as_str());
+                        row_with_trailing(
+                            ui,
+                            |ui| {
+                                ui.label(RichText::new("on").color(theme.text_muted).small());
+                                ui.add(
+                                    egui::Label::new(
+                                        RichText::new(branch).color(theme.accent).small().strong(),
+                                    )
+                                    .truncate(),
+                                );
+                            },
+                            |ui| {
+                                if let Some(default) = default {
+                                    // right_to_left: default sits rightmost, `vs` to its left.
                                     ui.add(
                                         egui::Label::new(
                                             RichText::new(default).color(theme.text_dim).small(),
                                         )
                                         .truncate(),
                                     );
+                                    ui.label(RichText::new("vs").color(theme.text_muted).small());
                                 }
-                            }
-                        });
+                            },
+                        );
                     }
                     ui.add_space(10.0);
 


### PR DESCRIPTION
## Problem

The Git sidebar's minimum width was effectively much larger than the configured `min_width` of 220, so the panel could not be shrunk down. With a long worktree branch name it settled around 440px and got stuck there.

## Root cause

The `on <branch> vs <default>` line was a plain `ui.horizontal` row containing a greedy `Label::truncate()` for the branch name, followed by more widgets (`vs` + the base branch).

In egui, a truncating label consumes **all** available width, which shoves the trailing `vs …` widgets past the panel's right edge. Because the right sidebar's `ScrollArea` has no horizontal scrollbar, it grows to fit its content — so that overflow ratcheted the whole panel wider every frame until the entire branch name fit, then stuck at that width.

Confirmed with a minimal headless egui repro: the panel grew 332 → 440px and stabilized at 440. Isolating the rows showed the branch line was the culprit; a single truncate label (and the path line above it) correctly stayed at 300.

## Fix

Use the existing `row_with_trailing` helper — the same shape `branch_diff_row` already uses for this exact reason. It pins `vs <default>` to the right and lets the current branch truncate in the space that's left, so the greedy truncate label is the last widget in its sub-row and can never push anything off the edge.

## Verification

Headless egui repro, panel width after 10 frames (default width 300, `min_width` 220):

| case | before | after |
| --- | --- | --- |
| long branch vs master | 440 | **300** |
| branch == default | — | **300** |
| no default branch | — | **300** |
| pathological 70-char base branch | — | 327 (bounded, no ratchet) |

The path line above was already fine (single truncate label, directly in the scroll area) and is untouched. `cargo fmt` and `cargo check -p alacritree` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)