### PR TITLE
feat(sidebar): searchable and filterable side panels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "log",
  "memmap2",
  "notify-rust",
+ "nucleo-matcher",
  "png 0.17.16",
  "rfd",
  "serde",
@@ -2404,6 +2405,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -39,6 +39,7 @@ notify-rust = "4"
 interprocess = { version = "2.4.2", default-features = false }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+nucleo-matcher = "0.3"
 
 [dev-dependencies]
 # Throwaway repos and state files for worktree, prune, and persistence tests.

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -14,6 +14,7 @@ use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
 use crate::config::Config;
 use crate::doppler;
+use crate::git_nav::{self, GitSection};
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, StatusCache};
 use crate::ipc;
 use crate::paste;
@@ -125,6 +126,7 @@ fn blend_toward(c: Color32, target: Color32, amount: f32) -> Color32 {
 enum PaneFocus {
     Terminal,
     ProjectsSidebar,
+    GitSidebar,
 }
 
 pub struct AlacritreeApp {
@@ -141,6 +143,19 @@ pub struct AlacritreeApp {
     sidebar_auto_shown: bool,
     /// One-shot: scroll the cursor row into view on the next sidebar paint.
     sidebar_cursor_moved: bool,
+    /// Git-panel cursor, identified by `(section, path)`.  Rebuilt every render
+    /// pass from `git_rows`, so it survives the 1.5 s status refresh.
+    git_cursor: Option<git_nav::GitRow>,
+    /// One-shot: scroll the git cursor row into view on the next paint.
+    git_cursor_moved: bool,
+    /// Render-order git rows the cursor steps over, refreshed by the render pass.
+    git_rows: Vec<git_nav::GitRow>,
+    /// Resolved default-branch ref backing the git panel's branch-diff rows,
+    /// refreshed by the render pass so Enter opens the same diff a click would.
+    git_branch_base: Option<String>,
+    /// The focus toggle opened a hidden git sidebar; returning focus closes it
+    /// again so a keyboard round trip leaves the layout untouched.
+    git_sidebar_auto_shown: bool,
     sessions: Vec<Session>,
     current_workspace: WorkspaceKey,
     active_session: HashMap<WorkspaceKey, SessionId>,
@@ -276,6 +291,24 @@ fn diff_key(req: &DiffRequest) -> String {
     format!("{tag}:{}", req.file)
 }
 
+/// The diff a git-panel cursor row would open, mirroring the render pass's
+/// per-section click mapping.  `None` for a branch-diff row with no resolved
+/// base, matching the render pass's unclickable base-less rows.
+fn git_row_diff_request(row: &git_nav::GitRow, base: Option<&str>) -> Option<DiffRequest> {
+    let source = match row.section {
+        GitSection::Staged => DiffSource::Staged,
+        GitSection::Unstaged => {
+            if row.kind == Some(ChangeKind::Untracked) {
+                DiffSource::Untracked
+            } else {
+                DiffSource::Worktree
+            }
+        },
+        GitSection::Branch => DiffSource::Branch { base: base?.to_string() },
+    };
+    Some(DiffRequest { file: row.path.clone(), source })
+}
+
 impl AlacritreeApp {
     pub fn new(cc: &CreationContext<'_>, config: Config) -> Self {
         let theme = Theme::from_config(&config);
@@ -384,6 +417,11 @@ impl AlacritreeApp {
             reorder_mode: false,
             sidebar_auto_shown: false,
             sidebar_cursor_moved: false,
+            git_cursor: None,
+            git_cursor_moved: false,
+            git_rows: Vec::new(),
+            git_branch_base: None,
+            git_sidebar_auto_shown: false,
             sessions: Vec::new(),
             current_workspace: None,
             active_session: HashMap::new(),
@@ -438,7 +476,7 @@ impl AlacritreeApp {
         // sidebar (e.g. from Ctrl+Shift+B while it was hidden) should not
         // reappear on next launch.
         let left = self.show_left_sidebar && !self.sidebar_auto_shown;
-        let right = self.show_right_sidebar;
+        let right = self.show_right_sidebar && !self.git_sidebar_auto_shown;
         state::mutate(|s| {
             s.show_left_sidebar = left;
             s.show_right_sidebar = right;
@@ -858,11 +896,28 @@ impl AlacritreeApp {
         self.sidebar_cursor_moved = true;
     }
 
+    fn focus_git_sidebar(&mut self) {
+        if !self.show_right_sidebar {
+            self.show_right_sidebar = true;
+            self.git_sidebar_auto_shown = true;
+            self.persist_sidebars();
+        }
+        self.focus = PaneFocus::GitSidebar;
+        // Rows come from the render pass, so seeding waits for it — leave the
+        // cursor as-is and let the render pass repair it.
+        self.git_cursor_moved = true;
+    }
+
     fn focus_terminal(&mut self) {
         self.focus = PaneFocus::Terminal;
         if self.sidebar_auto_shown {
             self.show_left_sidebar = false;
             self.sidebar_auto_shown = false;
+            self.persist_sidebars();
+        }
+        if self.git_sidebar_auto_shown {
+            self.show_right_sidebar = false;
+            self.git_sidebar_auto_shown = false;
             self.persist_sidebars();
         }
     }
@@ -978,6 +1033,71 @@ impl AlacritreeApp {
         }
     }
 
+    /// Arrow/Enter/Escape navigation while the git sidebar owns keyboard
+    /// focus.  Same event-drain shape as `handle_sidebar_nav`: consumes only
+    /// unmodified nav keys, leaving modifier-bound shortcuts for
+    /// `handle_shortcuts`.
+    fn handle_git_sidebar_nav(&mut self, ctx: &Context) {
+        use egui::Key;
+        let keys: Vec<Key> = ctx.input_mut(|i| {
+            let mut pressed = Vec::new();
+            i.events.retain(|ev| {
+                if let egui::Event::Key { key, pressed: true, modifiers, .. } = ev {
+                    if modifiers.is_none() && is_sidebar_nav_key(*key) {
+                        pressed.push(*key);
+                        return false;
+                    }
+                }
+                true
+            });
+            pressed
+        });
+        for key in keys {
+            self.apply_git_sidebar_nav(ctx, key);
+        }
+    }
+
+    fn apply_git_sidebar_nav(&mut self, ctx: &Context, key: egui::Key) {
+        use egui::Key;
+        let cursor = match self.git_cursor.clone() {
+            Some(c) if self.git_rows.contains(&c) => c,
+            // Stale or unseeded cursor (status refreshed the row out from under
+            // it): land on the first row and let the next press act from there.
+            _ => {
+                if let Some(first) = self.git_rows.first().cloned() {
+                    self.set_git_cursor(first);
+                }
+                return;
+            },
+        };
+        match key {
+            Key::ArrowUp => {
+                if let Some(row) = git_nav::step(&self.git_rows, &cursor, -1) {
+                    self.set_git_cursor(row);
+                }
+            },
+            Key::ArrowDown => {
+                if let Some(row) = git_nav::step(&self.git_rows, &cursor, 1) {
+                    self.set_git_cursor(row);
+                }
+            },
+            Key::Enter => {
+                if let Some(req) = git_row_diff_request(&cursor, self.git_branch_base.as_deref()) {
+                    self.open_diff(ctx, req);
+                }
+            },
+            Key::Escape => self.focus_terminal(),
+            _ => {},
+        }
+    }
+
+    fn set_git_cursor(&mut self, row: git_nav::GitRow) {
+        if self.git_cursor.as_ref() != Some(&row) {
+            self.git_cursor = Some(row);
+            self.git_cursor_moved = true;
+        }
+    }
+
     fn set_project_expanded(&mut self, root: &Path, expanded: bool) {
         if let Some(p) = self.projects.iter_mut().find(|p| p.root == *root) {
             if p.expanded != expanded {
@@ -1075,6 +1195,12 @@ impl AlacritreeApp {
             },
             BindingAction::Named(NamedAction::ToggleRightSidebar) => {
                 self.show_right_sidebar = !self.show_right_sidebar;
+                // A deliberate visibility change opts out of the auto-shown
+                // round trip, and a hidden sidebar cannot keep keyboard focus.
+                self.git_sidebar_auto_shown = false;
+                if !self.show_right_sidebar && self.focus == PaneFocus::GitSidebar {
+                    self.focus = PaneFocus::Terminal;
+                }
                 self.persist_sidebars();
             },
             BindingAction::Named(NamedAction::SelectNextWorkspace) => {
@@ -1087,10 +1213,20 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::ToggleSidebarFocus) => match self.focus {
                 PaneFocus::Terminal => self.focus_sidebar(),
                 PaneFocus::ProjectsSidebar => self.focus_terminal(),
+                // Toggle stays "left ↔ terminal"; from the right panel it hops
+                // to the left one rather than doing nothing.
+                PaneFocus::GitSidebar => self.focus_sidebar(),
             },
             BindingAction::Named(NamedAction::FocusProjectsSidebar) => {
                 if self.focus != PaneFocus::ProjectsSidebar {
                     self.focus_sidebar();
+                }
+            },
+            BindingAction::Named(NamedAction::FocusGitSidebar) => {
+                if self.focus != PaneFocus::GitSidebar {
+                    self.focus_git_sidebar()
+                } else {
+                    self.focus_terminal()
                 }
             },
             BindingAction::Named(NamedAction::FocusTerminal) => self.focus_terminal(),
@@ -1799,6 +1935,10 @@ impl AlacritreeApp {
                 let path = match self.active_session_path() {
                     Some(p) => p,
                     None => {
+                        // No workspace, no rows: keep the cursor model from
+                        // acting on stale rows left by a previous workspace.
+                        self.git_rows.clear();
+                        self.git_branch_base = None;
                         ScrollArea::vertical().show(ui, |ui| {
                             ui.label(
                                 RichText::new("Open a worktree from the left sidebar.")
@@ -1831,8 +1971,50 @@ impl AlacritreeApp {
                     pr_info.as_ref().map(|p| p.base_branch.clone()).or(project_default);
                 // Single non-blocking poll: returns the last known status and
                 // kicks off a background refresh if stale or if the hint
-                // changed since the last completed compute.
-                let status = cache.poll(effective_default.as_deref(), ctx);
+                // changed since the last completed compute.  Cloned so the
+                // `self.git_status` borrow ends before the cursor repair below
+                // mutates other `self` fields.
+                let status = cache.poll(effective_default.as_deref(), ctx).clone();
+
+                // Prefer the resolved ref (e.g. `refs/remotes/origin/main`) so
+                // the cursor's Enter-to-diff matches the branch section's rows.
+                let git_branch_base = status
+                    .default_branch_resolved
+                    .clone()
+                    .or_else(|| status.default_branch.clone());
+                self.git_rows = git_nav::visible_rows(
+                    &status.staged,
+                    &status.unstaged,
+                    &status.branch_diff,
+                    &|_| true,
+                    &mut |_| true,
+                )
+                .rows;
+                self.git_branch_base = git_branch_base.clone();
+                if self.focus == PaneFocus::GitSidebar {
+                    let mut repaired =
+                        git_nav::ensure_cursor(&self.git_rows, self.git_cursor.as_ref());
+                    // An unseeded cursor lands on the row backing the open diff
+                    // when there is one, so focusing the panel points at what
+                    // the user is already looking at.
+                    if self.git_cursor.is_none() {
+                        if let Some(active) = active_diff_key.as_deref() {
+                            if let Some(row) = self.git_rows.iter().find(|r| {
+                                git_row_diff_request(r, git_branch_base.as_deref())
+                                    .is_some_and(|req| diff_key(&req) == active)
+                            }) {
+                                repaired = Some(row.clone());
+                            }
+                        }
+                    }
+                    self.git_cursor = repaired;
+                }
+                let cursor_row = if self.focus == PaneFocus::GitSidebar {
+                    self.git_cursor.clone()
+                } else {
+                    None
+                };
+                let cursor_moved = std::mem::take(&mut self.git_cursor_moved);
 
                 ScrollArea::vertical().show(ui, |ui| {
                     if let Some(err) = &status.error {
@@ -1894,9 +2076,19 @@ impl AlacritreeApp {
                             let req =
                                 DiffRequest { file: f.path.clone(), source: DiffSource::Staged };
                             let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
-                            if file_row(ui, f, &theme, &palette, is_active).clicked() {
+                            let resp = file_row(ui, f, &theme, &palette, is_active);
+                            if resp.clicked() {
                                 diff_request.set(Some(req));
                             }
+                            paint_git_row_cursor(
+                                ui,
+                                &resp,
+                                &cursor_row,
+                                GitSection::Staged,
+                                &f.path,
+                                cursor_moved,
+                                &theme,
+                            );
                         }
                     });
 
@@ -1909,9 +2101,19 @@ impl AlacritreeApp {
                             };
                             let req = DiffRequest { file: f.path.clone(), source };
                             let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
-                            if file_row(ui, f, &theme, &palette, is_active).clicked() {
+                            let resp = file_row(ui, f, &theme, &palette, is_active);
+                            if resp.clicked() {
                                 diff_request.set(Some(req));
                             }
+                            paint_git_row_cursor(
+                                ui,
+                                &resp,
+                                &cursor_row,
+                                GitSection::Unstaged,
+                                &f.path,
+                                cursor_moved,
+                                &theme,
+                            );
                         }
                     });
 
@@ -1920,12 +2122,7 @@ impl AlacritreeApp {
                             Some(b) => format!("Changes vs {b}"),
                             None => "Changes vs default".to_string(),
                         };
-                        // Prefer the resolved ref (e.g. `refs/remotes/origin/main`) so the
-                        // sidebar's merge-base diff matches what delta will show.
-                        let base = status
-                            .default_branch_resolved
-                            .clone()
-                            .or_else(|| status.default_branch.clone());
+                        let base = git_branch_base.clone();
                         let count = status.branch_diff.len();
 
                         // Open-coded section header so the PR number can be a
@@ -1949,7 +2146,16 @@ impl AlacritreeApp {
                         ui.add_space(2.0);
                         for stat in &status.branch_diff {
                             let Some(base) = base.clone() else {
-                                branch_diff_row(ui, stat, &theme, &palette, false);
+                                let resp = branch_diff_row(ui, stat, &theme, &palette, false);
+                                paint_git_row_cursor(
+                                    ui,
+                                    &resp,
+                                    &cursor_row,
+                                    GitSection::Branch,
+                                    &stat.path,
+                                    cursor_moved,
+                                    &theme,
+                                );
                                 continue;
                             };
                             let req = DiffRequest {
@@ -1957,9 +2163,19 @@ impl AlacritreeApp {
                                 source: DiffSource::Branch { base },
                             };
                             let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
-                            if branch_diff_row(ui, stat, &theme, &palette, is_active).clicked() {
+                            let resp = branch_diff_row(ui, stat, &theme, &palette, is_active);
+                            if resp.clicked() {
                                 diff_request.set(Some(req));
                             }
+                            paint_git_row_cursor(
+                                ui,
+                                &resp,
+                                &cursor_row,
+                                GitSection::Branch,
+                                &stat.path,
+                                cursor_moved,
+                                &theme,
+                            );
                         }
                         ui.add_space(10.0);
                     }
@@ -2538,6 +2754,28 @@ fn paint_cursor_outline(ui: &egui::Ui, rect: egui::Rect, theme: &Theme) {
         egui::Stroke::new(1.0_f32, theme.accent),
         egui::StrokeKind::Inside,
     );
+}
+
+/// Outline the git row the keyboard cursor rests on, matched by section+path so
+/// it survives the status refresh.  Full-width rect from the panel plus the
+/// row's `y_range`, mirroring the project rows.
+fn paint_git_row_cursor(
+    ui: &egui::Ui,
+    resp: &egui::Response,
+    cursor: &Option<git_nav::GitRow>,
+    section: GitSection,
+    path: &str,
+    scroll_into_view: bool,
+    theme: &Theme,
+) {
+    if !matches!(cursor, Some(c) if c.section == section && c.path == path) {
+        return;
+    }
+    let rect = egui::Rect::from_x_y_ranges(ui.max_rect().x_range(), resp.rect.y_range());
+    paint_cursor_outline(ui, rect, theme);
+    if scroll_into_view {
+        ui.scroll_to_rect(rect, None);
+    }
 }
 
 fn is_sidebar_nav_key(key: egui::Key) -> bool {
@@ -3943,8 +4181,10 @@ impl eframe::App for AlacritreeApp {
         // not the app — alacritty's key_input returns early the same way,
         // above binding dispatch.
         if !modal_open && self.ime.preedit().is_none() {
-            if self.focus == PaneFocus::ProjectsSidebar {
-                self.handle_sidebar_nav(ctx);
+            match self.focus {
+                PaneFocus::ProjectsSidebar => self.handle_sidebar_nav(ctx),
+                PaneFocus::GitSidebar => self.handle_git_sidebar_nav(ctx),
+                PaneFocus::Terminal => {},
             }
             self.handle_shortcuts(ctx);
         }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1001,7 +1001,15 @@ impl AlacritreeApp {
             Outcome::FilterChanged => self.after_filter_changed(),
             Outcome::Consumed => {},
             Outcome::MoveCursor(delta) => self.move_sidebar_cursor(delta),
-            Outcome::Activate => self.activate_sidebar_cursor(ctx),
+            // Enter clears the query before yielding Activate, so the filtered
+            // row set is already gone; activate the cursor the preceding
+            // MoveCursor/FilterChanged handling maintained against it, rather
+            // than re-deriving rows and rejecting a now-hidden worktree.
+            Outcome::Activate => {
+                if let Some(cursor) = self.sidebar_cursor.clone() {
+                    self.activate_sidebar_row(ctx, &cursor);
+                }
+            },
             Outcome::LeavePanel => self.focus_terminal(),
         }
     }
@@ -1029,15 +1037,6 @@ impl AlacritreeApp {
             },
         };
         self.set_sidebar_cursor(sidebar_nav::step(&rows, &cursor, delta));
-    }
-
-    fn activate_sidebar_cursor(&mut self, ctx: &Context) {
-        let rows = self.current_project_rows();
-        let cursor = match self.sidebar_cursor.clone() {
-            Some(c) if rows.contains(&c) => c,
-            _ => return,
-        };
-        self.activate_sidebar_row(ctx, &cursor);
     }
 
     /// Rows the sidebar cursor steps over this frame: the fuzzy/toggle-filtered

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -14,8 +14,8 @@ use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
 use crate::config::Config;
 use crate::doppler;
-use crate::git_nav::{self, GitSection};
-use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, StatusCache};
+use crate::git_nav::{self, GitSection, SectionCount};
+use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, GitStatus, StatusCache};
 use crate::ipc;
 use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
@@ -147,6 +147,9 @@ pub struct AlacritreeApp {
     /// Fuzzy-search query and `s`/`a` toggle state for the projects panel.
     /// Transient: never persisted, never touches the `expanded` flag.
     project_filter: PanelFilter,
+    /// Fuzzy-search query and `m`/`d`/`u` change-kind toggle state for the git
+    /// panel.  Transient: never persisted.
+    git_filter: PanelFilter,
     /// Git-panel cursor, identified by `(section, path)`.  Rebuilt every render
     /// pass from `git_rows`, so it survives the 1.5 s status refresh.
     git_cursor: Option<git_nav::GitRow>,
@@ -422,6 +425,7 @@ impl AlacritreeApp {
             sidebar_auto_shown: false,
             sidebar_cursor_moved: false,
             project_filter: PanelFilter::new(&['s', 'a']),
+            git_filter: PanelFilter::new(&['m', 'd', 'u']),
             git_cursor: None,
             git_cursor_moved: false,
             git_rows: Vec::new(),
@@ -1164,23 +1168,130 @@ impl AlacritreeApp {
     /// unmodified nav keys, leaving modifier-bound shortcuts for
     /// `handle_shortcuts`.
     fn handle_git_sidebar_nav(&mut self, ctx: &Context) {
-        use egui::Key;
-        let keys: Vec<Key> = ctx.input_mut(|i| {
-            let mut pressed = Vec::new();
-            i.events.retain(|ev| {
-                if let egui::Event::Key { key, pressed: true, modifiers, .. } = ev {
-                    if modifiers.is_none() && is_sidebar_nav_key(*key) {
-                        pressed.push(*key);
+        let filter = &mut self.git_filter;
+        let steps: Vec<SidebarNavStep> = ctx.input_mut(|i| {
+            let mut steps = Vec::new();
+            i.events.retain(|ev| match ev {
+                egui::Event::Text(text) => match filter.on_text(text) {
+                    Some(outcome) => {
+                        steps.push(SidebarNavStep::Filter(outcome));
+                        false
+                    },
+                    None => true,
+                },
+                egui::Event::Key { key, pressed: true, modifiers, .. } if modifiers.is_none() => {
+                    if let Some(outcome) = filter.on_key(*key) {
+                        steps.push(SidebarNavStep::Filter(outcome));
                         return false;
                     }
-                }
-                true
+                    if is_sidebar_nav_key(*key) {
+                        steps.push(SidebarNavStep::Nav(*key));
+                        return false;
+                    }
+                    true
+                },
+                _ => true,
             });
-            pressed
+            steps
         });
-        for key in keys {
-            self.apply_git_sidebar_nav(ctx, key);
+        for step in steps {
+            match step {
+                SidebarNavStep::Filter(outcome) => self.apply_git_filter_outcome(ctx, outcome),
+                SidebarNavStep::Nav(key) => self.apply_git_sidebar_nav(ctx, key),
+            }
         }
+    }
+
+    fn apply_git_filter_outcome(&mut self, ctx: &Context, outcome: panel_filter::Outcome) {
+        use panel_filter::Outcome;
+        match outcome {
+            Outcome::FilterChanged => self.after_git_filter_changed(),
+            Outcome::Consumed => {},
+            Outcome::MoveCursor(delta) => self.move_git_cursor(delta),
+            // Enter clears the query before yielding Activate, so act on the
+            // cursor the preceding movement maintained against the filtered
+            // rows rather than re-deriving a now-widened set.  Focus stays on
+            // the panel so the next file is one keystroke away.
+            Outcome::Activate => {
+                if let Some(cursor) = self.git_cursor.clone() {
+                    if let Some(req) =
+                        git_row_diff_request(&cursor, self.git_branch_base.as_deref())
+                    {
+                        self.open_diff(ctx, req);
+                    }
+                }
+            },
+            Outcome::LeavePanel => self.focus_terminal(),
+        }
+    }
+
+    /// Repair the git cursor after the row set narrows or widens: recompute the
+    /// filtered rows from the cached status so the next key event acts on them,
+    /// then keep the cursor where it is when still visible, else fall to the
+    /// first surviving row.
+    fn after_git_filter_changed(&mut self) {
+        self.recompute_git_rows();
+        let next = git_nav::ensure_cursor(&self.git_rows, self.git_cursor.as_ref());
+        if next.as_ref() != self.git_cursor.as_ref() {
+            self.git_cursor = next;
+            self.git_cursor_moved = true;
+        }
+    }
+
+    fn move_git_cursor(&mut self, delta: i32) {
+        let cursor = match self.git_cursor.clone() {
+            Some(c) if self.git_rows.contains(&c) => c,
+            _ => {
+                if let Some(first) = self.git_rows.first().cloned() {
+                    self.set_git_cursor(first);
+                }
+                return;
+            },
+        };
+        if let Some(row) = git_nav::step(&self.git_rows, &cursor, delta) {
+            self.set_git_cursor(row);
+        }
+    }
+
+    /// Rebuild `git_rows` from the cached status under the active filter,
+    /// without polling.  The render pass recomputes the same way from a fresh
+    /// poll; this keeps the row set current between frames so a filter change
+    /// and a following key event in the same batch agree on the rows.
+    fn recompute_git_rows(&mut self) {
+        let Some(path) = self.active_session_path() else {
+            self.git_rows.clear();
+            return;
+        };
+        let Some(status) = self.git_status.get(&path).map(|c| c.last().clone()) else {
+            self.git_rows.clear();
+            return;
+        };
+        self.git_rows = self.filtered_git_rows(&status).rows;
+    }
+
+    /// Apply the git panel's kind toggles and fuzzy query to a status snapshot.
+    /// With no kind toggle active every kind passes; otherwise the active
+    /// toggles union (`m`: Modified/Renamed, `d`: Deleted, `u`: Untracked/Added).
+    /// Conflicted rows and the branch-diff section are handled by `visible_rows`.
+    fn filtered_git_rows(&mut self, status: &GitStatus) -> git_nav::GitRows {
+        let m = self.git_filter.is_toggled('m');
+        let d = self.git_filter.is_toggled('d');
+        let u = self.git_filter.is_toggled('u');
+        let any = m || d || u;
+        let kind_pass = move |k: ChangeKind| {
+            !any || (m && matches!(k, ChangeKind::Modified | ChangeKind::Renamed))
+                || (d && k == ChangeKind::Deleted)
+                || (u && matches!(k, ChangeKind::Untracked | ChangeKind::Added))
+        };
+        let filter = &mut self.git_filter;
+        let mut query_pass = |path: &str| filter.matches(path);
+        git_nav::visible_rows(
+            &status.staged,
+            &status.unstaged,
+            &status.branch_diff,
+            &kind_pass,
+            &mut query_pass,
+        )
     }
 
     fn apply_git_sidebar_nav(&mut self, ctx: &Context, key: egui::Key) {
@@ -2091,7 +2202,7 @@ impl AlacritreeApp {
             .frame(panel_frame)
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("Git").color(theme.text).strong());
+                    panel_header_filter_ui(ui, "Git", &self.git_filter, &theme);
                 });
                 ui.separator();
 
@@ -2145,14 +2256,23 @@ impl AlacritreeApp {
                     .default_branch_resolved
                     .clone()
                     .or_else(|| status.default_branch.clone());
-                self.git_rows = git_nav::visible_rows(
-                    &status.staged,
-                    &status.unstaged,
-                    &status.branch_diff,
-                    &|_| true,
-                    &mut |_| true,
-                )
-                .rows;
+                let filtering = self.git_filter.is_filtering();
+                let filtered = self.filtered_git_rows(&status);
+                let staged_count = filtered.staged;
+                let unstaged_count = filtered.unstaged;
+                let branch_count = filtered.branch;
+                self.git_rows = filtered.rows;
+                let mut staged_visible: HashSet<String> = HashSet::new();
+                let mut unstaged_visible: HashSet<String> = HashSet::new();
+                let mut branch_visible: HashSet<String> = HashSet::new();
+                for row in &self.git_rows {
+                    match row.section {
+                        GitSection::Staged => &mut staged_visible,
+                        GitSection::Unstaged => &mut unstaged_visible,
+                        GitSection::Branch => &mut branch_visible,
+                    }
+                    .insert(row.path.clone());
+                }
                 self.git_branch_base = git_branch_base.clone();
                 if self.focus == PaneFocus::GitSidebar {
                     let mut repaired =
@@ -2234,8 +2354,11 @@ impl AlacritreeApp {
                     }
                     ui.add_space(10.0);
 
-                    section(ui, &theme, "Staged", status.staged.len(), |ui| {
+                    section(ui, &theme, "Staged", staged_count, filtering, |ui| {
                         for f in &status.staged {
+                            if !staged_visible.contains(&f.path) {
+                                continue;
+                            }
                             let req =
                                 DiffRequest { file: f.path.clone(), source: DiffSource::Staged };
                             let is_active = active_diff_key.as_deref() == Some(&diff_key(&req));
@@ -2255,8 +2378,11 @@ impl AlacritreeApp {
                         }
                     });
 
-                    section(ui, &theme, "Unstaged", status.unstaged.len(), |ui| {
+                    section(ui, &theme, "Unstaged", unstaged_count, filtering, |ui| {
                         for f in &status.unstaged {
+                            if !unstaged_visible.contains(&f.path) {
+                                continue;
+                            }
                             let source = if f.kind == ChangeKind::Untracked {
                                 DiffSource::Untracked
                             } else {
@@ -2286,7 +2412,7 @@ impl AlacritreeApp {
                             None => "Changes vs default".to_string(),
                         };
                         let base = git_branch_base.clone();
-                        let count = status.branch_diff.len();
+                        let count_label = section_count_label(&branch_count, filtering);
 
                         // Open-coded section header so the PR number can be a
                         // hyperlink while the rest stays plain text.
@@ -2302,12 +2428,13 @@ impl AlacritreeApp {
                                     &pr.url,
                                 );
                             }
-                            ui.label(
-                                RichText::new(format!("{count}")).color(theme.text_muted).small(),
-                            );
+                            ui.label(RichText::new(count_label).color(theme.text_muted).small());
                         });
                         ui.add_space(2.0);
                         for stat in &status.branch_diff {
+                            if !branch_visible.contains(&stat.path) {
+                                continue;
+                            }
                             let Some(base) = base.clone() else {
                                 let resp = branch_diff_row(ui, stat, &theme, &palette, false);
                                 paint_git_row_cursor(
@@ -2585,19 +2712,31 @@ fn focus_default(ctx: &Context, id: egui::Id) {
 /// Empty sections are skipped entirely — a placeholder glyph for "no files
 /// here" added visual noise without communicating anything the count badge
 /// didn't already say.
+/// Section header count: `visible of total` while a filter narrows the panel,
+/// the plain total otherwise.
+fn section_count_label(count: &SectionCount, filtering: bool) -> String {
+    if filtering {
+        format!("{} of {}", count.visible, count.total)
+    } else {
+        format!("{}", count.total)
+    }
+}
+
 fn section<R>(
     ui: &mut egui::Ui,
     theme: &Theme,
     title: &str,
-    count: usize,
+    count: SectionCount,
+    filtering: bool,
     add_contents: impl FnOnce(&mut egui::Ui) -> R,
 ) {
-    if count == 0 {
+    if count.total == 0 {
         return;
     }
+    let label = section_count_label(&count, filtering);
     ui.horizontal(|ui| {
         ui.label(RichText::new(title).color(theme.text).strong().small());
-        ui.label(RichText::new(format!("{count}")).color(theme.text_muted).small());
+        ui.label(RichText::new(label).color(theme.text_muted).small());
     });
     ui.add_space(2.0);
     add_contents(ui);
@@ -2941,7 +3080,7 @@ fn paint_git_row_cursor(
     }
 }
 
-/// One drained event's effect on the projects panel: either a filter outcome
+/// One drained event's effect on a sidebar panel: either a filter outcome
 /// (search/toggle) or a plain browsing nav key.
 enum SidebarNavStep {
     Filter(panel_filter::Outcome),

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -29,7 +29,7 @@ use crate::worktree::{self as wt, CreateRequest, Progress};
 use crate::wsl::{self, ShellChoice};
 
 /// `None` is the home workspace (sessions inherit `$PWD`); `Some` is a worktree path.
-type WorkspaceKey = Option<PathBuf>;
+pub type WorkspaceKey = Option<PathBuf>;
 
 /// Channel from notification-worker threads back to the app.  Set once by
 /// `AlacritreeApp::new`; each worker reads it to deliver the workspace the
@@ -900,8 +900,12 @@ impl AlacritreeApp {
             self.persist_sidebars();
         }
         self.focus = PaneFocus::ProjectsSidebar;
-        self.sidebar_cursor =
-            Some(sidebar_nav::seed(&self.projects, self.current_workspace.as_deref()));
+        self.sidebar_cursor = Some(sidebar_nav::seed(
+            &self.projects,
+            self.current_workspace.as_deref(),
+            &self.listed_session_ids(),
+            self.active_session.get(&self.current_workspace).copied(),
+        ));
         // Seeding reads the unfiltered tree, so a lingering filter from a prior
         // focus round-trip can leave the seeded row outside the current rows;
         // repair it immediately rather than waiting for the first key press.
@@ -1051,8 +1055,9 @@ impl AlacritreeApp {
     /// Rows the sidebar cursor steps over this frame: the fuzzy/toggle-filtered
     /// set while a filter is active, the full visible set otherwise.
     fn current_project_rows(&mut self) -> Vec<SidebarRow> {
+        let listed_sessions = self.listed_session_ids();
         if !self.project_filter.is_filtering() {
-            return sidebar_nav::visible_rows(&self.projects);
+            return sidebar_nav::visible_rows(&self.projects, &listed_sessions);
         }
 
         let toggle_sessions = self.project_filter.is_toggled('s');
@@ -1092,6 +1097,7 @@ impl AlacritreeApp {
         };
         sidebar_nav::filtered_rows(
             &self.projects,
+            &listed_sessions,
             sidebar_nav::RowPredicates {
                 home,
                 project_self: &project_self,
@@ -1123,14 +1129,21 @@ impl AlacritreeApp {
         match key {
             Key::ArrowUp => self.set_sidebar_cursor(sidebar_nav::step(&rows, &cursor, -1)),
             Key::ArrowDown => self.set_sidebar_cursor(sidebar_nav::step(&rows, &cursor, 1)),
-            Key::ArrowRight => {
-                if let SidebarRow::Project(root) = &cursor {
-                    self.set_project_expanded(root, true);
-                }
+            Key::ArrowRight => match &cursor {
+                SidebarRow::Project(root) => {
+                    let root = root.clone();
+                    self.set_project_expanded(&root, true);
+                },
+                SidebarRow::Session(id) => {
+                    let id = *id;
+                    self.activate_session_by_id(id);
+                    self.focus_terminal();
+                },
+                _ => {},
             },
             Key::ArrowLeft => match &cursor {
                 SidebarRow::Project(root) => self.set_project_expanded(root, false),
-                SidebarRow::Worktree(_) => {
+                SidebarRow::Worktree(_) | SidebarRow::Session(_) => {
                     if let Some(target) = sidebar_nav::left_target(&rows, &cursor) {
                         self.set_sidebar_cursor(target);
                     }
@@ -1156,6 +1169,11 @@ impl AlacritreeApp {
                 self.activate_worktree(ctx, &path);
                 self.focus_terminal();
             },
+            SidebarRow::Session(id) => {
+                let id = *id;
+                self.activate_session_by_id(id);
+                self.focus_terminal();
+            },
             SidebarRow::Project(root) => {
                 let root = root.clone();
                 let expanded =
@@ -1163,6 +1181,19 @@ impl AlacritreeApp {
                 self.set_project_expanded(&root, !expanded);
             },
         }
+    }
+
+    /// Switch to the session's workspace and mark it active — the keyboard
+    /// equivalent of clicking its sidebar row.  A stale id (session reaped
+    /// this frame) self-heals next frame via `ensure_active_session`.
+    fn activate_session_by_id(&mut self, id: SessionId) {
+        let Some(ws) =
+            self.sessions.iter().find(|s| s.id == id).map(|s| s.working_directory.clone())
+        else {
+            return;
+        };
+        self.current_workspace = ws.clone();
+        self.active_session.insert(ws, id);
     }
 
     fn set_sidebar_cursor(&mut self, row: SidebarRow) {
@@ -1681,6 +1712,8 @@ impl AlacritreeApp {
                     SidebarRow::Worktree(path) => {
                         visible_worktrees.insert(path);
                     },
+                    // Session rows follow their workspace row's visibility.
+                    SidebarRow::Session(_) => {},
                 }
             }
         }
@@ -1822,7 +1855,11 @@ impl AlacritreeApp {
                             spawn_shell_request.set(Some(None));
                         }
                         for row in &home_session_rows {
-                            let act = session_row(ui, row, &theme);
+                            let is_cursor = matches!(
+                                &cursor_row,
+                                Some(SidebarRow::Session(id)) if *id == row.id
+                            );
+                            let act = session_row(ui, row, is_cursor, cursor_moved, &theme);
                             if act.activate {
                                 activate_session_request.set(Some((None, row.id)));
                             }
@@ -2100,7 +2137,11 @@ impl AlacritreeApp {
                                     .map(Vec::as_slice)
                                     .unwrap_or(&[]);
                                 for row in session_rows {
-                                    let act = session_row(ui, row, &theme);
+                                    let is_cursor = matches!(
+                                        &cursor_row,
+                                        Some(SidebarRow::Session(id)) if *id == row.id
+                                    );
+                                    let act = session_row(ui, row, is_cursor, cursor_moved, &theme);
                                     if act.activate {
                                         activate_session_request
                                             .set(Some((Some(wt.path.clone()), row.id)));
@@ -3409,7 +3450,13 @@ struct SessionRowAction {
     close: bool,
 }
 
-fn session_row(ui: &mut egui::Ui, row: &SessionRowData, theme: &Theme) -> SessionRowAction {
+fn session_row(
+    ui: &mut egui::Ui,
+    row: &SessionRowData,
+    is_cursor: bool,
+    scroll_into_view: bool,
+    theme: &Theme,
+) -> SessionRowAction {
     // Reserve a slot *before* the labels so the hover bg paints beneath them.
     let bg_idx = ui.painter().add(egui::Shape::Noop);
     let panel_x = ui.max_rect().x_range();
@@ -3470,9 +3517,15 @@ fn session_row(ui: &mut egui::Ui, row: &SessionRowData, theme: &Theme) -> Sessio
     } else {
         Color32::TRANSPARENT
     };
+    let full_rect = egui::Rect::from_x_y_ranges(panel_x, resp.rect.y_range());
     if bg != Color32::TRANSPARENT {
-        let rect = egui::Rect::from_x_y_ranges(panel_x, resp.rect.y_range());
-        ui.painter().set(bg_idx, egui::Shape::rect_filled(rect, 0.0, bg));
+        ui.painter().set(bg_idx, egui::Shape::rect_filled(full_rect, 0.0, bg));
+    }
+    if is_cursor {
+        paint_cursor_outline(ui, full_rect, theme);
+        if scroll_into_view {
+            ui.scroll_to_rect(full_rect, None);
+        }
     }
     SessionRowAction { activate: resp.clicked() && !close_clicked, close: close_clicked }
 }
@@ -3572,6 +3625,24 @@ impl AlacritreeApp {
             }
         }
         active_glyph.or(other_glyph)
+    }
+
+    /// The session rows every workspace currently lists, for the keyboard
+    /// cursor model.  Built from the same `sidebar_session_ids` rule the
+    /// paint pass uses, so cursor rows and painted rows cannot drift.
+    fn listed_session_ids(&self) -> sidebar_nav::ListedSessions {
+        let pairs: Vec<(WorkspaceKey, SessionId)> =
+            self.sessions.iter().map(|s| (s.working_directory.clone(), s.id)).collect();
+        let mut listed = sidebar_nav::ListedSessions::new();
+        for (ws, _) in &pairs {
+            if !listed.contains_key(ws) {
+                let ids = sidebar_session_ids(&pairs, ws);
+                if !ids.is_empty() {
+                    listed.insert(ws.clone(), ids);
+                }
+            }
+        }
+        listed
     }
 
     /// Session rows for `ws`'s sidebar list, per `sidebar_session_ids`'s

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -902,6 +902,11 @@ impl AlacritreeApp {
         self.focus = PaneFocus::ProjectsSidebar;
         self.sidebar_cursor =
             Some(sidebar_nav::seed(&self.projects, self.current_workspace.as_deref()));
+        // Seeding reads the unfiltered tree, so a lingering filter from a prior
+        // focus round-trip can leave the seeded row outside the current rows;
+        // repair it immediately rather than waiting for the first key press.
+        let rows = self.current_project_rows();
+        self.sidebar_cursor = sidebar_nav::ensure_cursor(&rows, self.sidebar_cursor.as_ref());
         self.sidebar_cursor_moved = true;
     }
 
@@ -1105,9 +1110,13 @@ impl AlacritreeApp {
         let cursor = match self.sidebar_cursor.clone() {
             Some(c) if rows.contains(&c) => c,
             // Stale or unseeded cursor (worktree removed, project collapsed
-            // by mouse): land on Home and let the next press act from there.
+            // by mouse, or a filter toggle narrowing the rows out from under
+            // it): land on the first row and let the next press act from
+            // there. Unfiltered `rows` always leads with Home.
             _ => {
-                self.set_sidebar_cursor(SidebarRow::Home);
+                if let Some(first) = rows.first() {
+                    self.set_sidebar_cursor(first.clone());
+                }
                 return;
             },
         };

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1814,6 +1814,9 @@ impl AlacritreeApp {
             .min_width(180.0 * theme.ui_scale)
             .frame(panel_frame)
             .show(ctx, |ui| {
+                // Sidebar rows are click targets, not selectable prose; the
+                // default I-beam-and-select on labels is the wrong affordance.
+                ui.style_mut().interaction.selectable_labels = false;
                 ui.horizontal(|ui| {
                     panel_header_filter_ui(
                         ui,
@@ -2257,6 +2260,9 @@ impl AlacritreeApp {
             .min_width(220.0 * theme.ui_scale)
             .frame(panel_frame)
             .show(ctx, |ui| {
+                // Sidebar rows are click targets, not selectable prose; the
+                // default I-beam-and-select on labels is the wrong affordance.
+                ui.style_mut().interaction.selectable_labels = false;
                 ui.horizontal(|ui| {
                     panel_header_filter_ui(
                         ui,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1815,7 +1815,13 @@ impl AlacritreeApp {
             .frame(panel_frame)
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
-                    panel_header_filter_ui(ui, "Projects", &self.project_filter, &theme);
+                    panel_header_filter_ui(
+                        ui,
+                        "Projects",
+                        &self.project_filter,
+                        &self.config.ui.icons.search,
+                        &theme,
+                    );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         if icon_button(ui, "+", theme.text_dim, &theme)
                             .on_hover_text("add project")
@@ -2252,7 +2258,13 @@ impl AlacritreeApp {
             .frame(panel_frame)
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
-                    panel_header_filter_ui(ui, "Git", &self.git_filter, &theme);
+                    panel_header_filter_ui(
+                        ui,
+                        "Git",
+                        &self.git_filter,
+                        &self.config.ui.icons.search,
+                        &theme,
+                    );
                 });
                 ui.separator();
 
@@ -3138,9 +3150,16 @@ enum SidebarNavStep {
 }
 
 /// Panel title plus its filter chrome, shared by both sidebars: the heading,
-/// then `[s]`-style chips for each active toggle, then a bordered `🔍 query▌`
-/// input box while searching.  Renders only the title when the filter is idle.
-fn panel_header_filter_ui(ui: &mut egui::Ui, title: &str, filter: &PanelFilter, theme: &Theme) {
+/// then `[s]`-style chips for each active toggle, then a bordered
+/// `<icon> query▌` input box while searching (`search_icon` comes from
+/// `[ui] search_icon`).  Renders only the title when the filter is idle.
+fn panel_header_filter_ui(
+    ui: &mut egui::Ui,
+    title: &str,
+    filter: &PanelFilter,
+    search_icon: &str,
+    theme: &Theme,
+) {
     ui.label(RichText::new(title).color(theme.text).strong());
     for key in filter.active_toggles() {
         ui.label(RichText::new(format!("[{key}]")).color(theme.accent).monospace().small());
@@ -3153,7 +3172,7 @@ fn panel_header_filter_ui(ui: &mut egui::Ui, title: &str, filter: &PanelFilter, 
             .inner_margin(Margin::symmetric((4.0 * s).round() as i8, (1.0 * s).round() as i8))
             .show(ui, |ui| {
                 ui.spacing_mut().item_spacing.x = 3.0 * s;
-                ui.label(RichText::new("🔍").color(theme.text_dim).small());
+                ui.label(RichText::new(search_icon).color(theme.text_dim).small());
                 ui.label(
                     RichText::new(format!("{}▌", filter.query()))
                         .color(theme.text)

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -3138,17 +3138,29 @@ enum SidebarNavStep {
 }
 
 /// Panel title plus its filter chrome, shared by both sidebars: the heading,
-/// then `[s]`-style chips for each active toggle, then a `/query▌` prompt while
-/// searching.  Renders only the title when the filter is idle.
+/// then `[s]`-style chips for each active toggle, then a bordered `🔍 query▌`
+/// input box while searching.  Renders only the title when the filter is idle.
 fn panel_header_filter_ui(ui: &mut egui::Ui, title: &str, filter: &PanelFilter, theme: &Theme) {
     ui.label(RichText::new(title).color(theme.text).strong());
     for key in filter.active_toggles() {
         ui.label(RichText::new(format!("[{key}]")).color(theme.accent).monospace().small());
     }
     if filter.mode() == panel_filter::Mode::Search || !filter.query().is_empty() {
-        ui.label(
-            RichText::new(format!("/{}▌", filter.query())).color(theme.text).monospace().small(),
-        );
+        let s = theme.ui_scale;
+        Frame::default()
+            .stroke(Stroke::new(1.0_f32, theme.text_muted))
+            .corner_radius((3.0 * s).round() as u8)
+            .inner_margin(Margin::symmetric((4.0 * s).round() as i8, (1.0 * s).round() as i8))
+            .show(ui, |ui| {
+                ui.spacing_mut().item_spacing.x = 3.0 * s;
+                ui.label(RichText::new("🔍").color(theme.text_dim).small());
+                ui.label(
+                    RichText::new(format!("{}▌", filter.query()))
+                        .color(theme.text)
+                        .monospace()
+                        .small(),
+                );
+            });
     }
 }
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -17,6 +17,7 @@ use crate::doppler;
 use crate::git_nav::{self, GitSection};
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, StatusCache};
 use crate::ipc;
+use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
 use crate::pr_status::PrCache;
 use crate::projects::{Project, Worktree, project_json};
@@ -143,6 +144,9 @@ pub struct AlacritreeApp {
     sidebar_auto_shown: bool,
     /// One-shot: scroll the cursor row into view on the next sidebar paint.
     sidebar_cursor_moved: bool,
+    /// Fuzzy-search query and `s`/`a` toggle state for the projects panel.
+    /// Transient: never persisted, never touches the `expanded` flag.
+    project_filter: PanelFilter,
     /// Git-panel cursor, identified by `(section, path)`.  Rebuilt every render
     /// pass from `git_rows`, so it survives the 1.5 s status refresh.
     git_cursor: Option<git_nav::GitRow>,
@@ -417,6 +421,7 @@ impl AlacritreeApp {
             reorder_mode: false,
             sidebar_auto_shown: false,
             sidebar_cursor_moved: false,
+            project_filter: PanelFilter::new(&['s', 'a']),
             git_cursor: None,
             git_cursor_moved: false,
             git_rows: Vec::new(),
@@ -956,28 +961,144 @@ impl AlacritreeApp {
     /// keyboard focus.  Consumes only unmodified keys, so modifier-bound
     /// app shortcuts still match in `handle_shortcuts` afterwards.
     fn handle_sidebar_nav(&mut self, ctx: &Context) {
-        use egui::Key;
-        let keys: Vec<Key> = ctx.input_mut(|i| {
-            let mut pressed = Vec::new();
-            i.events.retain(|ev| {
-                if let egui::Event::Key { key, pressed: true, modifiers, .. } = ev {
-                    if modifiers.is_none() && is_sidebar_nav_key(*key) {
-                        pressed.push(*key);
+        let filter = &mut self.project_filter;
+        let steps: Vec<SidebarNavStep> = ctx.input_mut(|i| {
+            let mut steps = Vec::new();
+            i.events.retain(|ev| match ev {
+                egui::Event::Text(text) => match filter.on_text(text) {
+                    Some(outcome) => {
+                        steps.push(SidebarNavStep::Filter(outcome));
+                        false
+                    },
+                    None => true,
+                },
+                egui::Event::Key { key, pressed: true, modifiers, .. } if modifiers.is_none() => {
+                    if let Some(outcome) = filter.on_key(*key) {
+                        steps.push(SidebarNavStep::Filter(outcome));
                         return false;
                     }
-                }
-                true
+                    if is_sidebar_nav_key(*key) {
+                        steps.push(SidebarNavStep::Nav(*key));
+                        return false;
+                    }
+                    true
+                },
+                _ => true,
             });
-            pressed
+            steps
         });
-        for key in keys {
-            self.apply_sidebar_nav(ctx, key);
+        for step in steps {
+            match step {
+                SidebarNavStep::Filter(outcome) => self.apply_filter_outcome(ctx, outcome),
+                SidebarNavStep::Nav(key) => self.apply_sidebar_nav(ctx, key),
+            }
         }
+    }
+
+    fn apply_filter_outcome(&mut self, ctx: &Context, outcome: panel_filter::Outcome) {
+        use panel_filter::Outcome;
+        match outcome {
+            Outcome::FilterChanged => self.after_filter_changed(),
+            Outcome::Consumed => {},
+            Outcome::MoveCursor(delta) => self.move_sidebar_cursor(delta),
+            Outcome::Activate => self.activate_sidebar_cursor(ctx),
+            Outcome::LeavePanel => self.focus_terminal(),
+        }
+    }
+
+    /// Repair the cursor after the row set narrows or widens: keep it where it
+    /// is when still visible, otherwise fall to the first surviving row.
+    fn after_filter_changed(&mut self) {
+        let rows = self.current_project_rows();
+        let next = sidebar_nav::ensure_cursor(&rows, self.sidebar_cursor.as_ref());
+        if next != self.sidebar_cursor {
+            self.sidebar_cursor = next;
+            self.sidebar_cursor_moved = true;
+        }
+    }
+
+    fn move_sidebar_cursor(&mut self, delta: i32) {
+        let rows = self.current_project_rows();
+        let cursor = match self.sidebar_cursor.clone() {
+            Some(c) if rows.contains(&c) => c,
+            _ => {
+                if let Some(first) = rows.first() {
+                    self.set_sidebar_cursor(first.clone());
+                }
+                return;
+            },
+        };
+        self.set_sidebar_cursor(sidebar_nav::step(&rows, &cursor, delta));
+    }
+
+    fn activate_sidebar_cursor(&mut self, ctx: &Context) {
+        let rows = self.current_project_rows();
+        let cursor = match self.sidebar_cursor.clone() {
+            Some(c) if rows.contains(&c) => c,
+            _ => return,
+        };
+        self.activate_sidebar_row(ctx, &cursor);
+    }
+
+    /// Rows the sidebar cursor steps over this frame: the fuzzy/toggle-filtered
+    /// set while a filter is active, the full visible set otherwise.
+    fn current_project_rows(&mut self) -> Vec<SidebarRow> {
+        if !self.project_filter.is_filtering() {
+            return sidebar_nav::visible_rows(&self.projects);
+        }
+
+        let toggle_sessions = self.project_filter.is_toggled('s');
+        let toggle_attention = self.project_filter.is_toggled('a');
+        let any_toggle = toggle_sessions || toggle_attention;
+
+        // Precompute every fuzzy result before building the closures: the
+        // matcher needs `&mut self.project_filter`, and releasing that borrow
+        // up-front lets the predicates read the rest of `&self` freely.
+        let home_matches = self.project_filter.matches("Home");
+        let project_matches: HashMap<PathBuf, bool> = {
+            let filter = &mut self.project_filter;
+            self.projects
+                .iter()
+                .map(|p| (p.root.clone(), filter.matches(p.display_name())))
+                .collect()
+        };
+        let worktree_matches: HashMap<PathBuf, bool> = {
+            let filter = &mut self.project_filter;
+            self.projects
+                .iter()
+                .flat_map(|p| p.worktrees.iter())
+                .map(|wt| (wt.path.clone(), filter.matches(&wt.name)))
+                .collect()
+        };
+
+        let toggles_pass = |key: &WorkspaceKey| {
+            (!toggle_sessions || self.workspace_has_sessions(key))
+                && (!toggle_attention || self.workspace_needs_attention(key))
+        };
+        let home = home_matches && toggles_pass(&None);
+        let project_self =
+            |p: &Project| !any_toggle && project_matches.get(&p.root).copied().unwrap_or(false);
+        let mut worktree = |_p: &Project, wt: &Worktree| {
+            worktree_matches.get(&wt.path).copied().unwrap_or(false)
+                && toggles_pass(&Some(wt.path.clone()))
+        };
+        sidebar_nav::filtered_rows(
+            &self.projects,
+            sidebar_nav::RowPredicates {
+                home,
+                project_self: &project_self,
+                worktree: &mut worktree,
+            },
+        )
+    }
+
+    fn workspace_has_sessions(&self, key: &WorkspaceKey) -> bool {
+        self.sessions.iter().any(|s| s.working_directory == *key)
     }
 
     fn apply_sidebar_nav(&mut self, ctx: &Context, key: egui::Key) {
         use egui::Key;
-        let rows = sidebar_nav::visible_rows(&self.projects);
+        let rows = self.current_project_rows();
         let cursor = match self.sidebar_cursor.clone() {
             Some(c) if rows.contains(&c) => c,
             // Stale or unseeded cursor (worktree removed, project collapsed
@@ -1004,25 +1125,31 @@ impl AlacritreeApp {
                 },
                 SidebarRow::Home => {},
             },
-            Key::Enter => match &cursor {
-                SidebarRow::Home => {
-                    self.activate_home(ctx);
-                    self.focus_terminal();
-                },
-                SidebarRow::Worktree(path) => {
-                    let path = path.clone();
-                    self.activate_worktree(ctx, &path);
-                    self.focus_terminal();
-                },
-                SidebarRow::Project(root) => {
-                    let root = root.clone();
-                    let expanded =
-                        self.projects.iter().find(|p| p.root == root).is_some_and(|p| p.expanded);
-                    self.set_project_expanded(&root, !expanded);
-                },
-            },
+            Key::Enter => self.activate_sidebar_row(ctx, &cursor),
             Key::Escape => self.focus_terminal(),
             _ => {},
+        }
+    }
+
+    /// Enter on a cursor row: open Home/worktree sessions and return focus to
+    /// the terminal, or toggle a project header's expansion in place.
+    fn activate_sidebar_row(&mut self, ctx: &Context, cursor: &SidebarRow) {
+        match cursor {
+            SidebarRow::Home => {
+                self.activate_home(ctx);
+                self.focus_terminal();
+            },
+            SidebarRow::Worktree(path) => {
+                let path = path.clone();
+                self.activate_worktree(ctx, &path);
+                self.focus_terminal();
+            },
+            SidebarRow::Project(root) => {
+                let root = root.clone();
+                let expanded =
+                    self.projects.iter().find(|p| p.root == root).is_some_and(|p| p.expanded);
+                self.set_project_expanded(&root, !expanded);
+            },
         }
     }
 
@@ -1416,6 +1543,33 @@ impl AlacritreeApp {
         };
         let cursor_moved = std::mem::take(&mut self.sidebar_cursor_moved);
 
+        // Membership for the active filter, resolved once so paint can skip
+        // non-surviving rows.  While filtering, matched projects render their
+        // matched worktrees regardless of `expanded` (display-only — the flag
+        // is never written).
+        let filtering = self.project_filter.is_filtering();
+        let mut home_visible = true;
+        let mut visible_projects: HashSet<PathBuf> = HashSet::new();
+        let mut visible_worktrees: HashSet<PathBuf> = HashSet::new();
+        if filtering {
+            home_visible = false;
+            for row in self.current_project_rows() {
+                match row {
+                    SidebarRow::Home => home_visible = true,
+                    SidebarRow::Project(root) => {
+                        visible_projects.insert(root);
+                    },
+                    SidebarRow::Worktree(path) => {
+                        visible_worktrees.insert(path);
+                    },
+                }
+            }
+        }
+        let filtered_empty = filtering
+            && !home_visible
+            && visible_projects.is_empty()
+            && visible_worktrees.is_empty();
+
         // Snapshot attention + agent-glyph state up-front so the `iter_mut`
         // over projects below isn't blocked from calling back into `&self`
         // helpers.
@@ -1509,7 +1663,7 @@ impl AlacritreeApp {
             .frame(panel_frame)
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("Projects").color(theme.text).strong());
+                    panel_header_filter_ui(ui, "Projects", &self.project_filter, &theme);
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         if icon_button(ui, "+", theme.text_dim, &theme)
                             .on_hover_text("add project")
@@ -1532,31 +1686,33 @@ impl AlacritreeApp {
                 ui.separator();
 
                 ScrollArea::vertical().show(ui, |ui| {
-                    let home_action = home_row(
-                        ui,
-                        self.current_workspace.is_none(),
-                        matches!(&cursor_row, Some(SidebarRow::Home)),
-                        cursor_moved,
-                        home_attention,
-                        home_agent_glyph,
-                        &theme,
-                    );
-                    if home_action.activate {
-                        home_clicked = true;
-                    }
-                    if home_action.spawn {
-                        spawn_shell_request.set(Some(None));
-                    }
-                    for row in &home_session_rows {
-                        let act = session_row(ui, row, &theme);
-                        if act.activate {
-                            activate_session_request.set(Some((None, row.id)));
+                    if !filtering || home_visible {
+                        let home_action = home_row(
+                            ui,
+                            self.current_workspace.is_none(),
+                            matches!(&cursor_row, Some(SidebarRow::Home)),
+                            cursor_moved,
+                            home_attention,
+                            home_agent_glyph,
+                            &theme,
+                        );
+                        if home_action.activate {
+                            home_clicked = true;
                         }
-                        if act.close {
-                            close_session_request.set(Some(row.id));
+                        if home_action.spawn {
+                            spawn_shell_request.set(Some(None));
                         }
+                        for row in &home_session_rows {
+                            let act = session_row(ui, row, &theme);
+                            if act.activate {
+                                activate_session_request.set(Some((None, row.id)));
+                            }
+                            if act.close {
+                                close_session_request.set(Some(row.id));
+                            }
+                        }
+                        ui.add_space(2.0);
                     }
-                    ui.add_space(2.0);
 
                     if self.projects.is_empty() {
                         ui.label(
@@ -1566,9 +1722,14 @@ impl AlacritreeApp {
                         );
                         ui.add_space(4.0);
                         ui.label(RichText::new("Ctrl+B to toggle").small().color(theme.text_muted));
+                    } else if filtered_empty {
+                        ui.label(RichText::new("no matches").color(theme.text_dim).small());
                     }
 
                     for (idx, project) in self.projects.iter_mut().enumerate() {
+                        if filtering && !visible_projects.contains(&project.root) {
+                            continue;
+                        }
                         let proj_attention = project_attention.get(idx).copied().unwrap_or(false);
                         // Bubble attention up to the project row only when the
                         // project is collapsed — once expanded, the actual
@@ -1754,8 +1915,11 @@ impl AlacritreeApp {
                             });
                         }
 
-                        if project.expanded {
+                        if project.expanded || filtering {
                             for (wt_idx, wt) in project.worktrees.iter().enumerate() {
+                                if filtering && !visible_worktrees.contains(&wt.path) {
+                                    continue;
+                                }
                                 let is_active = self.current_workspace.as_deref() == Some(&wt.path);
                                 let wt_attention = worktree_attention
                                     .get(idx)
@@ -2775,6 +2939,28 @@ fn paint_git_row_cursor(
     paint_cursor_outline(ui, rect, theme);
     if scroll_into_view {
         ui.scroll_to_rect(rect, None);
+    }
+}
+
+/// One drained event's effect on the projects panel: either a filter outcome
+/// (search/toggle) or a plain browsing nav key.
+enum SidebarNavStep {
+    Filter(panel_filter::Outcome),
+    Nav(egui::Key),
+}
+
+/// Panel title plus its filter chrome, shared by both sidebars: the heading,
+/// then `[s]`-style chips for each active toggle, then a `/query▌` prompt while
+/// searching.  Renders only the title when the filter is idle.
+fn panel_header_filter_ui(ui: &mut egui::Ui, title: &str, filter: &PanelFilter, theme: &Theme) {
+    ui.label(RichText::new(title).color(theme.text).strong());
+    for key in filter.active_toggles() {
+        ui.label(RichText::new(format!("[{key}]")).color(theme.accent).monospace().small());
+    }
+    if filter.mode() == panel_filter::Mode::Search || !filter.query().is_empty() {
+        ui.label(
+            RichText::new(format!("/{}▌", filter.query())).color(theme.text).monospace().small(),
+        );
     }
 }
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2707,11 +2707,6 @@ fn focus_default(ctx: &Context, id: egui::Id) {
     }
 }
 
-/// Render a collapsed-when-empty git section.
-///
-/// Empty sections are skipped entirely — a placeholder glyph for "no files
-/// here" added visual noise without communicating anything the count badge
-/// didn't already say.
 /// Section header count: `visible of total` while a filter narrows the panel,
 /// the plain total otherwise.
 fn section_count_label(count: &SectionCount, filtering: bool) -> String {
@@ -2722,6 +2717,11 @@ fn section_count_label(count: &SectionCount, filtering: bool) -> String {
     }
 }
 
+/// Render a collapsed-when-empty git section.
+///
+/// Empty sections are skipped entirely — a placeholder glyph for "no files
+/// here" added visual noise without communicating anything the count badge
+/// didn't already say.
 fn section<R>(
     ui: &mut egui::Ui,
     theme: &Theme,

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -52,6 +52,7 @@ pub enum NamedAction {
     AddProject,
     ToggleSidebarFocus,
     FocusProjectsSidebar,
+    FocusGitSidebar,
     FocusTerminal,
     /// 1-indexed into the `[[ui.profiles]]` order.
     SpawnProfile(u8),
@@ -193,6 +194,7 @@ fn default_bindings() -> Vec<KeyBinding> {
             mods: ctrl_shift,
             action: BindingAction::Named(ToggleSidebarFocus),
         },
+        KeyBinding { key: Key::G, mods: ctrl_shift, action: BindingAction::Named(FocusGitSidebar) },
         KeyBinding { key: Key::T, mods: ctrl, action: BindingAction::Named(SpawnNewInstance) },
         KeyBinding { key: Key::Q, mods: ctrl, action: BindingAction::Named(Quit) },
     ]);
@@ -498,6 +500,7 @@ fn parse_action(name: &str) -> BindingAction {
         "AddProject" => BindingAction::Named(AddProject),
         "ToggleSidebarFocus" => BindingAction::Named(ToggleSidebarFocus),
         "FocusProjectsSidebar" => BindingAction::Named(FocusProjectsSidebar),
+        "FocusGitSidebar" => BindingAction::Named(FocusGitSidebar),
         "FocusTerminal" => BindingAction::Named(FocusTerminal),
         "SpawnProfile1" => BindingAction::Named(SpawnProfile(1)),
         "SpawnProfile2" => BindingAction::Named(SpawnProfile(2)),
@@ -703,6 +706,7 @@ mod tests {
             ("ToggleSidebarFocus", NamedAction::ToggleSidebarFocus),
             ("FocusProjectsSidebar", NamedAction::FocusProjectsSidebar),
             ("FocusTerminal", NamedAction::FocusTerminal),
+            ("FocusGitSidebar", NamedAction::FocusGitSidebar),
         ] {
             let b = parse_bindings(vec![raw_action("F1", None, name)]);
             assert_eq!(named_matches(&b, Key::F1, Modifiers::NONE), vec![expected], "{name}");
@@ -766,6 +770,7 @@ mod tests {
             (Key::T, ctrl, SpawnNewInstance),
             (Key::Q, ctrl, Quit),
             (Key::B, ctrl_shift, ToggleSidebarFocus),
+            (Key::G, ctrl_shift, FocusGitSidebar),
         ] {
             assert_eq!(named_matches(&b, key, mods), vec![expected], "{key:?}+{mods:?}");
         }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -231,6 +231,24 @@ fn parse_confirm_session_close(raw: Option<&str>) -> ConfirmSessionClose {
     }
 }
 
+/// Text-presentation magnifier (U+2315).  Not in egui's bundled fonts; it
+/// resolves through the system fallback chain `fonts.rs` registers.
+const DEFAULT_SEARCH_ICON: &str = "⌕";
+
+/// Sidebar glyphs overridable via `[ui.icons]`, for users whose fonts carry
+/// nicer symbols (Nerd Fonts etc.).
+#[derive(Debug, Clone)]
+pub struct UiIcons {
+    /// Glyph prefixing the sidebar search prompt.
+    pub search: String,
+}
+
+impl Default for UiIcons {
+    fn default() -> Self {
+        Self { search: DEFAULT_SEARCH_ICON.into() }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct UiTheme {
     pub sidebar_background: Option<Color32>,
@@ -241,6 +259,7 @@ pub struct UiTheme {
     pub notifications: bool,
     /// Ask before the sidebar's per-session `×` kills the PTY.
     pub confirm_session_close: ConfirmSessionClose,
+    pub icons: UiIcons,
 }
 
 impl Default for UiTheme {
@@ -252,6 +271,7 @@ impl Default for UiTheme {
             sidebar_accent: None,
             notifications: true,
             confirm_session_close: ConfirmSessionClose::Never,
+            icons: UiIcons::default(),
         }
     }
 }
@@ -772,6 +792,15 @@ struct RawIndexed {
     color: RgbStr,
 }
 
+/// `[ui.icons]`: sidebar glyph overrides.  Any string works, so Nerd Font
+/// users can substitute their own icons.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RawUiIcons {
+    /// Glyph prefixing the sidebar search prompt.
+    search: Option<String>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 struct RawUiWsl {
@@ -793,6 +822,7 @@ struct RawUi {
     /// When the sidebar × on a session row asks before killing the PTY:
     /// "never" (default) | "busy" | "always".
     confirm_session_close: Option<String>,
+    icons: RawUiIcons,
     wsl: RawUiWsl,
     profiles: Vec<RawProfile>,
     default_profile: Option<String>,
@@ -921,6 +951,9 @@ impl RawConfig {
             confirm_session_close: parse_confirm_session_close(
                 self.ui.confirm_session_close.as_deref(),
             ),
+            icons: UiIcons {
+                search: self.ui.icons.search.unwrap_or_else(|| DEFAULT_SEARCH_ICON.into()),
+            },
         };
 
         // ---- Font ----
@@ -1178,6 +1211,12 @@ mod tests {
     fn confirm_session_close_invalid_falls_back_to_never() {
         let ui = ui_from_toml("[ui]\nconfirm_session_close = \"sometimes\"");
         assert_eq!(ui.confirm_session_close, ConfirmSessionClose::Never);
+    }
+
+    #[test]
+    fn search_icon_defaults_and_overrides() {
+        assert_eq!(ui_from_toml("").icons.search, DEFAULT_SEARCH_ICON);
+        assert_eq!(ui_from_toml("[ui.icons]\nsearch = \"\u{f002}\"").icons.search, "\u{f002}");
     }
 
     #[test]

--- a/alacritree/src/git_nav.rs
+++ b/alacritree/src/git_nav.rs
@@ -1,0 +1,256 @@
+//! Pure row model and cursor for the git-status sidebar.
+//!
+//! Rows are identified by `(section, path)`, not indices: the status lists
+//! refresh underneath the cursor every 1.5 s, and a file's `ChangeKind` can
+//! change between refreshes (staged -> modified, say) without the row
+//! changing identity. An index would silently retarget the cursor onto
+//! whatever file happens to land at that position next.
+
+use crate::git_status::{ChangeKind, DiffStat, FileChange};
+
+/// Which list of the git panel a row belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitSection {
+    Staged,
+    Unstaged,
+    Branch,
+}
+
+/// A row the git-panel cursor can rest on, in render order.
+#[derive(Debug, Clone)]
+pub struct GitRow {
+    pub section: GitSection,
+    pub path: String,
+    /// `None` for branch-diff rows: `DiffStat` carries no `ChangeKind`.
+    pub kind: Option<ChangeKind>,
+}
+
+impl PartialEq for GitRow {
+    fn eq(&self, other: &Self) -> bool {
+        self.section == other.section && self.path == other.path
+    }
+}
+
+/// Visible/total counts for one section, for the panel's header labels.
+pub struct SectionCount {
+    pub visible: usize,
+    pub total: usize,
+}
+
+pub struct GitRows {
+    pub rows: Vec<GitRow>,
+    pub staged: SectionCount,
+    pub unstaged: SectionCount,
+    pub branch: SectionCount,
+}
+
+/// Filters one file-change list into rows, in list order.
+///
+/// Conflicted files bypass `kind_pass`: a merge conflict must stay visible
+/// no matter which kind toggles are active, since hiding it is how you lose
+/// track of unresolved work.
+fn push_change_rows(
+    changes: &[FileChange],
+    section: GitSection,
+    kind_pass: &dyn Fn(ChangeKind) -> bool,
+    query_pass: &mut dyn FnMut(&str) -> bool,
+    rows: &mut Vec<GitRow>,
+) -> SectionCount {
+    let mut visible = 0;
+    for change in changes {
+        let kind_ok = change.kind == ChangeKind::Conflicted || kind_pass(change.kind);
+        if kind_ok && query_pass(&change.path) {
+            rows.push(GitRow { section, path: change.path.clone(), kind: Some(change.kind) });
+            visible += 1;
+        }
+    }
+    SectionCount { visible, total: changes.len() }
+}
+
+/// Render-order rows under the active kind/query filters: Staged, then
+/// Unstaged, then Branch. Branch rows have no `ChangeKind` to test against
+/// `kind_pass`, so only `query_pass` applies to them.
+pub fn visible_rows(
+    staged: &[FileChange],
+    unstaged: &[FileChange],
+    branch: &[DiffStat],
+    kind_pass: &dyn Fn(ChangeKind) -> bool,
+    query_pass: &mut dyn FnMut(&str) -> bool,
+) -> GitRows {
+    let mut rows = Vec::new();
+    let staged_count =
+        push_change_rows(staged, GitSection::Staged, kind_pass, query_pass, &mut rows);
+    let unstaged_count =
+        push_change_rows(unstaged, GitSection::Unstaged, kind_pass, query_pass, &mut rows);
+
+    let mut branch_visible = 0;
+    for stat in branch {
+        if query_pass(&stat.path) {
+            rows.push(GitRow { section: GitSection::Branch, path: stat.path.clone(), kind: None });
+            branch_visible += 1;
+        }
+    }
+
+    GitRows {
+        rows,
+        staged: staged_count,
+        unstaged: unstaged_count,
+        branch: SectionCount { visible: branch_visible, total: branch.len() },
+    }
+}
+
+/// The row `delta` steps away from `cursor`, clamped to the list ends.
+/// `None` only when `rows` is empty.
+pub fn step(rows: &[GitRow], cursor: &GitRow, delta: i32) -> Option<GitRow> {
+    if rows.is_empty() {
+        return None;
+    }
+    let pos = rows.iter().position(|r| r == cursor).unwrap_or(0);
+    let last = rows.len() as i32 - 1;
+    let new = (pos as i32 + delta).clamp(0, last) as usize;
+    Some(rows[new].clone())
+}
+
+/// Cursor fallback: unchanged when still visible, else the first row, else
+/// `None` when the panel has nothing to show.
+pub fn ensure_cursor(rows: &[GitRow], cursor: Option<&GitRow>) -> Option<GitRow> {
+    match cursor {
+        Some(c) if rows.contains(c) => Some(c.clone()),
+        _ => rows.first().cloned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn change(path: &str, kind: ChangeKind) -> FileChange {
+        FileChange { path: path.to_string(), kind }
+    }
+
+    fn stat(path: &str) -> DiffStat {
+        DiffStat { path: path.to_string(), additions: 1, deletions: 0 }
+    }
+
+    fn row(section: GitSection, path: &str, kind: Option<ChangeKind>) -> GitRow {
+        GitRow { section, path: path.to_string(), kind }
+    }
+
+    const ALL: &dyn Fn(ChangeKind) -> bool = &|_| true;
+    const NONE: &dyn Fn(ChangeKind) -> bool = &|_| false;
+
+    #[test]
+    fn rows_preserve_section_order_and_counts() {
+        let staged = vec![change("a.rs", ChangeKind::Added)];
+        let unstaged = vec![change("b.rs", ChangeKind::Modified)];
+        let branch = vec![stat("c.rs")];
+        let mut query_pass = |_: &str| true;
+
+        let result = visible_rows(&staged, &unstaged, &branch, ALL, &mut query_pass);
+
+        assert_eq!(
+            result.rows,
+            vec![
+                row(GitSection::Staged, "a.rs", Some(ChangeKind::Added)),
+                row(GitSection::Unstaged, "b.rs", Some(ChangeKind::Modified)),
+                row(GitSection::Branch, "c.rs", None),
+            ]
+        );
+        assert_eq!((result.staged.visible, result.staged.total), (1, 1));
+        assert_eq!((result.unstaged.visible, result.unstaged.total), (1, 1));
+        assert_eq!((result.branch.visible, result.branch.total), (1, 1));
+    }
+
+    #[test]
+    fn kind_filter_applies_to_staged_and_unstaged_but_not_branch() {
+        let staged = vec![change("a.rs", ChangeKind::Added)];
+        let unstaged = vec![change("b.rs", ChangeKind::Modified)];
+        let branch = vec![stat("c.rs")];
+        let mut query_pass = |_: &str| true;
+
+        let result = visible_rows(&staged, &unstaged, &branch, NONE, &mut query_pass);
+
+        assert_eq!(result.rows, vec![row(GitSection::Branch, "c.rs", None)]);
+        assert_eq!((result.staged.visible, result.staged.total), (0, 1));
+        assert_eq!((result.unstaged.visible, result.unstaged.total), (0, 1));
+        assert_eq!((result.branch.visible, result.branch.total), (1, 1));
+    }
+
+    #[test]
+    fn conflicted_rows_bypass_the_kind_filter() {
+        let staged = vec![change("conflict.rs", ChangeKind::Conflicted)];
+        let unstaged: Vec<FileChange> = Vec::new();
+        let branch: Vec<DiffStat> = Vec::new();
+        let mut query_pass = |_: &str| true;
+
+        let result = visible_rows(&staged, &unstaged, &branch, NONE, &mut query_pass);
+
+        assert_eq!(
+            result.rows,
+            vec![row(GitSection::Staged, "conflict.rs", Some(ChangeKind::Conflicted))]
+        );
+        assert_eq!((result.staged.visible, result.staged.total), (1, 1));
+    }
+
+    #[test]
+    fn query_filters_all_sections() {
+        let staged =
+            vec![change("keep.rs", ChangeKind::Added), change("drop.rs", ChangeKind::Added)];
+        let unstaged =
+            vec![change("keep.rs", ChangeKind::Modified), change("drop.rs", ChangeKind::Modified)];
+        let branch = vec![stat("keep.rs"), stat("drop.rs")];
+        let mut query_pass = |path: &str| path.starts_with("keep");
+
+        let result = visible_rows(&staged, &unstaged, &branch, ALL, &mut query_pass);
+
+        assert_eq!(
+            result.rows,
+            vec![
+                row(GitSection::Staged, "keep.rs", Some(ChangeKind::Added)),
+                row(GitSection::Unstaged, "keep.rs", Some(ChangeKind::Modified)),
+                row(GitSection::Branch, "keep.rs", None),
+            ]
+        );
+        assert_eq!((result.staged.visible, result.staged.total), (1, 2));
+        assert_eq!((result.unstaged.visible, result.unstaged.total), (1, 2));
+        assert_eq!((result.branch.visible, result.branch.total), (1, 2));
+    }
+
+    #[test]
+    fn step_clamps_and_ensure_cursor_falls_back_to_first() {
+        let rows = vec![
+            row(GitSection::Staged, "a.rs", Some(ChangeKind::Added)),
+            row(GitSection::Unstaged, "b.rs", Some(ChangeKind::Modified)),
+        ];
+
+        assert_eq!(step(&rows, &rows[0], 1), Some(rows[1].clone()));
+        // Clamp: no wrap past either end.
+        assert_eq!(step(&rows, &rows[1], 1), Some(rows[1].clone()));
+        assert_eq!(step(&rows, &rows[0], -1), Some(rows[0].clone()));
+        // Empty rows: None regardless of cursor.
+        assert_eq!(step(&[], &rows[0], 1), None);
+
+        // Still visible: unchanged.
+        assert_eq!(ensure_cursor(&rows, Some(&rows[1])), Some(rows[1].clone()));
+        // Vanished cursor and no cursor both fall back to the first row.
+        let gone = row(GitSection::Branch, "gone.rs", None);
+        assert_eq!(ensure_cursor(&rows, Some(&gone)), Some(rows[0].clone()));
+        assert_eq!(ensure_cursor(&rows, None), Some(rows[0].clone()));
+        // Empty rows always fall back to None.
+        assert_eq!(ensure_cursor(&[], Some(&rows[0])), None);
+        assert_eq!(ensure_cursor(&[], None), None);
+    }
+
+    #[test]
+    fn cursor_identity_ignores_kind_changes() {
+        let staged_kind = row(GitSection::Staged, "a.rs", Some(ChangeKind::Added));
+        let modified_kind = row(GitSection::Staged, "a.rs", Some(ChangeKind::Modified));
+        assert_eq!(staged_kind, modified_kind);
+
+        let different_section = row(GitSection::Unstaged, "a.rs", Some(ChangeKind::Added));
+        assert_ne!(staged_kind, different_section);
+
+        let different_path = row(GitSection::Staged, "b.rs", Some(ChangeKind::Added));
+        assert_ne!(staged_kind, different_path);
+    }
+}

--- a/alacritree/src/git_status.rs
+++ b/alacritree/src/git_status.rs
@@ -170,6 +170,13 @@ impl StatusCache {
         self.last.branch.as_deref()
     }
 
+    /// The most recent known status without triggering a refresh, for callers
+    /// that need to re-derive rows between polls (e.g. re-filtering on a
+    /// keystroke).
+    pub fn last(&self) -> &GitStatus {
+        &self.last
+    }
+
     /// Returns the most recent known status, kicking off a background refresh
     /// when stale or when the default-branch hint changed since the last
     /// completed compute.  Never blocks the caller.

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -11,6 +11,7 @@ mod command_ext;
 mod config;
 mod doppler;
 mod fonts;
+mod git_nav;
 mod git_status;
 mod ime;
 mod input;

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -18,6 +18,7 @@ mod ipc;
 mod links;
 mod mcp;
 mod mouse;
+mod panel_filter;
 mod paste;
 mod pr_status;
 mod projects;

--- a/alacritree/src/panel_filter.rs
+++ b/alacritree/src/panel_filter.rs
@@ -1,0 +1,288 @@
+//! Per-panel input mode, fuzzy-search query, and toggle-filter state for the
+//! sidebars.
+//!
+//! The search prompt this drives is custom-drawn (`/query` + caret), not an
+//! egui `TextEdit`: giving a widget native egui focus would fight the
+//! terminal view, which egui fake-clicks on Space/Enter whenever it holds
+//! that same native focus. Routing `Event::Text`/key presses through this
+//! module instead lets the terminal view keep focus throughout.
+
+use std::collections::BTreeSet;
+
+use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher, Utf32Str};
+
+/// Whether a panel is browsing its rows or typing a fuzzy-search query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Browsing,
+    Search,
+}
+
+/// What the caller should do in response to a key/text event the filter
+/// consumed. `None` from `on_key`/`on_text` means the event fell through
+/// unconsumed and the caller's existing handling should run instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    FilterChanged,
+    MoveCursor(i32),
+    Activate,
+    LeavePanel,
+    Consumed,
+}
+
+/// Search/toggle state for one sidebar panel.
+pub struct PanelFilter {
+    allowed_toggles: &'static [char],
+    mode: Mode,
+    query: String,
+    toggles: BTreeSet<char>,
+    pattern: Pattern,
+    matcher: Matcher,
+    buf: Vec<char>,
+}
+
+impl PanelFilter {
+    pub fn new(allowed_toggles: &'static [char]) -> Self {
+        Self {
+            allowed_toggles,
+            mode: Mode::Browsing,
+            pattern: parse_pattern(""),
+            query: String::new(),
+            toggles: BTreeSet::new(),
+            matcher: Matcher::new(Config::DEFAULT),
+            buf: Vec::new(),
+        }
+    }
+
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    pub fn is_toggled(&self, key: char) -> bool {
+        self.toggles.contains(&key)
+    }
+
+    /// Active toggles in `allowed_toggles` order (render order).
+    pub fn active_toggles(&self) -> Vec<char> {
+        self.allowed_toggles.iter().copied().filter(|k| self.toggles.contains(k)).collect()
+    }
+
+    /// Whether the panel currently narrows its rows: a non-empty query or
+    /// any active toggle.
+    pub fn is_filtering(&self) -> bool {
+        !self.query.is_empty() || !self.toggles.is_empty()
+    }
+
+    pub fn on_key(&mut self, key: egui::Key) -> Option<Outcome> {
+        match self.mode {
+            Mode::Browsing => match key {
+                egui::Key::Escape if !self.toggles.is_empty() => {
+                    self.toggles.clear();
+                    Some(Outcome::FilterChanged)
+                },
+                egui::Key::Escape => Some(Outcome::LeavePanel),
+                _ => None,
+            },
+            Mode::Search => match key {
+                egui::Key::Backspace => {
+                    self.query.pop();
+                    self.rebuild_pattern();
+                    Some(Outcome::FilterChanged)
+                },
+                egui::Key::ArrowUp => Some(Outcome::MoveCursor(-1)),
+                egui::Key::ArrowDown => Some(Outcome::MoveCursor(1)),
+                egui::Key::Enter => {
+                    self.clear_query();
+                    self.mode = Mode::Browsing;
+                    Some(Outcome::Activate)
+                },
+                egui::Key::Escape => {
+                    self.clear_query();
+                    self.mode = Mode::Browsing;
+                    Some(Outcome::FilterChanged)
+                },
+                _ => None,
+            },
+        }
+    }
+
+    pub fn on_text(&mut self, text: &str) -> Option<Outcome> {
+        match self.mode {
+            Mode::Browsing => {
+                if text == "/" {
+                    self.mode = Mode::Search;
+                    return Some(Outcome::Consumed);
+                }
+                let mut chars = text.chars();
+                let (Some(c), None) = (chars.next(), chars.next()) else {
+                    return None;
+                };
+                if !self.allowed_toggles.contains(&c) {
+                    return None;
+                }
+                if !self.toggles.remove(&c) {
+                    self.toggles.insert(c);
+                }
+                Some(Outcome::FilterChanged)
+            },
+            Mode::Search => {
+                self.query.push_str(text);
+                self.rebuild_pattern();
+                Some(Outcome::FilterChanged)
+            },
+        }
+    }
+
+    /// Whether `haystack` matches the current query. An empty query matches
+    /// everything.
+    pub fn matches(&mut self, haystack: &str) -> bool {
+        if self.query.is_empty() {
+            return true;
+        }
+        let haystack = Utf32Str::new(haystack, &mut self.buf);
+        self.pattern.score(haystack, &mut self.matcher).is_some()
+    }
+
+    fn clear_query(&mut self) {
+        self.query.clear();
+        self.rebuild_pattern();
+    }
+
+    fn rebuild_pattern(&mut self) {
+        self.pattern = parse_pattern(&self.query);
+    }
+}
+
+fn parse_pattern(query: &str) -> Pattern {
+    Pattern::parse(query, CaseMatching::Smart, Normalization::Smart)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOGGLES: &[char] = &['s', 'a'];
+
+    #[test]
+    fn slash_enters_search_mode_and_is_consumed() {
+        let mut f = PanelFilter::new(TOGGLES);
+        assert_eq!(f.on_text("/"), Some(Outcome::Consumed));
+        assert_eq!(f.mode(), Mode::Search);
+    }
+
+    #[test]
+    fn typing_in_search_builds_the_query_and_reports_filter_change() {
+        let mut f = PanelFilter::new(TOGGLES);
+        f.on_text("/");
+        assert_eq!(f.on_text("f"), Some(Outcome::FilterChanged));
+        assert_eq!(f.on_text("oo"), Some(Outcome::FilterChanged));
+        assert_eq!(f.query(), "foo");
+    }
+
+    #[test]
+    fn backspace_pops_and_esc_clears_back_to_browsing() {
+        let mut f = PanelFilter::new(TOGGLES);
+        f.on_text("/");
+        f.on_text("foo");
+        assert_eq!(f.on_key(egui::Key::Backspace), Some(Outcome::FilterChanged));
+        assert_eq!(f.query(), "fo");
+
+        assert_eq!(f.on_key(egui::Key::Escape), Some(Outcome::FilterChanged));
+        assert_eq!(f.mode(), Mode::Browsing);
+        assert_eq!(f.query(), "");
+    }
+
+    #[test]
+    fn enter_in_search_activates_and_clears_the_query() {
+        let mut f = PanelFilter::new(TOGGLES);
+        f.on_text("/");
+        f.on_text("foo");
+        assert_eq!(f.on_key(egui::Key::Enter), Some(Outcome::Activate));
+        assert_eq!(f.mode(), Mode::Browsing);
+        assert_eq!(f.query(), "");
+    }
+
+    #[test]
+    fn arrows_in_search_move_the_cursor() {
+        let mut f = PanelFilter::new(TOGGLES);
+        f.on_text("/");
+        assert_eq!(f.on_key(egui::Key::ArrowUp), Some(Outcome::MoveCursor(-1)));
+        assert_eq!(f.on_key(egui::Key::ArrowDown), Some(Outcome::MoveCursor(1)));
+    }
+
+    #[test]
+    fn toggle_keys_flip_in_browsing_and_are_inert_in_search() {
+        let mut f = PanelFilter::new(TOGGLES);
+        assert_eq!(f.on_text("s"), Some(Outcome::FilterChanged));
+        assert!(f.is_toggled('s'));
+        assert_eq!(f.active_toggles(), vec!['s']);
+
+        assert_eq!(f.on_text("s"), Some(Outcome::FilterChanged));
+        assert!(!f.is_toggled('s'));
+
+        f.on_text("/");
+        assert_eq!(f.on_text("s"), Some(Outcome::FilterChanged));
+        assert_eq!(f.query(), "s");
+        assert!(!f.is_toggled('s'));
+    }
+
+    #[test]
+    fn esc_in_browsing_clears_toggles_before_leaving_the_panel() {
+        let mut f = PanelFilter::new(TOGGLES);
+        f.on_text("s");
+        assert!(f.is_toggled('s'));
+
+        assert_eq!(f.on_key(egui::Key::Escape), Some(Outcome::FilterChanged));
+        assert!(!f.is_toggled('s'));
+
+        assert_eq!(f.on_key(egui::Key::Escape), Some(Outcome::LeavePanel));
+    }
+
+    #[test]
+    fn unknown_keys_and_text_are_not_consumed_in_browsing() {
+        let mut f = PanelFilter::new(TOGGLES);
+        assert_eq!(f.on_text("x"), None);
+        assert_eq!(f.on_key(egui::Key::ArrowDown), None);
+        assert_eq!(f.on_key(egui::Key::Enter), None);
+    }
+
+    #[test]
+    fn is_filtering_tracks_query_and_toggles() {
+        let mut f = PanelFilter::new(TOGGLES);
+        assert!(!f.is_filtering());
+
+        f.on_text("s");
+        assert!(f.is_filtering());
+        f.on_text("s");
+        assert!(!f.is_filtering());
+
+        f.on_text("/");
+        f.on_text("x");
+        assert!(f.is_filtering());
+    }
+
+    #[test]
+    fn fuzzy_match_is_subsequence_and_smart_case() {
+        let mut f = PanelFilter::new(TOGGLES);
+        assert!(f.matches("anything"));
+
+        f.on_text("/");
+        f.on_text("fdps");
+        assert!(f.matches("fix/diff-pane-scroll"));
+
+        let mut f = PanelFilter::new(TOGGLES);
+        f.on_text("/");
+        f.on_text("readme");
+        assert!(f.matches("README.md"));
+
+        let mut f = PanelFilter::new(TOGGLES);
+        f.on_text("/");
+        f.on_text("Read");
+        assert!(!f.matches("readme"));
+    }
+}

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -836,9 +836,17 @@ mod tests {
         let lines: String = (0..500).map(|i| format!("line {i}\n")).collect();
         std::fs::write(&page, lines).unwrap();
 
+        // The app exports a capable TERM before any session can spawn
+        // (`tty::setup_env` in `AlacritreeApp::new`), but this test spawns
+        // without the app, so a bare runner's unset or `dumb` TERM would reach
+        // the pager and `less` would never leave the primary screen. Inject
+        // the fallback `setup_env` guarantees.
+        let mut config = Config::default();
+        config.env.insert("TERM".to_string(), "xterm-256color".to_string());
+
         let session = Session::spawn_command(
             egui::Context::default(),
-            &Config::default(),
+            &config,
             std::env::current_dir().ok(),
             TermSize::new(80, 24),
             (8.0, 16.0),

--- a/alacritree/src/sidebar_nav.rs
+++ b/alacritree/src/sidebar_nav.rs
@@ -276,6 +276,24 @@ mod tests {
     }
 
     #[test]
+    fn filtered_rows_drops_projects_matching_neither_self_nor_worktrees() {
+        let projects = vec![project("/a", true, &["/a/wt1"]), project("/b", true, &["/b/wt1"])];
+        let preds = RowPredicates {
+            home: true,
+            project_self: &|p| p.root == PathBuf::from("/a"),
+            worktree: &mut |p, _wt| p.root == PathBuf::from("/a"),
+        };
+        assert_eq!(
+            filtered_rows(&projects, preds),
+            vec![
+                SidebarRow::Home,
+                SidebarRow::Project(PathBuf::from("/a")),
+                SidebarRow::Worktree(PathBuf::from("/a/wt1")),
+            ]
+        );
+    }
+
+    #[test]
     fn ensure_cursor_keeps_a_visible_row_and_falls_back_to_first() {
         let rows = vec![SidebarRow::Home, SidebarRow::Project(PathBuf::from("/a"))];
         // Still visible: unchanged.

--- a/alacritree/src/sidebar_nav.rs
+++ b/alacritree/src/sidebar_nav.rs
@@ -4,9 +4,12 @@
 //! indices: the project list mutates underneath the cursor (git-status
 //! refresh, worktree add/remove), and an index would silently retarget.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::app::WorkspaceKey;
 use crate::projects::{Project, Worktree};
+use crate::session::SessionId;
 
 /// A row the sidebar cursor can rest on, in render order.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,16 +19,36 @@ pub enum SidebarRow {
     Project(PathBuf),
     /// Worktree row, keyed by the worktree path.
     Worktree(PathBuf),
+    /// Session row, keyed by its stable session id.  Only present when its
+    /// workspace lists sessions in the sidebar.
+    Session(SessionId),
+}
+
+/// The session rows each workspace currently *displays*, keyed by workspace.
+/// The caller owns the listing rule (threshold, config overrides); taking the
+/// resolved listing keeps the cursor model unable to drift from the paint
+/// pass.
+pub type ListedSessions = HashMap<WorkspaceKey, Vec<SessionId>>;
+
+fn push_session_rows(rows: &mut Vec<SidebarRow>, sessions: &ListedSessions, ws: &WorkspaceKey) {
+    if let Some(ids) = sessions.get(ws) {
+        rows.extend(ids.iter().copied().map(SidebarRow::Session));
+    }
 }
 
 /// Every row the sidebar currently renders, in render order: Home first,
-/// then each project's header followed by its worktrees when expanded.
-pub fn visible_rows(projects: &[Project]) -> Vec<SidebarRow> {
+/// then each project's header followed by its worktrees when expanded, with
+/// each workspace's listed session rows directly after its own row.
+pub fn visible_rows(projects: &[Project], sessions: &ListedSessions) -> Vec<SidebarRow> {
     let mut rows = vec![SidebarRow::Home];
+    push_session_rows(&mut rows, sessions, &None);
     for p in projects {
         rows.push(SidebarRow::Project(p.root.clone()));
         if p.expanded {
-            rows.extend(p.worktrees.iter().map(|wt| SidebarRow::Worktree(wt.path.clone())));
+            for wt in &p.worktrees {
+                rows.push(SidebarRow::Worktree(wt.path.clone()));
+                push_session_rows(&mut rows, sessions, &Some(wt.path.clone()));
+            }
         }
     }
     rows
@@ -43,20 +66,48 @@ pub fn step(rows: &[SidebarRow], cursor: &SidebarRow, delta: i32) -> SidebarRow 
     rows[new].clone()
 }
 
-/// The project header owning a worktree row — the standard tree-view
-/// "Left jumps to parent" idiom.  `None` for Home and project cursors.
+/// The row owning `cursor` — the standard tree-view "Left jumps to parent"
+/// idiom.  A worktree's parent is its project header; a session's parent is
+/// the worktree (or Home) row it's listed under.  `None` for Home and
+/// project cursors.
 pub fn left_target(rows: &[SidebarRow], cursor: &SidebarRow) -> Option<SidebarRow> {
-    if !matches!(cursor, SidebarRow::Worktree(_)) {
-        return None;
-    }
     let pos = rows.iter().position(|r| r == cursor)?;
-    rows[..pos].iter().rev().find(|r| matches!(r, SidebarRow::Project(_))).cloned()
+    match cursor {
+        SidebarRow::Worktree(_) => {
+            rows[..pos].iter().rev().find(|r| matches!(r, SidebarRow::Project(_))).cloned()
+        },
+        SidebarRow::Session(_) => rows[..pos]
+            .iter()
+            .rev()
+            .find(|r| matches!(r, SidebarRow::Worktree(_) | SidebarRow::Home))
+            .cloned(),
+        _ => None,
+    }
 }
 
-/// Where the cursor lands when the sidebar gains focus: the current
-/// workspace's row, its project header when that project is collapsed,
-/// Home otherwise.
-pub fn seed(projects: &[Project], current_workspace: Option<&Path>) -> SidebarRow {
+/// Where the cursor lands when the sidebar gains focus: the active session's
+/// row when it's currently listed in the sidebar, otherwise the current
+/// workspace's row, its project header when that project is collapsed, or
+/// Home.
+pub fn seed(
+    projects: &[Project],
+    current_workspace: Option<&Path>,
+    sessions: &ListedSessions,
+    active: Option<SessionId>,
+) -> SidebarRow {
+    if let Some(id) = active {
+        let ws: WorkspaceKey = current_workspace.map(Path::to_path_buf);
+        // Session rows of a worktree only show while its project is expanded.
+        let shown = match &ws {
+            None => true,
+            Some(path) => {
+                projects.iter().any(|p| p.expanded && p.worktrees.iter().any(|wt| wt.path == *path))
+            },
+        };
+        if shown && sessions.get(&ws).is_some_and(|ids| ids.contains(&id)) {
+            return SidebarRow::Session(id);
+        }
+    }
     let Some(path) = current_workspace else {
         return SidebarRow::Home;
     };
@@ -82,20 +133,26 @@ pub struct RowPredicates<'a> {
 
 /// Render-order rows under an active filter. Projects are force-expanded (a
 /// filter that hides its own results is useless); a header survives when it
-/// matches itself or keeps at least one visible worktree.
-pub fn filtered_rows(projects: &[Project], preds: RowPredicates<'_>) -> Vec<SidebarRow> {
+/// matches itself or keeps at least one visible worktree.  Surviving
+/// workspace rows keep their listed session rows — the filter matches
+/// workspaces, not sessions.
+pub fn filtered_rows(
+    projects: &[Project],
+    sessions: &ListedSessions,
+    preds: RowPredicates<'_>,
+) -> Vec<SidebarRow> {
     let mut rows = Vec::new();
     if preds.home {
         rows.push(SidebarRow::Home);
+        push_session_rows(&mut rows, sessions, &None);
     }
     for p in projects {
         let self_matches = (preds.project_self)(p);
-        let visible_worktrees: Vec<SidebarRow> = p
-            .worktrees
-            .iter()
-            .filter(|wt| (preds.worktree)(p, wt))
-            .map(|wt| SidebarRow::Worktree(wt.path.clone()))
-            .collect();
+        let mut visible_worktrees: Vec<SidebarRow> = Vec::new();
+        for wt in p.worktrees.iter().filter(|wt| (preds.worktree)(p, wt)) {
+            visible_worktrees.push(SidebarRow::Worktree(wt.path.clone()));
+            push_session_rows(&mut visible_worktrees, sessions, &Some(wt.path.clone()));
+        }
         if self_matches || !visible_worktrees.is_empty() {
             rows.push(SidebarRow::Project(p.root.clone()));
             rows.extend(visible_worktrees);
@@ -116,6 +173,10 @@ pub fn ensure_cursor(rows: &[SidebarRow], cursor: Option<&SidebarRow>) -> Option
 mod tests {
     use super::*;
     use crate::projects::Worktree;
+
+    fn no_sessions() -> ListedSessions {
+        HashMap::new()
+    }
 
     pub(super) fn project(root: &str, expanded: bool, worktrees: &[&str]) -> Project {
         Project {
@@ -143,7 +204,7 @@ mod tests {
         let projects =
             vec![project("/a", true, &["/a/wt1", "/a/wt2"]), project("/b", true, &["/b/wt1"])];
         assert_eq!(
-            visible_rows(&projects),
+            visible_rows(&projects, &no_sessions()),
             vec![
                 SidebarRow::Home,
                 SidebarRow::Project(PathBuf::from("/a")),
@@ -159,19 +220,19 @@ mod tests {
     fn visible_rows_hides_worktrees_of_collapsed_projects() {
         let projects = vec![project("/a", false, &["/a/wt1"])];
         assert_eq!(
-            visible_rows(&projects),
+            visible_rows(&projects, &no_sessions()),
             vec![SidebarRow::Home, SidebarRow::Project(PathBuf::from("/a")),]
         );
     }
 
     #[test]
     fn visible_rows_with_no_projects_is_just_home() {
-        assert_eq!(visible_rows(&[]), vec![SidebarRow::Home]);
+        assert_eq!(visible_rows(&[], &no_sessions()), vec![SidebarRow::Home]);
     }
 
     #[test]
     fn step_moves_and_clamps_at_both_ends() {
-        let rows = visible_rows(&[project("/a", true, &["/a/wt1"])]);
+        let rows = visible_rows(&[project("/a", true, &["/a/wt1"])], &no_sessions());
         // Home -> Project -> Worktree
         assert_eq!(step(&rows, &SidebarRow::Home, 1), SidebarRow::Project(PathBuf::from("/a")));
         assert_eq!(
@@ -188,7 +249,7 @@ mod tests {
 
     #[test]
     fn step_from_vanished_cursor_falls_back_to_home() {
-        let rows = visible_rows(&[project("/a", true, &["/a/wt1"])]);
+        let rows = visible_rows(&[project("/a", true, &["/a/wt1"])], &no_sessions());
         let gone = SidebarRow::Worktree(PathBuf::from("/a/removed"));
         assert_eq!(step(&rows, &gone, 1), SidebarRow::Home);
     }
@@ -197,7 +258,7 @@ mod tests {
     fn left_target_is_the_owning_project_header() {
         let rows =
             vec![project("/a", true, &["/a/wt1"]), project("/b", true, &["/b/wt1", "/b/wt2"])];
-        let rows = visible_rows(&rows);
+        let rows = visible_rows(&rows, &no_sessions());
         assert_eq!(
             left_target(&rows, &SidebarRow::Worktree(PathBuf::from("/b/wt2"))),
             Some(SidebarRow::Project(PathBuf::from("/b")))
@@ -213,17 +274,20 @@ mod tests {
         let projects = vec![project("/a", true, &["/a/wt1"]), project("/b", false, &["/b/wt1"])];
         // Expanded project: the worktree row itself.
         assert_eq!(
-            seed(&projects, Some(Path::new("/a/wt1"))),
+            seed(&projects, Some(Path::new("/a/wt1")), &no_sessions(), None),
             SidebarRow::Worktree(PathBuf::from("/a/wt1"))
         );
         // Collapsed project: its header stands in for the hidden row.
         assert_eq!(
-            seed(&projects, Some(Path::new("/b/wt1"))),
+            seed(&projects, Some(Path::new("/b/wt1")), &no_sessions(), None),
             SidebarRow::Project(PathBuf::from("/b"))
         );
         // Home workspace and unknown paths both land on Home.
-        assert_eq!(seed(&projects, None), SidebarRow::Home);
-        assert_eq!(seed(&projects, Some(Path::new("/nowhere"))), SidebarRow::Home);
+        assert_eq!(seed(&projects, None, &no_sessions(), None), SidebarRow::Home);
+        assert_eq!(
+            seed(&projects, Some(Path::new("/nowhere")), &no_sessions(), None),
+            SidebarRow::Home
+        );
     }
 
     #[test]
@@ -235,7 +299,7 @@ mod tests {
             worktree: &mut |_p, wt| wt.path == PathBuf::from("/a/wt1"),
         };
         assert_eq!(
-            filtered_rows(&projects, preds),
+            filtered_rows(&projects, &no_sessions(), preds),
             vec![
                 SidebarRow::Home,
                 SidebarRow::Project(PathBuf::from("/a")),
@@ -253,7 +317,7 @@ mod tests {
             worktree: &mut |_p, _wt| false,
         };
         assert_eq!(
-            filtered_rows(&projects, preds),
+            filtered_rows(&projects, &no_sessions(), preds),
             vec![SidebarRow::Home, SidebarRow::Project(PathBuf::from("/a"))]
         );
     }
@@ -267,7 +331,7 @@ mod tests {
             worktree: &mut |_p, _wt| true,
         };
         assert_eq!(
-            filtered_rows(&projects, preds),
+            filtered_rows(&projects, &no_sessions(), preds),
             vec![
                 SidebarRow::Project(PathBuf::from("/a")),
                 SidebarRow::Worktree(PathBuf::from("/a/wt1"))
@@ -284,13 +348,122 @@ mod tests {
             worktree: &mut |p, _wt| p.root == PathBuf::from("/a"),
         };
         assert_eq!(
-            filtered_rows(&projects, preds),
+            filtered_rows(&projects, &no_sessions(), preds),
             vec![
                 SidebarRow::Home,
                 SidebarRow::Project(PathBuf::from("/a")),
                 SidebarRow::Worktree(PathBuf::from("/a/wt1")),
             ]
         );
+    }
+
+    #[test]
+    fn visible_rows_interleaves_session_rows_after_their_workspace_row() {
+        let projects = vec![project("/a", true, &["/a/wt1"])];
+        let sessions =
+            HashMap::from([(None, vec![1, 2]), (Some(PathBuf::from("/a/wt1")), vec![3, 4])]);
+        assert_eq!(
+            visible_rows(&projects, &sessions),
+            vec![
+                SidebarRow::Home,
+                SidebarRow::Session(1),
+                SidebarRow::Session(2),
+                SidebarRow::Project(PathBuf::from("/a")),
+                SidebarRow::Worktree(PathBuf::from("/a/wt1")),
+                SidebarRow::Session(3),
+                SidebarRow::Session(4),
+            ]
+        );
+    }
+
+    #[test]
+    fn visible_rows_hides_session_rows_of_collapsed_projects() {
+        let projects = vec![project("/a", false, &["/a/wt1"])];
+        let sessions = HashMap::from([(Some(PathBuf::from("/a/wt1")), vec![3, 4])]);
+        assert_eq!(
+            visible_rows(&projects, &sessions),
+            vec![SidebarRow::Home, SidebarRow::Project(PathBuf::from("/a"))]
+        );
+    }
+
+    #[test]
+    fn left_target_of_session_is_its_owning_workspace_row() {
+        let projects = vec![project("/a", true, &["/a/wt1"])];
+        let sessions =
+            HashMap::from([(None, vec![1, 2]), (Some(PathBuf::from("/a/wt1")), vec![3, 4])]);
+        let rows = visible_rows(&projects, &sessions);
+        assert_eq!(left_target(&rows, &SidebarRow::Session(2)), Some(SidebarRow::Home));
+        assert_eq!(
+            left_target(&rows, &SidebarRow::Session(4)),
+            Some(SidebarRow::Worktree(PathBuf::from("/a/wt1")))
+        );
+    }
+
+    #[test]
+    fn seed_lands_on_the_active_session_row_when_listed() {
+        let projects = vec![project("/a", true, &["/a/wt1"])];
+        let sessions = HashMap::from([(Some(PathBuf::from("/a/wt1")), vec![3, 4])]);
+        assert_eq!(
+            seed(&projects, Some(Path::new("/a/wt1")), &sessions, Some(4)),
+            SidebarRow::Session(4)
+        );
+        // An unlisted active id (single-session workspace) falls back to the
+        // workspace row.
+        assert_eq!(
+            seed(&projects, Some(Path::new("/a/wt1")), &HashMap::new(), Some(4)),
+            SidebarRow::Worktree(PathBuf::from("/a/wt1"))
+        );
+    }
+
+    #[test]
+    fn seed_ignores_the_active_session_of_a_collapsed_project() {
+        let projects = vec![project("/a", false, &["/a/wt1"])];
+        let sessions = HashMap::from([(Some(PathBuf::from("/a/wt1")), vec![3, 4])]);
+        assert_eq!(
+            seed(&projects, Some(Path::new("/a/wt1")), &sessions, Some(3)),
+            SidebarRow::Project(PathBuf::from("/a"))
+        );
+    }
+
+    #[test]
+    fn seed_lands_on_home_session_rows_too() {
+        let sessions = HashMap::from([(None, vec![1, 2])]);
+        assert_eq!(seed(&[], None, &sessions, Some(2)), SidebarRow::Session(2));
+    }
+
+    #[test]
+    fn filtered_rows_appends_session_rows_to_surviving_workspace_rows() {
+        let projects = vec![project("/a", false, &["/a/wt1", "/a/wt2"])];
+        let sessions = HashMap::from([
+            (None, vec![1]),
+            (Some(PathBuf::from("/a/wt1")), vec![3]),
+            (Some(PathBuf::from("/a/wt2")), vec![9]),
+        ]);
+        let preds = RowPredicates {
+            home: true,
+            project_self: &|_p| false,
+            worktree: &mut |_p, wt| wt.path == PathBuf::from("/a/wt1"),
+        };
+        assert_eq!(
+            filtered_rows(&projects, &sessions, preds),
+            vec![
+                SidebarRow::Home,
+                SidebarRow::Session(1),
+                SidebarRow::Project(PathBuf::from("/a")),
+                SidebarRow::Worktree(PathBuf::from("/a/wt1")),
+                SidebarRow::Session(3),
+            ]
+        );
+    }
+
+    #[test]
+    fn filtered_rows_hides_home_session_rows_with_home() {
+        let projects = vec![project("/a", true, &["/a/wt1"])];
+        let sessions = HashMap::from([(None, vec![1])]);
+        let preds =
+            RowPredicates { home: false, project_self: &|_| true, worktree: &mut |_, _| true };
+        let rows = filtered_rows(&projects, &sessions, preds);
+        assert!(!rows.contains(&SidebarRow::Session(1)));
     }
 
     #[test]

--- a/alacritree/src/sidebar_nav.rs
+++ b/alacritree/src/sidebar_nav.rs
@@ -6,7 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::projects::Project;
+use crate::projects::{Project, Worktree};
 
 /// A row the sidebar cursor can rest on, in render order.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,6 +70,46 @@ pub fn seed(projects: &[Project], current_workspace: Option<&Path>) -> SidebarRo
         }
     }
     SidebarRow::Home
+}
+
+/// The three predicates that decide whether a row survives an active filter.
+/// `worktree` is `FnMut` because the fuzzy matcher it wraps needs `&mut self`.
+pub struct RowPredicates<'a> {
+    pub home: bool,
+    pub project_self: &'a dyn Fn(&Project) -> bool,
+    pub worktree: &'a mut dyn FnMut(&Project, &Worktree) -> bool,
+}
+
+/// Render-order rows under an active filter. Projects are force-expanded (a
+/// filter that hides its own results is useless); a header survives when it
+/// matches itself or keeps at least one visible worktree.
+pub fn filtered_rows(projects: &[Project], preds: RowPredicates<'_>) -> Vec<SidebarRow> {
+    let mut rows = Vec::new();
+    if preds.home {
+        rows.push(SidebarRow::Home);
+    }
+    for p in projects {
+        let self_matches = (preds.project_self)(p);
+        let visible_worktrees: Vec<SidebarRow> = p
+            .worktrees
+            .iter()
+            .filter(|wt| (preds.worktree)(p, wt))
+            .map(|wt| SidebarRow::Worktree(wt.path.clone()))
+            .collect();
+        if self_matches || !visible_worktrees.is_empty() {
+            rows.push(SidebarRow::Project(p.root.clone()));
+            rows.extend(visible_worktrees);
+        }
+    }
+    rows
+}
+
+/// Cursor fallback: unchanged when still visible, else the first row.
+pub fn ensure_cursor(rows: &[SidebarRow], cursor: Option<&SidebarRow>) -> Option<SidebarRow> {
+    match cursor {
+        Some(c) if rows.contains(c) => Some(c.clone()),
+        _ => rows.first().cloned(),
+    }
 }
 
 #[cfg(test)]
@@ -184,5 +224,71 @@ mod tests {
         // Home workspace and unknown paths both land on Home.
         assert_eq!(seed(&projects, None), SidebarRow::Home);
         assert_eq!(seed(&projects, Some(Path::new("/nowhere"))), SidebarRow::Home);
+    }
+
+    #[test]
+    fn filtered_rows_keeps_projects_with_matching_worktrees_and_forces_expansion() {
+        let projects = vec![project("/a", false, &["/a/wt1", "/a/wt2"])];
+        let preds = RowPredicates {
+            home: true,
+            project_self: &|_p| false,
+            worktree: &mut |_p, wt| wt.path == PathBuf::from("/a/wt1"),
+        };
+        assert_eq!(
+            filtered_rows(&projects, preds),
+            vec![
+                SidebarRow::Home,
+                SidebarRow::Project(PathBuf::from("/a")),
+                SidebarRow::Worktree(PathBuf::from("/a/wt1")),
+            ]
+        );
+    }
+
+    #[test]
+    fn filtered_rows_keeps_a_self_matching_header_without_its_worktrees() {
+        let projects = vec![project("/a", true, &["/a/wt1"])];
+        let preds = RowPredicates {
+            home: true,
+            project_self: &|p| p.root == PathBuf::from("/a"),
+            worktree: &mut |_p, _wt| false,
+        };
+        assert_eq!(
+            filtered_rows(&projects, preds),
+            vec![SidebarRow::Home, SidebarRow::Project(PathBuf::from("/a"))]
+        );
+    }
+
+    #[test]
+    fn filtered_rows_drops_home_when_it_fails_the_predicate() {
+        let projects = vec![project("/a", true, &["/a/wt1"])];
+        let preds = RowPredicates {
+            home: false,
+            project_self: &|p| p.root == PathBuf::from("/a"),
+            worktree: &mut |_p, _wt| true,
+        };
+        assert_eq!(
+            filtered_rows(&projects, preds),
+            vec![
+                SidebarRow::Project(PathBuf::from("/a")),
+                SidebarRow::Worktree(PathBuf::from("/a/wt1"))
+            ]
+        );
+    }
+
+    #[test]
+    fn ensure_cursor_keeps_a_visible_row_and_falls_back_to_first() {
+        let rows = vec![SidebarRow::Home, SidebarRow::Project(PathBuf::from("/a"))];
+        // Still visible: unchanged.
+        assert_eq!(
+            ensure_cursor(&rows, Some(&SidebarRow::Project(PathBuf::from("/a")))),
+            Some(SidebarRow::Project(PathBuf::from("/a")))
+        );
+        // Vanished cursor and no cursor both fall back to the first row.
+        let gone = SidebarRow::Worktree(PathBuf::from("/gone"));
+        assert_eq!(ensure_cursor(&rows, Some(&gone)), Some(SidebarRow::Home));
+        assert_eq!(ensure_cursor(&rows, None), Some(SidebarRow::Home));
+        // Empty rows always fall back to None.
+        assert_eq!(ensure_cursor(&[], Some(&SidebarRow::Home)), None);
+        assert_eq!(ensure_cursor(&[], None), None);
     }
 }

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -213,6 +213,9 @@ sidebar_border     = "#2a2a2a"
 sidebar_accent     = "#6a9fb5"
 notifications      = true   # desktop notification when a hidden session bells
 
+[ui.icons]                  # sidebar glyph overrides (e.g. Nerd Font icons)
+search = "⌕"                # glyph prefixing the sidebar search prompt
+
 [workspace]
 worktree_dir = "~/dev/worktrees"   # base dir for new worktrees (default ~/.alacritree/worktrees)
 


### PR DESCRIPTION
Adds LazyVim-style `/` fuzzy search and single-key filter toggles to both sidebars, plus a keyboard focus mode for the git sidebar.

## What

- **Search**: `/` in a focused sidebar enters filter-as-you-type; fuzzy, smart-case matching via `nucleo-matcher` (Helix's matcher). Rows are filtered, not re-ranked. Enter activates the cursor row and clears the query (transient jump); Esc clears back to browsing.
- **Filter toggles**, shown as chips next to the panel title, stacking with the query:
  - Left panel: `s` = workspaces with running sessions, `a` = needs attention.
  - Git panel: `m` = Modified+Renamed, `d` = Deleted, `u` = Untracked+Added (union). Conflicted rows are never filterable out. The branch-diff section is query-only.
  - Esc ladder: search → clear query; browsing with toggles → clear toggles; otherwise → focus terminal. Filter state is transient (never persisted).
- **Git-sidebar focus mode**: new `FocusGitSidebar` named action (default **Ctrl+Shift+G**, configurable via `[[keyboard.bindings]]`) with the same auto-show/re-hide round-trip as the left panel; arrows move a row cursor, Enter opens the diff for the cursor row, section headers show `x of y` counts while filtering.

## How

Two new pure modules mirror `sidebar_nav`'s pattern and carry the unit tests: `panel_filter` (input-mode state machine + fuzzy predicate; `Pattern` cached, `Matcher` reused) and `git_nav` (row model keyed by `(section, path)` so 1.5 s status refreshes can't retarget the cursor). `app.rs` routes sidebar key events filter-first through the existing retain-loop, falling through to the pre-existing nav handling. While filtering, projects render force-expanded (display-only; the stored `expanded` flag is untouched).

Tests: 298 passing (36 new across the pure modules and bindings round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)