### PR TITLE
fix(sidebar): match worktree icon spacing to project rows

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1448,6 +1448,7 @@ impl AlacritreeApp {
                         let row_rect = row_with_trailing(
                             ui,
                             |ui| {
+                                ui.spacing_mut().item_spacing.x = ICON_CLUSTER_SPACING;
                                 if reorder_mode {
                                     drag_handle(ui, &theme)
                                         .dnd_set_drag_payload(DraggedProject(project.root.clone()));
@@ -1471,7 +1472,6 @@ impl AlacritreeApp {
                                 );
                             },
                             |ui| {
-                                ui.spacing_mut().item_spacing.x = 2.0;
                                 if icon_button(ui, "×", theme.text_muted, &theme)
                                     .on_hover_text("remove from sidebar")
                                     .clicked()
@@ -2427,6 +2427,11 @@ fn paint_row_status_icon(
     ui.label(RichText::new(glyph).color(color).size(10.0 * s));
 }
 
+/// Gap between adjacent `icon_button`s. They already pad their own glyph, so
+/// the default item spacing on top of that reads as a hole in the cluster.
+/// Deliberately unscaled: the padding it supplements grows with `ui_scale`.
+const ICON_CLUSTER_SPACING: f32 = 2.0;
+
 fn icon_button(ui: &mut egui::Ui, glyph: &str, color: Color32, theme: &Theme) -> egui::Response {
     let s = theme.ui_scale;
     let size = egui::vec2(16.0 * s, 16.0 * s);
@@ -2489,7 +2494,12 @@ where
 {
     let row_size = egui::vec2(ui.available_width(), ui.spacing().interact_size.y);
     ui.allocate_ui_with_layout(row_size, egui::Layout::right_to_left(egui::Align::Center), |ui| {
+        let outer_spacing = ui.spacing().item_spacing.x;
+        ui.spacing_mut().item_spacing.x = ICON_CLUSTER_SPACING;
         trailing(ui);
+        // Restore before the leading group so only the icons cluster; the
+        // labels next to them keep the panel's normal spacing.
+        ui.spacing_mut().item_spacing.x = outer_spacing;
         let remaining = ui.available_width();
         if remaining <= 0.0 {
             return;


### PR DESCRIPTION
## What

Worktree rows' trailing icons were spaced ~14px wider than the project rows' and didn't share their columns.

Only the project row set `item_spacing.x = 2.0` on its trailing icons; every other sidebar row fell back to the panel default (`8.0 * ui_scale`). Measured in the reported screenshot: project icons 36px apart, worktree icons 50.5px apart.

The `×` column was already right-aligned on every row (the `right: 0` frame margin does its job) — what read as ragged was purely the `+` sitting too far left.

## How

Move the spacing into `row_with_trailing`, the helper every sidebar row shares, so project, worktree, home, and session rows get one trailing-icon cluster spacing.

The old value was set inside the trailing closure, which mutates the shared row `Ui` and so leaked into the *leading* group too, tightening the project row's `▸`-to-name gap. Restoring the outer spacing before the leading group runs, and setting it explicitly in the project row's leading closure, keeps that row pixel-identical.

## Verification

Rendered the real app in a nested headless compositor and measured icon centers before/after on the same sidebar:

| Row | Before | After |
|---|---|---|
| Project `monorepo` | `+ ↻ ×` at 281.5 / 306.5 / 333 | unchanged |
| Worktree `fix-tags-badges` | `+ ×` at 296.5 / 333, gap 36.5 | 306.5 / 333, gap 26.5 |

The worktree `+` now lands on the project row's `↻` column with an identical 26.5px gap. Every row's leading text starts and ends at the same x as before, so nothing else shifted. `cargo fmt` + `cargo check -p alacritree` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)