### PR TITLE
fix(sidebar): align row labels by fixing the marker slot width

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2380,26 +2380,18 @@ fn paint_row_bg(
     ui.painter().set(bg_idx, egui::Shape::rect_filled(rect, 0.0, bg));
 }
 
-/// Lay out a row whose `trailing` widgets pin to the right edge while `leading`
-/// fills the remaining width — so a `Label::truncate()` inside `leading` knows
-/// exactly how much space it has and ellipsizes cleanly when the panel is narrow.
-///
-/// The row is pre-sized to `interact_size.y` (mirroring `Ui::horizontal`'s own
-/// internals) so it doesn't claim the parent's full remaining height when nested
-/// in a vertical layout — without this, `Align::Center` would push the row's
-/// content to the middle of the column and leave a giant gap before the next row.
-/// Frameless, fixed-footprint icon button. Painter-drawn rather than a
-/// `Button` because `Button` lays text out from the top-left of its rect, so
-/// glyphs of different intrinsic heights (e.g. `+` vs `↻`) end up on different
-/// baselines. `painter.text` with `CENTER_CENTER` centers the galley in the
-/// rect, giving real grid alignment.
+/// Footprint every leading row marker claims, whichever glyph it ends up
+/// drawing. Markers vary wildly in intrinsic width (`·` vs `✳`), so sizing the
+/// slot to the glyph would start each row's label at a different x.
+fn row_status_icon_size(theme: &Theme) -> egui::Vec2 {
+    egui::vec2(10.0, 14.0) * theme.ui_scale
+}
+
 /// Painted (rather than `RichText("●")`) so its size is independent of font
 /// metrics — `RichText("●")` renders inconsistently across fallback fonts.
 fn attention_dot(ui: &mut egui::Ui, theme: &Theme) {
-    let s = theme.ui_scale;
-    let size = egui::vec2(10.0 * s, 14.0 * s);
-    let (rect, _) = ui.allocate_exact_size(size, egui::Sense::hover());
-    let radius = 3.0 * s;
+    let (rect, _) = ui.allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
+    let radius = 3.0 * theme.ui_scale;
     ui.painter().circle_filled(rect.center(), radius, theme.attention);
 }
 
@@ -2424,7 +2416,16 @@ fn paint_row_status_icon(
             (default_glyph.to_string(), if is_active { theme.accent } else { theme.text_muted })
         },
     };
-    ui.label(RichText::new(glyph).color(color).size(10.0 * s));
+    // Centered into the fixed slot, like `icon_button`: laying the glyph out as
+    // text would size the slot to its advance width and shift the label with it.
+    let (rect, _) = ui.allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
+    ui.painter().text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        glyph,
+        egui::FontId::proportional(10.0 * s),
+        color,
+    );
 }
 
 /// Gap between adjacent `icon_button`s. They already pad their own glyph, so
@@ -2432,6 +2433,11 @@ fn paint_row_status_icon(
 /// Deliberately unscaled: the padding it supplements grows with `ui_scale`.
 const ICON_CLUSTER_SPACING: f32 = 2.0;
 
+/// Frameless, fixed-footprint icon button. Painter-drawn rather than a
+/// `Button` because `Button` lays text out from the top-left of its rect, so
+/// glyphs of different intrinsic heights (e.g. `+` vs `↻`) end up on different
+/// baselines. `painter.text` with `CENTER_CENTER` centers the galley in the
+/// rect, giving real grid alignment.
 fn icon_button(ui: &mut egui::Ui, glyph: &str, color: Color32, theme: &Theme) -> egui::Response {
     let s = theme.ui_scale;
     let size = egui::vec2(16.0 * s, 16.0 * s);
@@ -2487,6 +2493,14 @@ fn drag_handle(ui: &mut egui::Ui, theme: &Theme) -> egui::Response {
     resp.on_hover_cursor(egui::CursorIcon::Grab)
 }
 
+/// Lay out a row whose `trailing` widgets pin to the right edge while `leading`
+/// fills the remaining width — so a `Label::truncate()` inside `leading` knows
+/// exactly how much space it has and ellipsizes cleanly when the panel is narrow.
+///
+/// The row is pre-sized to `interact_size.y` (mirroring `Ui::horizontal`'s own
+/// internals) so it doesn't claim the parent's full remaining height when nested
+/// in a vertical layout — without this, `Align::Center` would push the row's
+/// content to the middle of the column and leave a giant gap before the next row.
 fn row_with_trailing<L, T>(ui: &mut egui::Ui, leading: L, trailing: T) -> egui::Rect
 where
     L: FnOnce(&mut egui::Ui),


### PR DESCRIPTION
Sidebar row labels started at a different x depending on which marker the row drew, so `Home`, `main`, `support-...` and `investigate-...` never lined up.

## Cause

`paint_row_status_icon` laid the marker out as a text label (`ui.label(RichText::new(glyph))`), so the slot it claimed was only as wide as that particular glyph's advance width. A narrow `·` and a wide `✳` produced different slot widths, and the label after it shifted to match. The `attention_dot` and `icon_button` helpers directly beside it had already solved this by allocating a fixed rect and painting the glyph centered; the status icon just never got the same treatment.

## Fix

Allocate a fixed 10x14 slot (shared with `attention_dot` via `row_status_icon_size`) and paint the glyph centered into it.

## Verified in the running app

Built and launched on an off-screen output, drove real sessions over IPC, and forced each marker by making the shells emit OSC 0 titles. Measured per-row glyph ink and label start-x from the screenshots:

```
BEFORE  worktree tier   glyph ink   ink center   label_x
        ● main           (47,59)       53.0        76
        ○ automation     (47,59)       53.0        76
        · support        (54,56)       55.0        77
        ✳ investigate    (49,66)       57.5        87   <-- 11px out
        -> glyph-center spread: 4.5px    label_x spread: 11px
        session tier: ✳=103  ▪=93       label_x spread: 10px

AFTER   ● main           (47,55)       51.0        70
        ○ automation     (47,55)       51.0        71
        · support        (50,52)       51.0        71
        ✳ investigate    (45,57)       51.0        72
        -> glyph-center spread: 0.0px    label_x spread: 2px
        session tier: ✳=83   ▪=83       label_x spread: 0px
```

Before, every glyph started at the same left edge (47) and the wide one ate the difference. Now every glyph shares the same center (51.0).

Holding one row fixed and varying only its glyph (ink 3px to 13px: `·` `✳` `❖` `漢` `𝕎`) keeps `label_x` at 71 for all of them, which also shows the residual 2px above is the label's own first-letter ink bearing in the monospace font ('m' fills its cell, 'i' is inset), not the slot. The widest glyph (`✳`, 13px ink) overflows the 10px slot by ~1px per side and still sits 14px clear of the label, so the fixed slot causes no collision. The attention-dot branch (`printf '\a'`) also lands on `label_x` 71.

## Also

Reunites two doc comments with the functions they describe: the `icon_button` block had drifted onto `attention_dot` (it was `icon_button`'s originally, per `git log -S` back to f1ceddd0), and `row_with_trailing`'s block was stranded 120 lines above its `fn`, silently documenting whichever helper got inserted below it.

Complements #97, which fixed the *trailing* icon cluster spacing on these same rows. Independent bug, same rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)