### PR TITLE
fix(windows): rename pinned exes aside for rebuilds and installs

### DIFF
--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -67,6 +67,11 @@ sysinfo = { version = "0.36", default-features = false, features = ["system"] }
 # approach) — no process spawn at startup, and it identifies the default.
 winreg = "0.55"
 
+[target.'cfg(windows)'.dev-dependencies]
+# Share-mode constants for tests that hold a file the way the loader holds a
+# running exe image: writes denied, rename allowed.
+windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }
+
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "3.0.2"
 

--- a/alacritree/build.rs
+++ b/alacritree/build.rs
@@ -27,8 +27,9 @@ fn main() {
     }
 }
 
-/// The linker writes `deps/alacritree-<hash>.exe` and cargo hardlinks
-/// `alacritree.exe` to it, so both names must be free before a relink.
+/// The linker writes `deps/alacritree-<hash>.exe` and cargo publishes it as
+/// `alacritree.exe` (a hardlink or a copy), so both names must be free
+/// before a relink.
 /// Best-effort throughout: a failed rename leaves the build to fail at link
 /// exactly as it would have anyway, plus a warning naming the culprit.
 #[cfg(windows)]

--- a/alacritree/build.rs
+++ b/alacritree/build.rs
@@ -1,9 +1,62 @@
 // Embeds the application icon into the Windows .exe so File Explorer, the
 // taskbar, and Scoop-generated shortcuts all show the proper icon instead of
-// the default executable glyph.
+// the default executable glyph.  Also frees target exes that running
+// alacritree processes pin: a mapped image cannot be overwritten, so linking
+// over it fails with "Access is denied" until the file is renamed aside.
+
+#[cfg(windows)]
+include!("src/stale_exe.rs");
+
 fn main() {
+    // embed_resource emits its own narrow rerun-if-changed directives, which
+    // would otherwise stop this script from running ahead of source-change
+    // relinks.  Directory-scoped directives keep the rename-aside in step
+    // with every build that writes a new exe.  (A dependency-only change
+    // relinks without a rerun — accepted: the vendored crates are effectively
+    // frozen in this fork.)
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=windows");
+
     #[cfg(windows)]
-    embed_resource::compile("./windows/alacritree.rc", embed_resource::NONE)
-        .manifest_optional()
-        .unwrap();
+    {
+        free_pinned_target_exes();
+        embed_resource::compile("./windows/alacritree.rc", embed_resource::NONE)
+            .manifest_optional()
+            .unwrap();
+    }
+}
+
+/// The linker writes `deps/alacritree-<hash>.exe` and cargo hardlinks
+/// `alacritree.exe` to it, so both names must be free before a relink.
+/// Best-effort throughout: a failed rename leaves the build to fail at link
+/// exactly as it would have anyway, plus a warning naming the culprit.
+#[cfg(windows)]
+fn free_pinned_target_exes() {
+    // OUT_DIR = <target>/<profile>/build/alacritree-<hash>/out
+    let Some(profile_dir) = std::env::var_os("OUT_DIR")
+        .map(PathBuf::from)
+        .and_then(|out| out.ancestors().nth(3).map(Path::to_path_buf))
+    else {
+        return;
+    };
+    let deps_dir = profile_dir.join("deps");
+    sweep_stale(&profile_dir);
+    sweep_stale(&deps_dir);
+
+    let mut candidates = vec![profile_dir.join("alacritree.exe")];
+    if let Ok(entries) = fs::read_dir(&deps_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with("alacritree") && name.ends_with(".exe") {
+                candidates.push(entry.path());
+            }
+        }
+    }
+    for exe in candidates {
+        if let Err(e) = rename_aside_if_locked(&exe) {
+            println!("cargo:warning=cannot move the pinned {} aside: {e}", exe.display());
+        }
+    }
 }

--- a/alacritree/src/cli/doctor.rs
+++ b/alacritree/src/cli/doctor.rs
@@ -100,6 +100,8 @@ fn report(socket: Option<&Path>) -> Vec<Check> {
     checks.extend(config_checks(&config::diagnose()));
     checks.extend(persisted_state_checks(&config));
     checks.extend(ipc_checks(socket, config.ipc_socket));
+    #[cfg(windows)]
+    checks.extend(process_checks(&running_alacritree_processes()));
     checks
 }
 
@@ -311,6 +313,67 @@ fn ipc_checks(socket: Option<&Path>, enabled: bool) -> Vec<Check> {
         },
     });
     checks
+}
+
+/// A live process running one of our binaries, and therefore pinning it.
+#[cfg(windows)]
+struct AlacritreeProcess {
+    pid: u32,
+    exe: Option<PathBuf>,
+    bridge: bool,
+}
+
+/// Running processes pin their exe images.  Builds and installs rename a
+/// pinned exe aside rather than fail, so a pin is not a fault and the rows
+/// are informational — but when a rename does fail (antivirus, a read-only
+/// volume), this section turns "Access is denied (os error 5)" into a pid
+/// worth closing.
+#[cfg(windows)]
+fn process_checks(processes: &[AlacritreeProcess]) -> Vec<Check> {
+    if processes.is_empty() {
+        let detail = "no running alacritree pins a binary";
+        return vec![check("processes", "images", Status::Ok, detail)];
+    }
+    processes
+        .iter()
+        .map(|p| {
+            let role = if p.bridge { "mcp bridge" } else { "window" };
+            let image = match &p.exe {
+                Some(exe) => exe.display().to_string(),
+                None => "an unreadable image path".to_string(),
+            };
+            let detail = format!("pid {} holds {image}", p.pid);
+            check("processes", role, Status::Ok, detail)
+        })
+        .collect()
+}
+
+#[cfg(windows)]
+fn running_alacritree_processes() -> Vec<AlacritreeProcess> {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing().with_exe(UpdateKind::Always).with_cmd(UpdateKind::Always),
+    );
+    let me = std::process::id();
+    let mut processes: Vec<AlacritreeProcess> = sys
+        .processes()
+        .iter()
+        // This doctor run is itself an alacritree process, but it exits with
+        // the report and pins nothing worth mentioning.
+        .filter(|(pid, _)| pid.as_u32() != me)
+        .filter(|(_, p)| p.name().to_string_lossy().to_lowercase().starts_with("alacritree"))
+        .map(|(pid, p)| AlacritreeProcess {
+            pid: pid.as_u32(),
+            exe: p.exe().map(Path::to_path_buf),
+            bridge: p.cmd().iter().any(|arg| arg == "mcp"),
+        })
+        .collect();
+    processes.sort_by_key(|p| p.pid);
+    processes
 }
 
 /// Resolve `program` the way the OS would: an explicit path as itself, a bare
@@ -827,5 +890,54 @@ mod tests {
 
         assert_eq!(to_json(&bad)["ok"], false);
         assert_eq!(to_json(&[check("a", "x", Status::Warn, "")])["ok"], true);
+    }
+
+    #[cfg(windows)]
+    fn alacritree_process(pid: u32, bridge: bool) -> AlacritreeProcess {
+        AlacritreeProcess {
+            pid,
+            exe: Some(PathBuf::from(r"C:\target\release\alacritree.exe")),
+            bridge,
+        }
+    }
+
+    /// A bridge lives as long as its MCP client, not as long as the window —
+    /// telling them apart tells the user which program to close.
+    #[cfg(windows)]
+    #[test]
+    fn a_bridge_and_a_window_are_told_apart() {
+        let checks = process_checks(&[alacritree_process(7, true), alacritree_process(8, false)]);
+
+        assert_eq!(names(&checks), vec!["mcp bridge", "window"]);
+    }
+
+    /// The row has to name the pid and the file, or the reader knows neither
+    /// what to close nor which file is pinned.  It stays `ok`, not `warn`:
+    /// builds and installs rename a pinned exe aside rather than fail, so a
+    /// running process is the normal state of a working machine — and a
+    /// report that always has a warning in it stops being read.
+    #[cfg(windows)]
+    #[test]
+    fn a_pinning_process_is_an_ok_row_naming_its_pid_and_image() {
+        let checks = process_checks(&[alacritree_process(4242, true)]);
+
+        assert_eq!(checks[0].status, Status::Ok);
+        assert!(checks[0].detail.contains("4242"), "{:?} lacks the pid", checks[0].detail);
+        assert!(
+            checks[0].detail.contains(r"release\alacritree.exe"),
+            "{:?} lacks the image",
+            checks[0].detail
+        );
+    }
+
+    /// Most doctor runs happen with nothing running; that is a clean bill of
+    /// health worth stating, not a section to omit.
+    #[cfg(windows)]
+    #[test]
+    fn no_processes_is_a_clean_ok_row() {
+        let checks = process_checks(&[]);
+
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, Status::Ok);
     }
 }

--- a/alacritree/src/cli/install.rs
+++ b/alacritree/src/cli/install.rs
@@ -14,8 +14,9 @@ use std::path::{Path, PathBuf};
 use crate::stale_exe;
 
 pub fn run(dest: Option<PathBuf>, as_json: bool) -> i32 {
-    let installed = destination(dest).and_then(|dir| {
-        install_file(&std::env::current_exe()?, &dir)
+    let installed = std::env::current_exe().and_then(|source| {
+        let dir = destination(dest)?;
+        install_file(&source, &dir)
             .map_err(|e| io::Error::other(format!("installing into {}: {e}", dir.display())))
     });
     match installed {
@@ -56,9 +57,17 @@ fn install_file(source: &Path, dir: &Path) -> io::Result<Installed> {
     fs::create_dir_all(dir)?;
     stale_exe::sweep_stale(dir);
     let target = dir.join(format!("alacritree{}", std::env::consts::EXE_SUFFIX));
-    let renamed_aside = stale_exe::rename_aside_if_locked(&target)?;
+    // The source may be the target itself — a self-install from the installed
+    // binary — so the copy must land before the target's name is freed.
     let temp = dir.join(format!("alacritree{}{}", stale_exe::TEMP_MARKER, std::process::id()));
     fs::copy(source, &temp)?;
+    let renamed_aside = match stale_exe::rename_aside_if_locked(&target) {
+        Ok(moved) => moved,
+        Err(e) => {
+            let _ = fs::remove_file(&temp);
+            return Err(e);
+        },
+    };
     if let Err(e) = fs::rename(&temp, &target) {
         let _ = fs::remove_file(&temp);
         return Err(e);
@@ -169,5 +178,25 @@ mod tests {
         let dest = destination(None).unwrap();
 
         assert!(dest.ends_with(Path::new(".local").join("bin")), "{}", dest.display());
+    }
+
+    /// `alacritree install` run from the installed binary itself: the source
+    /// IS the target, and the process holds it.  The copy must land in the
+    /// temp file before the target's name is freed, or a self-install deletes
+    /// the very binary it is installing.
+    #[cfg(windows)]
+    #[test]
+    fn a_self_install_survives_the_source_being_the_target() {
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path().join("bin");
+        fs::create_dir_all(&dest).unwrap();
+        let target = target_in(&dest);
+        fs::write(&target, "v1").unwrap();
+        let _running = crate::test_util::hold_like_a_running_image(&target);
+
+        let installed = install_file(&target, &dest).unwrap();
+
+        assert_eq!(fs::read_to_string(&installed.target).unwrap(), "v1");
+        assert!(installed.renamed_aside.is_some(), "the held image was moved aside");
     }
 }

--- a/alacritree/src/cli/install.rs
+++ b/alacritree/src/cli/install.rs
@@ -1,0 +1,173 @@
+//! `alacritree install` — copy the running binary into a bin directory.
+//!
+//! Reading a running image is always allowed, so the source is simply
+//! `current_exe()`.  What may be pinned is the *destination*: a window or MCP
+//! bridge still running from an earlier install.  Its image cannot be
+//! overwritten, but it can be renamed — the running process keeps working
+//! from the renamed file, and a later install sweeps it once the process has
+//! exited.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::stale_exe;
+
+pub fn run(dest: Option<PathBuf>, as_json: bool) -> i32 {
+    let installed = destination(dest).and_then(|dir| {
+        install_file(&std::env::current_exe()?, &dir)
+            .map_err(|e| io::Error::other(format!("installing into {}: {e}", dir.display())))
+    });
+    match installed {
+        Ok(installed) => {
+            report(&installed, as_json);
+            0
+        },
+        // In JSON mode the error goes to stdout as JSON too, matching how the
+        // IPC-backed commands behave.
+        Err(e) if as_json => {
+            println!("{:#}", serde_json::json!({ "error": e.to_string() }));
+            1
+        },
+        Err(e) => {
+            eprintln!("alacritree: {e}");
+            1
+        },
+    }
+}
+
+struct Installed {
+    target: PathBuf,
+    renamed_aside: Option<PathBuf>,
+}
+
+fn destination(dest: Option<PathBuf>) -> io::Result<PathBuf> {
+    match dest {
+        Some(dir) => Ok(dir),
+        None => home::home_dir()
+            .map(|home| home.join(".local").join("bin"))
+            .ok_or_else(|| io::Error::other("no home directory — pass --dest")),
+    }
+}
+
+/// The target name never points at a partial file: the copy lands under a
+/// temp name and takes the target name in one rename.
+fn install_file(source: &Path, dir: &Path) -> io::Result<Installed> {
+    fs::create_dir_all(dir)?;
+    stale_exe::sweep_stale(dir);
+    let target = dir.join(format!("alacritree{}", std::env::consts::EXE_SUFFIX));
+    let renamed_aside = stale_exe::rename_aside_if_locked(&target)?;
+    let temp = dir.join(format!("alacritree{}{}", stale_exe::TEMP_MARKER, std::process::id()));
+    fs::copy(source, &temp)?;
+    if let Err(e) = fs::rename(&temp, &target) {
+        let _ = fs::remove_file(&temp);
+        return Err(e);
+    }
+    Ok(Installed { target, renamed_aside })
+}
+
+fn report(installed: &Installed, as_json: bool) {
+    if as_json {
+        println!(
+            "{:#}",
+            serde_json::json!({
+                "installed": &installed.target,
+                "renamed_aside": &installed.renamed_aside,
+            })
+        );
+        return;
+    }
+    println!("installed {}", installed.target.display());
+    if let Some(old) = &installed.renamed_aside {
+        println!(
+            "a running alacritree still holds the old binary — moved to {} until it exits",
+            old.display()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn source_exe(dir: &Path, content: &str) -> PathBuf {
+        let path = dir.join("source-build.exe");
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    fn target_in(dir: &Path) -> PathBuf {
+        dir.join(format!("alacritree{}", std::env::consts::EXE_SUFFIX))
+    }
+
+    /// `--dest` may name a directory that does not exist yet; a first install
+    /// must not demand a manual mkdir.
+    #[test]
+    fn installs_into_a_directory_that_does_not_exist_yet() {
+        let dir = TempDir::new().unwrap();
+        let source = source_exe(dir.path(), "v2");
+        let dest = dir.path().join("bin");
+
+        let installed = install_file(&source, &dest).unwrap();
+
+        assert_eq!(installed.target, target_in(&dest));
+        assert_eq!(fs::read_to_string(&installed.target).unwrap(), "v2");
+        assert_eq!(installed.renamed_aside, None);
+    }
+
+    #[test]
+    fn replaces_a_previous_install_nothing_is_running_from() {
+        let dir = TempDir::new().unwrap();
+        let source = source_exe(dir.path(), "v2");
+        let dest = dir.path().join("bin");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(target_in(&dest), "v1").unwrap();
+
+        let installed = install_file(&source, &dest).unwrap();
+
+        assert_eq!(fs::read_to_string(&installed.target).unwrap(), "v2");
+        assert_eq!(installed.renamed_aside, None);
+    }
+
+    /// The point of the subcommand: installing over a binary the window or a
+    /// bridge still runs from must succeed, not fail with access denied.
+    #[cfg(windows)]
+    #[test]
+    fn a_pinned_previous_install_is_renamed_aside_and_replaced() {
+        let dir = TempDir::new().unwrap();
+        let source = source_exe(dir.path(), "v2");
+        let dest = dir.path().join("bin");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(target_in(&dest), "v1").unwrap();
+        let _running = crate::test_util::hold_like_a_running_image(&target_in(&dest));
+
+        let installed = install_file(&source, &dest).unwrap();
+
+        assert_eq!(fs::read_to_string(&installed.target).unwrap(), "v2");
+        let aside = installed.renamed_aside.expect("the pinned exe was moved");
+        assert_eq!(fs::read_to_string(&aside).unwrap(), "v1", "the running image is intact");
+    }
+
+    #[test]
+    fn leftovers_from_earlier_installs_are_swept() {
+        let dir = TempDir::new().unwrap();
+        let source = source_exe(dir.path(), "v2");
+        let dest = dir.path().join("bin");
+        fs::create_dir_all(&dest).unwrap();
+        let leftover = dest.join("alacritree.exe.stale-9-0");
+        fs::write(&leftover, "v0").unwrap();
+
+        install_file(&source, &dest).unwrap();
+
+        assert!(!leftover.exists());
+    }
+
+    #[test]
+    fn the_default_destination_is_local_bin() {
+        let dest = destination(None).unwrap();
+
+        assert!(dest.ends_with(Path::new(".local").join("bin")), "{}", dest.display());
+    }
+}

--- a/alacritree/src/cli/mod.rs
+++ b/alacritree/src/cli/mod.rs
@@ -10,6 +10,7 @@
 //! window (anything about sessions) fail there rather than pretending.
 
 mod doctor;
+mod install;
 mod offline;
 mod render;
 
@@ -73,6 +74,17 @@ enum Command {
 
     /// Check the external tools, config and state alacritree depends on.
     Doctor,
+
+    /// Copy this binary into a bin directory (default: ~/.local/bin).
+    ///
+    /// A window or MCP bridge still running from the destination does not
+    /// block the install: its binary is renamed aside, kept until that
+    /// process exits, and cleaned up by a later install.
+    Install {
+        /// Directory to install into.
+        #[arg(long, value_name = "DIR")]
+        dest: Option<PathBuf>,
+    },
 
     /// Write a shell completion script to stdout.
     Completions { shell: Shell },
@@ -166,6 +178,7 @@ pub fn run(cli: Cli) -> Option<i32> {
         // Diagnosing the machine is not something a running instance can answer:
         // the report has to be truthful when there is nothing to ask.
         Command::Doctor => return Some(doctor::run(cli.json, cli.socket.as_deref())),
+        Command::Install { dest } => return Some(install::run(dest, cli.json)),
         other => to_request(other),
     };
 
@@ -250,7 +263,7 @@ fn to_request(command: Command) -> IpcRequest {
             },
         },
         // None of these reach an alacritree, so none has a request to build.
-        Command::Completions { .. } | Command::Mcp | Command::Doctor => {
+        Command::Completions { .. } | Command::Mcp | Command::Doctor | Command::Install { .. } => {
             unreachable!("handled before dispatch")
         },
     }

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -23,6 +23,7 @@ mod pr_status;
 mod projects;
 mod session;
 mod sidebar_nav;
+mod stale_exe;
 mod state;
 mod terminal_view;
 #[cfg(test)]

--- a/alacritree/src/stale_exe.rs
+++ b/alacritree/src/stale_exe.rs
@@ -1,0 +1,151 @@
+// Rename-aside for executables pinned by running processes.
+//
+// A running process's exe image cannot be overwritten or deleted on Windows,
+// but it can be renamed: the directory entry changes while the process keeps
+// its mapped image.  Renaming a pinned exe aside frees its name for a fresh
+// binary; the leftover is deleted by a later sweep, once its process exits.
+//
+// build.rs pastes this file in with `include!`, so it must stay std-only and
+// must not open with a `//!` inner doc comment — included mid-crate, an inner
+// attribute fails to parse.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Marks a renamed-aside file.  Changing the extension also keeps leftovers
+/// out of PATH lookups and cargo's uplift.
+pub(crate) const STALE_MARKER: &str = ".stale-";
+/// Marks a not-yet-renamed install copy, so an interrupted install is swept
+/// like a stale exe.
+pub(crate) const TEMP_MARKER: &str = ".tmp-";
+
+/// Delete leftovers from earlier rename-asides and interrupted installs.
+/// Best-effort on purpose: a leftover whose process still runs refuses
+/// deletion and waits for a later sweep.
+pub(crate) fn sweep_stale(dir: &Path) {
+    let Ok(entries) = fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("alacritree")
+            && (name.contains(STALE_MARKER) || name.contains(TEMP_MARKER))
+        {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// Rename `path` aside if a running process holds it, returning the new name.
+/// `Ok(None)` means the name is already free to write: missing, or openable
+/// for writing in place.
+pub(crate) fn rename_aside_if_locked(path: &Path) -> io::Result<Option<PathBuf>> {
+    match fs::OpenOptions::new().write(true).open(path) {
+        Ok(_) => return Ok(None),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        // Any other refusal reads as "held": a mapped image on Windows denies
+        // write sharing, a running exe on Linux is ETXTBSY.
+        Err(_) => {},
+    }
+    let name = path.file_name().unwrap_or_default().to_string_lossy().into_owned();
+    let pid = std::process::id();
+    for attempt in 0u32.. {
+        let target = path.with_file_name(format!("{name}{STALE_MARKER}{pid}-{attempt}"));
+        if target.exists() {
+            continue;
+        }
+        return fs::rename(path, &target).map(|()| Some(target));
+    }
+    unreachable!("some pid-attempt suffix is free")
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn touch(path: &Path) {
+        fs::write(path, "old").unwrap();
+    }
+
+    /// The probe must not disturb a file nothing is running from — the common
+    /// case for an install over a stopped binary.
+    #[test]
+    fn a_writable_file_stays_in_place() {
+        let dir = TempDir::new().unwrap();
+        let exe = dir.path().join("alacritree.exe");
+        touch(&exe);
+
+        assert_eq!(rename_aside_if_locked(&exe).unwrap(), None);
+        assert!(exe.exists());
+    }
+
+    #[test]
+    fn a_missing_file_needs_no_rename() {
+        let dir = TempDir::new().unwrap();
+
+        assert_eq!(rename_aside_if_locked(&dir.path().join("alacritree.exe")).unwrap(), None);
+    }
+
+    /// The mechanism this whole branch rests on: write sharing denied, rename
+    /// still allowed — exactly what the loader grants a mapped exe image.
+    #[cfg(windows)]
+    #[test]
+    fn a_held_file_is_renamed_aside() {
+        let dir = TempDir::new().unwrap();
+        let exe = dir.path().join("alacritree.exe");
+        touch(&exe);
+        let _hold = crate::test_util::hold_like_a_running_image(&exe);
+
+        let moved = rename_aside_if_locked(&exe).unwrap().expect("a rename");
+
+        assert!(!exe.exists(), "the original name is free again");
+        assert!(moved.exists());
+        assert!(moved.file_name().unwrap().to_string_lossy().contains(STALE_MARKER));
+    }
+
+    /// Two rename-asides from the same pid must not collide, or the second
+    /// rebuild while two bridges run would fail on the suffix.
+    #[cfg(windows)]
+    #[test]
+    fn a_second_rename_picks_a_fresh_name() {
+        let dir = TempDir::new().unwrap();
+        let exe = dir.path().join("alacritree.exe");
+        touch(&exe);
+        let _hold_one = crate::test_util::hold_like_a_running_image(&exe);
+        let first = rename_aside_if_locked(&exe).unwrap().expect("a rename");
+        touch(&exe);
+        let _hold_two = crate::test_util::hold_like_a_running_image(&exe);
+
+        let second = rename_aside_if_locked(&exe).unwrap().expect("a rename");
+
+        assert_ne!(first, second);
+        assert!(first.exists() && second.exists());
+    }
+
+    /// `~/.local/bin` and `target/` are shared directories: the sweep may only
+    /// ever delete files this code created, recognised by name prefix + marker.
+    #[test]
+    fn the_sweep_removes_only_our_leftovers() {
+        let dir = TempDir::new().unwrap();
+        let stale = dir.path().join("alacritree.exe.stale-7-0");
+        let temp = dir.path().join("alacritree.tmp-7");
+        let live = dir.path().join("alacritree.exe");
+        let foreign = dir.path().join("other.exe.stale-7-0");
+        for f in [&stale, &temp, &live, &foreign] {
+            touch(f);
+        }
+
+        sweep_stale(dir.path());
+
+        assert!(!stale.exists() && !temp.exists());
+        assert!(live.exists(), "the live binary is not sweepable");
+        assert!(foreign.exists(), "other tools' files are not ours to delete");
+    }
+
+    #[test]
+    fn a_sweep_of_a_missing_directory_is_a_no_op() {
+        sweep_stale(Path::new("/nowhere/alacritree-sweep-test"));
+    }
+}

--- a/alacritree/src/test_util.rs
+++ b/alacritree/src/test_util.rs
@@ -27,3 +27,21 @@ pub fn add_worktree(repo: &Repository, name: &str) -> PathBuf {
     repo.worktree(name, &path, None).unwrap();
     path
 }
+
+/// Hold `path` the way the loader holds a running exe image: write sharing
+/// denied (overwrites fail with access denied), delete/rename sharing allowed.
+/// One divergence from a real image: this file *can* be deleted while held,
+/// a mapped image cannot — so tests may rely on rename behaviour, never on
+/// delete behaviour.
+#[cfg(windows)]
+pub fn hold_like_a_running_image(path: &Path) -> std::fs::File {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_DELETE, FILE_SHARE_READ};
+
+    std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_DELETE)
+        .open(path)
+        .unwrap()
+}


### PR DESCRIPTION
On Windows, a running `alacritree` window or `alacritree mcp` bridge pins its exe image: the file can be renamed but not overwritten or deleted. MCP bridges live as long as their client sessions, so a bridge running from `target\release\alacritree.exe` makes every `cargo build -p alacritree` fail with "Access is denied (os error 5)" — the daily dev-loop pain this PR removes. Rename-aside is the established fix (`go build` does it natively; rustup/minio self-updates use it; cargo has it filed unresolved as rust-lang/cargo#12485).

**What changed**

- `build.rs` renames pinned `target/<profile>/alacritree.exe` and `deps/alacritree*.exe` aside to `<name>.stale-<pid>-<n>` before linking, and sweeps leftovers once their processes exit. Every step is best-effort: a failed rename degrades to a `cargo:warning` plus the same link error as today.
- New `alacritree install [--dest <dir>]` (default `~/.local/bin`) copies the running binary into a bin directory with the same rename-aside on a pinned destination — including self-install, where the source *is* the target. Copy lands under a temp name and takes the target name in one rename, so the target is never a partial file.
- `alacritree doctor` gains a Windows-only `processes` section listing each running window/bridge pid and the image it pins (informational rows — with the above, a pinned exe is self-healing, not a fault).

Sockets/pipes needed no work: named pipes vanish with their process, and the unix socket cleanup already unlinks and sweeps.

**Verification**

- `cargo test -p alacritree`: 273 passed (new unit tests simulate the image lock with `share_mode(FILE_SHARE_READ | FILE_SHARE_DELETE)` — write denied, rename allowed, exactly the loader's sharing).
- build.rs verified by live RED→GREEN e2e (build scripts aren't unit-testable): with a real `alacritree mcp` bridge pinning the debug exe, `cargo build` failed with os error 5 before the change and succeeds after, leaving a `.stale-` file the next post-exit build sweeps; a no-change build stays a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)