### PR TITLE
fix(diff): let the scrollwheel scroll diff panes

### DIFF
--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -517,12 +517,15 @@ impl Session {
 
         let mut env = config.env.clone();
         if matches!(kind, SessionKind::Diff { .. }) {
-            // git hands its pager `LESS=FRX`; the `F` (quit-if-one-screen) makes
-            // delta's `less` exit the instant a diff fits the pane, so the tab is
-            // reaped before it can be read. Keep git's other defaults but drop
-            // `F` so the pager waits for `q` regardless of diff length. A `LESS`
-            // set by the user (via `[env]`) wins.
-            env.entry("LESS".to_string()).or_insert_with(|| "RX".to_string());
+            // git hands its pager `LESS=FRX`; both of those defaults hurt a diff
+            // tab. `F` (quit-if-one-screen) makes delta's `less` exit the instant
+            // a diff fits the pane, so the tab is reaped before it can be read.
+            // `X` (no-init) keeps `less` off the alternate screen, and without
+            // `ALT_SCREEN` the wheel loses its alternate-scroll arrow keys
+            // (`terminal_view::apply_scroll`) and falls back to a scrollback that
+            // `-X` repaints over instead of filling, leaving the pane unscrollable.
+            // A `LESS` set by the user (via `[env]`) wins.
+            env.entry("LESS".to_string()).or_insert_with(|| "R".to_string());
         }
 
         #[cfg(not(windows))]
@@ -814,6 +817,51 @@ mod tests {
         apply_term_event(event, &mut title, &mut exited, &mut outcome);
 
         assert_eq!(outcome.clipboard, vec![(Target::Clipboard, "hello".to_owned())]);
+    }
+
+    /// The wheel scrolls a diff pane only because its pager sits on the alternate
+    /// screen: `terminal_view::apply_scroll` emits arrow keys for `ALT_SCREEN |
+    /// ALTERNATE_SCROLL` and otherwise falls back to a scrollback the pager
+    /// repaints over rather than fills.  git hands its pager `LESS=FRX`, whose `X`
+    /// (`--no-init`) suppresses that screen, so a diff pane's `LESS` must not carry
+    /// it.  Drives a real pager through a real PTY and reads the negotiated mode.
+    #[cfg(unix)]
+    #[test]
+    fn a_diff_panes_pager_runs_on_the_alternate_screen() {
+        use alacritty_terminal::term::TermMode;
+
+        let page =
+            std::env::temp_dir().join(format!("alacritree-pager-probe-{}.txt", std::process::id()));
+        // Longer than the pane, so the pager has a reason to stay up and page.
+        let lines: String = (0..500).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(&page, lines).unwrap();
+
+        let session = Session::spawn_command(
+            egui::Context::default(),
+            &Config::default(),
+            std::env::current_dir().ok(),
+            TermSize::new(80, 24),
+            (8.0, 16.0),
+            "less".to_string(),
+            vec![page.to_string_lossy().into_owned()],
+            "probe".to_string(),
+            SessionKind::Diff { key: "probe".to_string() },
+        )
+        .unwrap();
+
+        let start = Instant::now();
+        while !session.term.lock().mode().contains(TermMode::ALT_SCREEN) {
+            assert!(
+                start.elapsed() < Duration::from_secs(10),
+                "the pager never entered the alternate screen, so the wheel has nothing to \
+                 scroll: check that a diff pane's LESS does not carry `X` (--no-init)"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        // Paired with ALT_SCREEN this is what `apply_scroll` keys off; it is on by
+        // default, so a pager resetting it would silently break the wheel too.
+        assert!(session.term.lock().mode().contains(TermMode::ALTERNATE_SCROLL));
     }
 
     /// A pane must not wait on the console host's startup handshake.


### PR DESCRIPTION
The scrollwheel did nothing in diff panes.

## Cause

Not the wheel code — `terminal_view::apply_scroll` already mirrors alacritty, and diff panes render through the same `terminal_view::show` as any shell. The cause was one character of pager environment.

`session.rs` handed diff panes `LESS=RX`. The `X` (`--no-init`) keeps `less` off the alternate screen, so `ALT_SCREEN` was never set and this gate was always false:

```rust
let alt_alt_scroll = mode.contains(TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL);
```

The wheel therefore skipped the arrow-key path and fell through to `scroll_display` on the scrollback, which `less -X` never fills because it repaints in place. Nothing to scroll.

The `X` was inherited from git's `LESS=FRX` default. The `F` was dropped deliberately (see the existing comment); the `X` came along without a reason.

## Fix

`RX` → `R`. `ALTERNATE_SCROLL` is already on in `TermMode::default()`, so once the pager is on the alternate screen the existing path sends `ESC O A`/`ESC O B` and `less` scrolls.

Dropping `X` costs nothing here: its only benefit is leaving output on screen after `q`, and `reap_exited_sessions` closes the pane the moment the child exits.

## Verification

| `LESS` | alt screen |
|---|---|
| `RX` (before) | no |
| `R` (after) | yes |

Also confirmed `less` acts on the exact SS3 bytes `apply_scroll` writes.

Adds a regression test that spawns a real `SessionKind::Diff` session through a real PTY and asserts the negotiated mode bits. It **fails on `RX` and passes on `R`**, so it pins the bug rather than the current behavior. Uses `less` (present on `ubuntu-latest`) and is `#[cfg(unix)]`.

`cargo build`, all 243 tests, `cargo fmt`, and clippy (as CI runs it) pass.

One gap worth naming: I could not inject a physical wheel event (Wayland, and `xdotool` is X11-only), so every link is verified except egui's `MouseWheel` → `apply_scroll` delivery, which is shared with shell panes and unchanged. Confirmed working by hand in a rebuilt pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)