### PR TITLE
[4] feat(ui): session-display visibility and directional focus

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -137,6 +137,18 @@ enum FocusDir {
     Right,
 }
 
+/// Where a dispatched binding action came from.  A keyboard action consumed
+/// a real key press, so FocusLeft/FocusRight may re-synthesize it into the
+/// PTY when the inner TUI should handle it.  An IPC action has no key press
+/// to forward — the caller is typically that inner program declaring it has
+/// no window in the requested direction, and passthrough would bounce the
+/// key straight back to it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActionOrigin {
+    Keyboard,
+    Ipc,
+}
+
 /// What a FocusLeft/FocusRight press does, decided by [`focus_move`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FocusMove {
@@ -167,16 +179,19 @@ fn inner_handles(title: &str, dir: FocusDir) -> bool {
 
 /// Panel-focus decision for FocusLeft/FocusRight.  Panels sit in a fixed
 /// `ProjectsSidebar ↔ Terminal ↔ GitSidebar` row; movement toward a hidden
-/// panel is dropped (focus never opens a panel), and from the terminal the
-/// inner TUI gets first refusal via [`inner_handles`].
+/// panel is dropped (focus never opens a panel), and from the terminal a
+/// keyboard-originated move gives the inner TUI first refusal via
+/// [`inner_handles`].  IPC moves never pass through (see [`ActionOrigin`]).
 fn focus_move(
     focus: PaneFocus,
     dir: FocusDir,
     left_open: bool,
     right_open: bool,
+    origin: ActionOrigin,
     title: &str,
 ) -> FocusMove {
-    if focus == PaneFocus::Terminal && inner_handles(title, dir) {
+    if origin == ActionOrigin::Keyboard && focus == PaneFocus::Terminal && inner_handles(title, dir)
+    {
         return FocusMove::Passthrough;
     }
     let target = match (focus, dir) {
@@ -1070,11 +1085,17 @@ impl AlacritreeApp {
         }
     }
 
-    fn move_focus(&mut self, dir: FocusDir) {
+    fn move_focus(&mut self, dir: FocusDir, origin: ActionOrigin) {
         let idx = self.active_session_index();
         let title = idx.map(|i| self.sessions[i].title.as_str()).unwrap_or("");
-        let decision =
-            focus_move(self.focus, dir, self.show_left_sidebar, self.show_right_sidebar, title);
+        let decision = focus_move(
+            self.focus,
+            dir,
+            self.show_left_sidebar,
+            self.show_right_sidebar,
+            origin,
+            title,
+        );
         match decision {
             FocusMove::Passthrough => {
                 let Some(i) = idx else { return };
@@ -1137,7 +1158,7 @@ impl AlacritreeApp {
             actions
         });
         for action in actions {
-            self.dispatch_action(ctx, action);
+            self.dispatch_action(ctx, action, ActionOrigin::Keyboard);
         }
     }
 
@@ -1586,7 +1607,7 @@ impl AlacritreeApp {
         }
     }
 
-    fn dispatch_action(&mut self, ctx: &Context, action: BindingAction) {
+    fn dispatch_action(&mut self, ctx: &Context, action: BindingAction, origin: ActionOrigin) {
         match action {
             BindingAction::Chars(bytes) => {
                 if let Some(idx) = self.active_session_index() {
@@ -1745,8 +1766,12 @@ impl AlacritreeApp {
                 }
             },
             BindingAction::Named(NamedAction::FocusTerminal) => self.focus_terminal(),
-            BindingAction::Named(NamedAction::FocusLeft) => self.move_focus(FocusDir::Left),
-            BindingAction::Named(NamedAction::FocusRight) => self.move_focus(FocusDir::Right),
+            BindingAction::Named(NamedAction::FocusLeft) => {
+                self.move_focus(FocusDir::Left, origin);
+            },
+            BindingAction::Named(NamedAction::FocusRight) => {
+                self.move_focus(FocusDir::Right, origin);
+            },
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
             },
@@ -5079,6 +5104,13 @@ impl AlacritreeApp {
                 let idx = self.rename_project(&root, label)?;
                 Ok(project_json(&self.projects[idx]))
             },
+            Req::RunAction { action } => match crate::bindings::parse_action(&action) {
+                BindingAction::Unsupported(name) => Err(format!("unknown action `{name}`")),
+                parsed => {
+                    self.dispatch_action(ctx, parsed, ActionOrigin::Ipc);
+                    Ok(json!({ "action": action }))
+                },
+            },
             // Dispatched on the IPC connection thread; never forwarded here.
             Req::GitStatus { .. } | Req::CreateWorktree { .. } => {
                 Err("request is handled off the UI thread".to_string())
@@ -5494,9 +5526,9 @@ mod tests {
         assert_eq!(project_main_for(&projects, Path::new("/elsewhere")), None);
     }
 
-    /// `focus_move` with both panels open.
+    /// Keyboard-originated `focus_move` with both panels open.
     fn mv(focus: PaneFocus, dir: FocusDir, title: &str) -> FocusMove {
-        focus_move(focus, dir, true, true, title)
+        focus_move(focus, dir, true, true, ActionOrigin::Keyboard, title)
     }
 
     #[test]
@@ -5528,11 +5560,25 @@ mod tests {
     #[test]
     fn focus_never_moves_toward_a_closed_panel() {
         assert_eq!(
-            focus_move(PaneFocus::Terminal, FocusDir::Left, false, true, ""),
+            focus_move(
+                PaneFocus::Terminal,
+                FocusDir::Left,
+                false,
+                true,
+                ActionOrigin::Keyboard,
+                ""
+            ),
             FocusMove::Nothing
         );
         assert_eq!(
-            focus_move(PaneFocus::Terminal, FocusDir::Right, true, false, ""),
+            focus_move(
+                PaneFocus::Terminal,
+                FocusDir::Right,
+                true,
+                false,
+                ActionOrigin::Keyboard,
+                ""
+            ),
             FocusMove::Nothing
         );
     }
@@ -5556,7 +5602,14 @@ mod tests {
     #[test]
     fn tmux_at_edge_with_closed_panel_does_nothing() {
         assert_eq!(
-            focus_move(PaneFocus::Terminal, FocusDir::Left, false, true, "tmux:L x"),
+            focus_move(
+                PaneFocus::Terminal,
+                FocusDir::Left,
+                false,
+                true,
+                ActionOrigin::Keyboard,
+                "tmux:L x"
+            ),
             FocusMove::Nothing
         );
     }
@@ -5580,6 +5633,30 @@ mod tests {
         assert_eq!(
             mv(PaneFocus::ProjectsSidebar, FocusDir::Right, "tmux: x"),
             FocusMove::Focus(PaneFocus::Terminal)
+        );
+    }
+
+    /// An IPC move is the inner program saying it is out of windows —
+    /// passthrough would bounce the key straight back to it.
+    #[test]
+    fn ipc_moves_never_pass_through() {
+        for title in ["nvim ~/notes.md", "tmux:R /home/lev"] {
+            assert_eq!(
+                focus_move(
+                    PaneFocus::Terminal,
+                    FocusDir::Left,
+                    true,
+                    true,
+                    ActionOrigin::Ipc,
+                    title
+                ),
+                FocusMove::Focus(PaneFocus::ProjectsSidebar),
+                "{title}"
+            );
+        }
+        assert_eq!(
+            focus_move(PaneFocus::Terminal, FocusDir::Left, false, true, ActionOrigin::Ipc, "nvim"),
+            FocusMove::Nothing
         );
     }
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -135,6 +135,10 @@ pub struct AlacritreeApp {
     show_left_sidebar: bool,
     show_right_sidebar: bool,
     focus: PaneFocus,
+    /// Runtime copies of `[ui.session_display]`.  The config is only the
+    /// startup default; toggles flip these and are never persisted.
+    session_rows_always: bool,
+    session_tabs_always: bool,
     sidebar_cursor: Option<SidebarRow>,
     /// Reveals the project rows' drag grips.  A transient mode, not persisted:
     /// reordering is a rare, deliberate act, and a grip on every row the rest
@@ -435,6 +439,8 @@ impl AlacritreeApp {
             show_left_sidebar: persisted.show_left_sidebar,
             show_right_sidebar: persisted.show_right_sidebar,
             focus: PaneFocus::Terminal,
+            session_rows_always: config.ui.session_display.sidebar_always,
+            session_tabs_always: config.ui.session_display.tabs_always,
             sidebar_cursor: None,
             reorder_mode: false,
             sidebar_auto_shown: false,
@@ -1717,10 +1723,11 @@ impl AlacritreeApp {
             ui.allocate_exact_size(egui::vec2(avail, strip_height + 2.0), egui::Sense::hover());
 
         let mut activate: Option<SessionId> = None;
-        // Session segments only when there is a choice to make, but the
-        // trailing + segment always renders alongside them once the strip
-        // itself renders (i.e. at least one session exists).
-        if indices.len() >= 2 {
+        // Session segments only when there is a choice to make (or the user
+        // forces them via session_display), but the trailing + segment always
+        // renders alongside them once the strip itself renders (i.e. at least
+        // one session exists).
+        if indices.len() >= 2 || self.session_tabs_always {
             let seg_avail = avail - plus_width - gap;
             let segment_width =
                 ((seg_avail - gap * (indices.len() as f32 - 1.0)) / indices.len() as f32).max(1.0);
@@ -3553,13 +3560,19 @@ struct SessionRowData {
     is_displayed: bool,
 }
 
-/// Spawn-ordered ids of the sessions in `ws`, or empty below the two-session
-/// list threshold — a single-session workspace row keeps its compact form,
-/// mirroring the tab strip. Pure over (workspace, id) pairs so the grouping
-/// rule is testable without spawning PTYs.
-fn sidebar_session_ids(pairs: &[(WorkspaceKey, SessionId)], ws: &WorkspaceKey) -> Vec<SessionId> {
+/// Spawn-ordered ids of the sessions in `ws`, or empty below the list
+/// threshold.  The threshold is normally two — a single-session workspace row
+/// keeps its compact form, mirroring the tab strip — and `always` lowers it
+/// to one.  Pure over (workspace, id) pairs so the grouping rule is testable
+/// without spawning PTYs.
+fn sidebar_session_ids(
+    pairs: &[(WorkspaceKey, SessionId)],
+    ws: &WorkspaceKey,
+    always: bool,
+) -> Vec<SessionId> {
     let ids: Vec<SessionId> = pairs.iter().filter(|(w, _)| w == ws).map(|(_, id)| *id).collect();
-    if ids.len() < 2 { Vec::new() } else { ids }
+    let threshold = if always { 1 } else { 2 };
+    if ids.len() < threshold { Vec::new() } else { ids }
 }
 
 /// Where the view goes after a session's removal.
@@ -3963,7 +3976,7 @@ impl AlacritreeApp {
         let mut listed = sidebar_nav::ListedSessions::new();
         for (ws, _) in &pairs {
             if !listed.contains_key(ws) {
-                let ids = sidebar_session_ids(&pairs, ws);
+                let ids = sidebar_session_ids(&pairs, ws, self.session_rows_always);
                 if !ids.is_empty() {
                     listed.insert(ws.clone(), ids);
                 }
@@ -3973,11 +3986,11 @@ impl AlacritreeApp {
     }
 
     /// Session rows for `ws`'s sidebar list, per `sidebar_session_ids`'s
-    /// two-session threshold.
+    /// list threshold.
     fn workspace_session_rows(&self, ws: &WorkspaceKey) -> Vec<SessionRowData> {
         let pairs: Vec<(WorkspaceKey, SessionId)> =
             self.sessions.iter().map(|s| (s.working_directory.clone(), s.id)).collect();
-        let ids = sidebar_session_ids(&pairs, ws);
+        let ids = sidebar_session_ids(&pairs, ws, self.session_rows_always);
         let active = self.active_session.get(ws).copied();
         let is_current = self.current_workspace == *ws;
         ids.iter()
@@ -5242,16 +5255,16 @@ mod tests {
     #[test]
     fn session_ids_filter_by_workspace_and_keep_spawn_order() {
         let pairs = vec![(None, 1), (ws("/a"), 2), (None, 3), (ws("/b"), 4), (ws("/a"), 5)];
-        assert_eq!(sidebar_session_ids(&pairs, &None), vec![1, 3]);
-        assert_eq!(sidebar_session_ids(&pairs, &ws("/a")), vec![2, 5]);
+        assert_eq!(sidebar_session_ids(&pairs, &None, false), vec![1, 3]);
+        assert_eq!(sidebar_session_ids(&pairs, &ws("/a"), false), vec![2, 5]);
         // /b has a single session, below the two-session list threshold.
-        assert!(sidebar_session_ids(&pairs, &ws("/b")).is_empty());
+        assert!(sidebar_session_ids(&pairs, &ws("/b"), false).is_empty());
     }
 
     #[test]
     fn session_ids_empty_for_unknown_workspace() {
         let pairs = vec![(None, 1)];
-        assert!(sidebar_session_ids(&pairs, &ws("/missing")).is_empty());
+        assert!(sidebar_session_ids(&pairs, &ws("/missing"), false).is_empty());
     }
 
     #[test]
@@ -5268,13 +5281,23 @@ mod tests {
     #[test]
     fn session_ids_apply_two_session_threshold() {
         let no_match: Vec<(WorkspaceKey, SessionId)> = vec![(ws("/other"), 1)];
-        assert!(sidebar_session_ids(&no_match, &ws("/a")).is_empty());
+        assert!(sidebar_session_ids(&no_match, &ws("/a"), false).is_empty());
 
         let one_match = vec![(ws("/a"), 1), (ws("/other"), 2)];
-        assert!(sidebar_session_ids(&one_match, &ws("/a")).is_empty());
+        assert!(sidebar_session_ids(&one_match, &ws("/a"), false).is_empty());
 
         let two_match = vec![(ws("/a"), 1), (ws("/other"), 2), (ws("/a"), 3)];
-        assert_eq!(sidebar_session_ids(&two_match, &ws("/a")), vec![1, 3]);
+        assert_eq!(sidebar_session_ids(&two_match, &ws("/a"), false), vec![1, 3]);
+    }
+
+    #[test]
+    fn session_ids_always_flag_lists_single_sessions() {
+        let one_match = vec![(ws("/a"), 1), (ws("/other"), 2)];
+        assert_eq!(sidebar_session_ids(&one_match, &ws("/a"), true), vec![1]);
+
+        // Zero sessions stays empty even with the flag on.
+        let no_match: Vec<(WorkspaceKey, SessionId)> = vec![(ws("/other"), 2)];
+        assert!(sidebar_session_ids(&no_match, &ws("/a"), true).is_empty());
     }
 
     use crate::projects::{Project, Worktree};

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1070,6 +1070,33 @@ impl AlacritreeApp {
         }
     }
 
+    fn move_focus(&mut self, dir: FocusDir) {
+        let idx = self.active_session_index();
+        let title = idx.map(|i| self.sessions[i].title.as_str()).unwrap_or("");
+        let decision =
+            focus_move(self.focus, dir, self.show_left_sidebar, self.show_right_sidebar, title);
+        match decision {
+            FocusMove::Passthrough => {
+                let Some(i) = idx else { return };
+                let key = match dir {
+                    FocusDir::Left => egui::Key::ArrowLeft,
+                    FocusDir::Right => egui::Key::ArrowRight,
+                };
+                let mode = *self.sessions[i].term.lock().mode();
+                // The binding consumed the key press before the terminal view
+                // saw it, so the Ctrl+Arrow the inner TUI listens for is
+                // re-synthesized with the terminal's own encoding.
+                if let Some(bytes) = crate::input::key_to_bytes(key, egui::Modifiers::CTRL, mode) {
+                    self.sessions[i].write(bytes);
+                }
+            },
+            FocusMove::Focus(PaneFocus::ProjectsSidebar) => self.focus_sidebar(),
+            FocusMove::Focus(PaneFocus::Terminal) => self.focus_terminal(),
+            FocusMove::Focus(PaneFocus::GitSidebar) => self.focus = PaneFocus::GitSidebar,
+            FocusMove::Nothing => {},
+        }
+    }
+
     /// Match key events against the binding table (user bindings + defaults)
     /// before the terminal sees raw events, so a binding wins over plain
     /// text input.  Matched events are consumed unless every matched action
@@ -1718,6 +1745,8 @@ impl AlacritreeApp {
                 }
             },
             BindingAction::Named(NamedAction::FocusTerminal) => self.focus_terminal(),
+            BindingAction::Named(NamedAction::FocusLeft) => self.move_focus(FocusDir::Left),
+            BindingAction::Named(NamedAction::FocusRight) => self.move_focus(FocusDir::Right),
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
             },

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1594,6 +1594,12 @@ impl AlacritreeApp {
                 }
                 self.persist_sidebars();
             },
+            BindingAction::Named(NamedAction::ToggleSessionRows) => {
+                self.session_rows_always = !self.session_rows_always;
+            },
+            BindingAction::Named(NamedAction::ToggleSessionTabs) => {
+                self.session_tabs_always = !self.session_tabs_always;
+            },
             BindingAction::Named(NamedAction::SelectNextWorkspace) => {
                 self.cycle_workspaces(ctx, 1);
             },

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -159,39 +159,23 @@ enum FocusMove {
     Nothing,
 }
 
-/// Whether the program inside the terminal should receive the directional key
-/// instead of alacritree switching panels.  Cooperating setups publish edge
-/// state through the terminal title: tmux as `tmux:<edges>`, where a letter
-/// (L/R/U/D) marks a wall its active pane — with any nvim split edges folded
-/// in — cannot move past.  An absent letter means the inner stack still has
-/// somewhere to go.  A title that looks like bare (n)vim always wins: vim
-/// publishes no edge state, so alacritree can never tell when it is done.
-fn inner_handles(title: &str, dir: FocusDir) -> bool {
-    if let Some(rest) = title.strip_prefix("tmux:") {
-        let letter = match dir {
-            FocusDir::Left => 'L',
-            FocusDir::Right => 'R',
-        };
-        return !rest.chars().take_while(char::is_ascii_uppercase).any(|c| c == letter);
-    }
-    title.starts_with("nvim") || title.starts_with("vim")
-}
-
 /// Panel-focus decision for FocusLeft/FocusRight.  Panels sit in a fixed
 /// `ProjectsSidebar ↔ Terminal ↔ GitSidebar` row; movement toward a hidden
-/// panel is dropped (focus never opens a panel), and from the terminal a
-/// keyboard-originated move gives the inner TUI first refusal via
-/// [`inner_handles`].  IPC moves never pass through (see [`ActionOrigin`]).
+/// panel is dropped (focus never opens a panel).  From the terminal, a
+/// keyboard-originated move is forwarded to a running split-managing TUI
+/// (`tui_running`, see [`Session::nav_tui_running`]): the TUI walks its own
+/// splits and hands focus back with `alacritree action Focus…` once it has
+/// no window left in that direction — which is why IPC moves never pass
+/// through (see [`ActionOrigin`]).
 fn focus_move(
     focus: PaneFocus,
     dir: FocusDir,
     left_open: bool,
     right_open: bool,
     origin: ActionOrigin,
-    title: &str,
+    tui_running: bool,
 ) -> FocusMove {
-    if origin == ActionOrigin::Keyboard && focus == PaneFocus::Terminal && inner_handles(title, dir)
-    {
+    if origin == ActionOrigin::Keyboard && focus == PaneFocus::Terminal && tui_running {
         return FocusMove::Passthrough;
     }
     let target = match (focus, dir) {
@@ -1087,14 +1071,14 @@ impl AlacritreeApp {
 
     fn move_focus(&mut self, dir: FocusDir, origin: ActionOrigin) {
         let idx = self.active_session_index();
-        let title = idx.map(|i| self.sessions[i].title.as_str()).unwrap_or("");
+        let tui_running = idx.is_some_and(|i| self.sessions[i].nav_tui_running());
         let decision = focus_move(
             self.focus,
             dir,
             self.show_left_sidebar,
             self.show_right_sidebar,
             origin,
-            title,
+            tui_running,
         );
         match decision {
             FocusMove::Passthrough => {
@@ -5527,34 +5511,34 @@ mod tests {
     }
 
     /// Keyboard-originated `focus_move` with both panels open.
-    fn mv(focus: PaneFocus, dir: FocusDir, title: &str) -> FocusMove {
-        focus_move(focus, dir, true, true, ActionOrigin::Keyboard, title)
+    fn mv(focus: PaneFocus, dir: FocusDir, tui_running: bool) -> FocusMove {
+        focus_move(focus, dir, true, true, ActionOrigin::Keyboard, tui_running)
     }
 
     #[test]
     fn focus_moves_between_open_panels() {
         assert_eq!(
-            mv(PaneFocus::Terminal, FocusDir::Left, ""),
+            mv(PaneFocus::Terminal, FocusDir::Left, false),
             FocusMove::Focus(PaneFocus::ProjectsSidebar)
         );
         assert_eq!(
-            mv(PaneFocus::Terminal, FocusDir::Right, ""),
+            mv(PaneFocus::Terminal, FocusDir::Right, false),
             FocusMove::Focus(PaneFocus::GitSidebar)
         );
         assert_eq!(
-            mv(PaneFocus::ProjectsSidebar, FocusDir::Right, ""),
+            mv(PaneFocus::ProjectsSidebar, FocusDir::Right, false),
             FocusMove::Focus(PaneFocus::Terminal)
         );
         assert_eq!(
-            mv(PaneFocus::GitSidebar, FocusDir::Left, ""),
+            mv(PaneFocus::GitSidebar, FocusDir::Left, false),
             FocusMove::Focus(PaneFocus::Terminal)
         );
     }
 
     #[test]
     fn focus_stops_at_the_outer_edges() {
-        assert_eq!(mv(PaneFocus::ProjectsSidebar, FocusDir::Left, ""), FocusMove::Nothing);
-        assert_eq!(mv(PaneFocus::GitSidebar, FocusDir::Right, ""), FocusMove::Nothing);
+        assert_eq!(mv(PaneFocus::ProjectsSidebar, FocusDir::Left, false), FocusMove::Nothing);
+        assert_eq!(mv(PaneFocus::GitSidebar, FocusDir::Right, false), FocusMove::Nothing);
     }
 
     #[test]
@@ -5566,7 +5550,7 @@ mod tests {
                 false,
                 true,
                 ActionOrigin::Keyboard,
-                ""
+                false
             ),
             FocusMove::Nothing
         );
@@ -5577,61 +5561,22 @@ mod tests {
                 true,
                 false,
                 ActionOrigin::Keyboard,
-                ""
+                false
             ),
             FocusMove::Nothing
         );
     }
 
     #[test]
-    fn tmux_edges_gate_passthrough() {
-        // No letter for the direction: the inner stack can still move.
-        assert_eq!(
-            mv(PaneFocus::Terminal, FocusDir::Left, "tmux:R /home/lev"),
-            FocusMove::Passthrough
-        );
-        // Against that wall: alacritree takes over.
-        assert_eq!(
-            mv(PaneFocus::Terminal, FocusDir::Left, "tmux:LU /home/lev"),
-            FocusMove::Focus(PaneFocus::ProjectsSidebar)
-        );
-        // Bare prefix publishes no blocked edges at all.
-        assert_eq!(mv(PaneFocus::Terminal, FocusDir::Right, "tmux:"), FocusMove::Passthrough);
-    }
-
-    #[test]
-    fn tmux_at_edge_with_closed_panel_does_nothing() {
-        assert_eq!(
-            focus_move(
-                PaneFocus::Terminal,
-                FocusDir::Left,
-                false,
-                true,
-                ActionOrigin::Keyboard,
-                "tmux:L x"
-            ),
-            FocusMove::Nothing
-        );
-    }
-
-    #[test]
-    fn nvim_titles_always_pass_through() {
-        assert_eq!(
-            mv(PaneFocus::Terminal, FocusDir::Left, "nvim ~/notes.md"),
-            FocusMove::Passthrough
-        );
-        assert_eq!(mv(PaneFocus::Terminal, FocusDir::Right, "vim"), FocusMove::Passthrough);
-        // A shell whose title merely mentions vim is not vim.
-        assert_eq!(
-            mv(PaneFocus::Terminal, FocusDir::Left, "pwsh — nvim docs"),
-            FocusMove::Focus(PaneFocus::ProjectsSidebar)
-        );
+    fn running_tui_keeps_the_key() {
+        assert_eq!(mv(PaneFocus::Terminal, FocusDir::Left, true), FocusMove::Passthrough);
+        assert_eq!(mv(PaneFocus::Terminal, FocusDir::Right, true), FocusMove::Passthrough);
     }
 
     #[test]
     fn sidebars_never_pass_through() {
         assert_eq!(
-            mv(PaneFocus::ProjectsSidebar, FocusDir::Right, "tmux: x"),
+            mv(PaneFocus::ProjectsSidebar, FocusDir::Right, true),
             FocusMove::Focus(PaneFocus::Terminal)
         );
     }
@@ -5640,22 +5585,12 @@ mod tests {
     /// passthrough would bounce the key straight back to it.
     #[test]
     fn ipc_moves_never_pass_through() {
-        for title in ["nvim ~/notes.md", "tmux:R /home/lev"] {
-            assert_eq!(
-                focus_move(
-                    PaneFocus::Terminal,
-                    FocusDir::Left,
-                    true,
-                    true,
-                    ActionOrigin::Ipc,
-                    title
-                ),
-                FocusMove::Focus(PaneFocus::ProjectsSidebar),
-                "{title}"
-            );
-        }
         assert_eq!(
-            focus_move(PaneFocus::Terminal, FocusDir::Left, false, true, ActionOrigin::Ipc, "nvim"),
+            focus_move(PaneFocus::Terminal, FocusDir::Left, true, true, ActionOrigin::Ipc, true),
+            FocusMove::Focus(PaneFocus::ProjectsSidebar)
+        );
+        assert_eq!(
+            focus_move(PaneFocus::Terminal, FocusDir::Left, false, true, ActionOrigin::Ipc, true),
             FocusMove::Nothing
         );
     }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -124,11 +124,72 @@ fn blend_toward(c: Color32, target: Color32, amount: f32) -> Color32 {
 /// Which pane owns keyboard input.  The terminal re-requests egui focus
 /// every frame while it owns this; anything else holding focus (modals
 /// aside) must win here first.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PaneFocus {
     Terminal,
     ProjectsSidebar,
     GitSidebar,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FocusDir {
+    Left,
+    Right,
+}
+
+/// What a FocusLeft/FocusRight press does, decided by [`focus_move`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FocusMove {
+    /// The TUI inside the terminal can still move that way — forward the
+    /// Ctrl+Arrow to the PTY instead of switching panels.
+    Passthrough,
+    Focus(PaneFocus),
+    Nothing,
+}
+
+/// Whether the program inside the terminal should receive the directional key
+/// instead of alacritree switching panels.  Cooperating setups publish edge
+/// state through the terminal title: tmux as `tmux:<edges>`, where a letter
+/// (L/R/U/D) marks a wall its active pane — with any nvim split edges folded
+/// in — cannot move past.  An absent letter means the inner stack still has
+/// somewhere to go.  A title that looks like bare (n)vim always wins: vim
+/// publishes no edge state, so alacritree can never tell when it is done.
+fn inner_handles(title: &str, dir: FocusDir) -> bool {
+    if let Some(rest) = title.strip_prefix("tmux:") {
+        let letter = match dir {
+            FocusDir::Left => 'L',
+            FocusDir::Right => 'R',
+        };
+        return !rest.chars().take_while(char::is_ascii_uppercase).any(|c| c == letter);
+    }
+    title.starts_with("nvim") || title.starts_with("vim")
+}
+
+/// Panel-focus decision for FocusLeft/FocusRight.  Panels sit in a fixed
+/// `ProjectsSidebar ↔ Terminal ↔ GitSidebar` row; movement toward a hidden
+/// panel is dropped (focus never opens a panel), and from the terminal the
+/// inner TUI gets first refusal via [`inner_handles`].
+fn focus_move(
+    focus: PaneFocus,
+    dir: FocusDir,
+    left_open: bool,
+    right_open: bool,
+    title: &str,
+) -> FocusMove {
+    if focus == PaneFocus::Terminal && inner_handles(title, dir) {
+        return FocusMove::Passthrough;
+    }
+    let target = match (focus, dir) {
+        (PaneFocus::Terminal, FocusDir::Left) => left_open.then_some(PaneFocus::ProjectsSidebar),
+        (PaneFocus::Terminal, FocusDir::Right) => right_open.then_some(PaneFocus::GitSidebar),
+        (PaneFocus::ProjectsSidebar, FocusDir::Right) => Some(PaneFocus::Terminal),
+        (PaneFocus::GitSidebar, FocusDir::Left) => Some(PaneFocus::Terminal),
+        _ => None,
+    };
+    match target {
+        Some(t) => FocusMove::Focus(t),
+        None => FocusMove::Nothing,
+    }
 }
 
 pub struct AlacritreeApp {
@@ -5402,6 +5463,95 @@ mod tests {
         // The main itself and unknown paths have no fallback target.
         assert_eq!(project_main_for(&projects, Path::new("/repo")), None);
         assert_eq!(project_main_for(&projects, Path::new("/elsewhere")), None);
+    }
+
+    /// `focus_move` with both panels open.
+    fn mv(focus: PaneFocus, dir: FocusDir, title: &str) -> FocusMove {
+        focus_move(focus, dir, true, true, title)
+    }
+
+    #[test]
+    fn focus_moves_between_open_panels() {
+        assert_eq!(
+            mv(PaneFocus::Terminal, FocusDir::Left, ""),
+            FocusMove::Focus(PaneFocus::ProjectsSidebar)
+        );
+        assert_eq!(
+            mv(PaneFocus::Terminal, FocusDir::Right, ""),
+            FocusMove::Focus(PaneFocus::GitSidebar)
+        );
+        assert_eq!(
+            mv(PaneFocus::ProjectsSidebar, FocusDir::Right, ""),
+            FocusMove::Focus(PaneFocus::Terminal)
+        );
+        assert_eq!(
+            mv(PaneFocus::GitSidebar, FocusDir::Left, ""),
+            FocusMove::Focus(PaneFocus::Terminal)
+        );
+    }
+
+    #[test]
+    fn focus_stops_at_the_outer_edges() {
+        assert_eq!(mv(PaneFocus::ProjectsSidebar, FocusDir::Left, ""), FocusMove::Nothing);
+        assert_eq!(mv(PaneFocus::GitSidebar, FocusDir::Right, ""), FocusMove::Nothing);
+    }
+
+    #[test]
+    fn focus_never_moves_toward_a_closed_panel() {
+        assert_eq!(
+            focus_move(PaneFocus::Terminal, FocusDir::Left, false, true, ""),
+            FocusMove::Nothing
+        );
+        assert_eq!(
+            focus_move(PaneFocus::Terminal, FocusDir::Right, true, false, ""),
+            FocusMove::Nothing
+        );
+    }
+
+    #[test]
+    fn tmux_edges_gate_passthrough() {
+        // No letter for the direction: the inner stack can still move.
+        assert_eq!(
+            mv(PaneFocus::Terminal, FocusDir::Left, "tmux:R /home/lev"),
+            FocusMove::Passthrough
+        );
+        // Against that wall: alacritree takes over.
+        assert_eq!(
+            mv(PaneFocus::Terminal, FocusDir::Left, "tmux:LU /home/lev"),
+            FocusMove::Focus(PaneFocus::ProjectsSidebar)
+        );
+        // Bare prefix publishes no blocked edges at all.
+        assert_eq!(mv(PaneFocus::Terminal, FocusDir::Right, "tmux:"), FocusMove::Passthrough);
+    }
+
+    #[test]
+    fn tmux_at_edge_with_closed_panel_does_nothing() {
+        assert_eq!(
+            focus_move(PaneFocus::Terminal, FocusDir::Left, false, true, "tmux:L x"),
+            FocusMove::Nothing
+        );
+    }
+
+    #[test]
+    fn nvim_titles_always_pass_through() {
+        assert_eq!(
+            mv(PaneFocus::Terminal, FocusDir::Left, "nvim ~/notes.md"),
+            FocusMove::Passthrough
+        );
+        assert_eq!(mv(PaneFocus::Terminal, FocusDir::Right, "vim"), FocusMove::Passthrough);
+        // A shell whose title merely mentions vim is not vim.
+        assert_eq!(
+            mv(PaneFocus::Terminal, FocusDir::Left, "pwsh — nvim docs"),
+            FocusMove::Focus(PaneFocus::ProjectsSidebar)
+        );
+    }
+
+    #[test]
+    fn sidebars_never_pass_through() {
+        assert_eq!(
+            mv(PaneFocus::ProjectsSidebar, FocusDir::Right, "tmux: x"),
+            FocusMove::Focus(PaneFocus::Terminal)
+        );
     }
 
     fn req(file: &str, source: DiffSource) -> DiffRequest {

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -73,6 +73,10 @@ pub enum NamedAction {
     /// us) but suppress_chars stays off so the key still reaches the PTY.
     /// Mirrors `Action::ReceiveChar` in `alacritty/src/input/keyboard.rs`.
     ReceiveChar,
+    /// Directional panel focus with TUI passthrough (see `focus_move` in
+    /// `app.rs`).
+    FocusLeft,
+    FocusRight,
 }
 
 impl NamedAction {
@@ -148,6 +152,8 @@ impl NamedAction {
             Self::ShowShortcuts => "Show this shortcuts window".into(),
             Self::ToggleSessionRows => "Toggle single-session sidebar rows".into(),
             Self::ToggleSessionTabs => "Toggle single-session tab segments".into(),
+            Self::FocusLeft => "Move panel focus left (TUIs get the key first)".into(),
+            Self::FocusRight => "Move panel focus right (TUIs get the key first)".into(),
             Self::NoOp | Self::ReceiveChar => String::new(),
         }
     }
@@ -637,6 +643,8 @@ fn parse_action(name: &str) -> BindingAction {
         "Quit" => BindingAction::Named(Quit),
         "None" => BindingAction::Named(NoOp),
         "ReceiveChar" => BindingAction::Named(ReceiveChar),
+        "FocusLeft" => BindingAction::Named(FocusLeft),
+        "FocusRight" => BindingAction::Named(FocusRight),
         other => BindingAction::Unsupported(other.to_string()),
     }
 }
@@ -831,6 +839,8 @@ mod tests {
             ("FocusGitSidebar", NamedAction::FocusGitSidebar),
             ("ToggleSessionRows", NamedAction::ToggleSessionRows),
             ("ToggleSessionTabs", NamedAction::ToggleSessionTabs),
+            ("FocusLeft", NamedAction::FocusLeft),
+            ("FocusRight", NamedAction::FocusRight),
         ] {
             let b = parse_bindings(vec![raw_action("F1", None, name)]);
             assert_eq!(named_matches(&b, Key::F1, Modifiers::NONE), vec![expected], "{name}");

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -576,7 +576,7 @@ fn parse_mods(s: &str) -> Option<Modifiers> {
     Some(m)
 }
 
-fn parse_action(name: &str) -> BindingAction {
+pub fn parse_action(name: &str) -> BindingAction {
     use NamedAction::*;
     match name {
         "Paste" => BindingAction::Named(Paste),

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -60,6 +60,10 @@ pub enum NamedAction {
     FocusProjectsSidebar,
     FocusGitSidebar,
     FocusTerminal,
+    /// Flip the runtime `session_display.sidebar_always` value.
+    ToggleSessionRows,
+    /// Flip the runtime `session_display.tabs_always` value.
+    ToggleSessionTabs,
     /// 1-indexed into the `[[ui.profiles]]` order.
     SpawnProfile(u8),
     Quit,
@@ -142,6 +146,8 @@ impl NamedAction {
             Self::SpawnProfile(n) => format!("Open a session with shell profile {n}"),
             Self::Quit => "Open the quit confirmation dialog".into(),
             Self::ShowShortcuts => "Show this shortcuts window".into(),
+            Self::ToggleSessionRows => "Toggle single-session sidebar rows".into(),
+            Self::ToggleSessionTabs => "Toggle single-session tab segments".into(),
             Self::NoOp | Self::ReceiveChar => String::new(),
         }
     }
@@ -616,6 +622,8 @@ fn parse_action(name: &str) -> BindingAction {
         "FocusProjectsSidebar" => BindingAction::Named(FocusProjectsSidebar),
         "FocusGitSidebar" => BindingAction::Named(FocusGitSidebar),
         "FocusTerminal" => BindingAction::Named(FocusTerminal),
+        "ToggleSessionRows" => BindingAction::Named(ToggleSessionRows),
+        "ToggleSessionTabs" => BindingAction::Named(ToggleSessionTabs),
         "SpawnProfile1" => BindingAction::Named(SpawnProfile(1)),
         "SpawnProfile2" => BindingAction::Named(SpawnProfile(2)),
         "SpawnProfile3" => BindingAction::Named(SpawnProfile(3)),
@@ -821,6 +829,8 @@ mod tests {
             ("FocusProjectsSidebar", NamedAction::FocusProjectsSidebar),
             ("FocusTerminal", NamedAction::FocusTerminal),
             ("FocusGitSidebar", NamedAction::FocusGitSidebar),
+            ("ToggleSessionRows", NamedAction::ToggleSessionRows),
+            ("ToggleSessionTabs", NamedAction::ToggleSessionTabs),
         ] {
             let b = parse_bindings(vec![raw_action("F1", None, name)]);
             assert_eq!(named_matches(&b, Key::F1, Modifiers::NONE), vec![expected], "{name}");

--- a/alacritree/src/cli/mod.rs
+++ b/alacritree/src/cli/mod.rs
@@ -72,6 +72,13 @@ enum Command {
         command: WorktreeCommand,
     },
 
+    /// Run a named key-binding action in the running window, as if its key
+    /// had been pressed.  Needs a running alacritree.
+    Action {
+        /// Action name as accepted in `[[keyboard.bindings]]`, e.g. FocusLeft.
+        name: String,
+    },
+
     /// Check the external tools, config and state alacritree depends on.
     Doctor,
 
@@ -257,6 +264,7 @@ fn to_request(command: Command) -> IpcRequest {
             },
         },
         Command::GitStatus { path } => IpcRequest::GitStatus { path: absolute(path) },
+        Command::Action { name } => IpcRequest::RunAction { action: name },
         Command::Worktree { command } => match command {
             WorktreeCommand::Create { project_root, branch } => {
                 IpcRequest::CreateWorktree { project_root: absolute(project_root), branch }
@@ -326,6 +334,10 @@ mod tests {
         assert!(matches!(
             request_for(&["alacritree", "project", "rename", ".", "Work"]),
             IpcRequest::RenameProject { label: Some(label), .. } if label == "Work"
+        ));
+        assert!(matches!(
+            request_for(&["alacritree", "action", "FocusLeft"]),
+            IpcRequest::RunAction { action } if action == "FocusLeft"
         ));
     }
 

--- a/alacritree/src/cli/offline.rs
+++ b/alacritree/src/cli/offline.rs
@@ -68,7 +68,8 @@ fn handle_at(state_path: &Path, request: &IpcRequest) -> IpcResult {
         | IpcRequest::CreateSession { .. }
         | IpcRequest::CloseSession { .. }
         | IpcRequest::SendText { .. }
-        | IpcRequest::ReadScreen { .. } => Err("alacritree is not running".to_string()),
+        | IpcRequest::ReadScreen { .. }
+        | IpcRequest::RunAction { .. } => Err("alacritree is not running".to_string()),
     }
 }
 

--- a/alacritree/src/cli/render.rs
+++ b/alacritree/src/cli/render.rs
@@ -34,6 +34,9 @@ pub fn human(request: &IpcRequest, value: &Value) {
         IpcRequest::CreateWorktree { .. } => {
             println!("{}", text(&value["path"]));
         },
+        IpcRequest::RunAction { .. } => {
+            println!("ran {}", text(&value["action"]));
+        },
     }
 }
 

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -279,6 +279,16 @@ fn parse_last_session_close(raw: Option<&str>) -> LastSessionClose {
     }
 }
 
+/// Whether per-session UI (sidebar session rows, tab-strip segments) renders
+/// for a single-session workspace instead of waiting for the two-session
+/// threshold.  These are startup defaults only: the app copies them into
+/// runtime state that key bindings can toggle, and nothing is persisted.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SessionDisplay {
+    pub sidebar_always: bool,
+    pub tabs_always: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct UiTheme {
     pub sidebar_background: Option<Color32>,
@@ -291,6 +301,8 @@ pub struct UiTheme {
     pub confirm_session_close: ConfirmSessionClose,
     /// What closing the last session in the on-screen workspace does.
     pub last_session_close: LastSessionClose,
+    /// Show single-session sidebar rows / tab segments ([`SessionDisplay`]).
+    pub session_display: SessionDisplay,
     pub icons: UiIcons,
 }
 
@@ -304,6 +316,7 @@ impl Default for UiTheme {
             notifications: true,
             confirm_session_close: ConfirmSessionClose::Never,
             last_session_close: LastSessionClose::Respawn,
+            session_display: SessionDisplay::default(),
             icons: UiIcons::default(),
         }
     }
@@ -847,6 +860,15 @@ struct RawUiWsl {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
+struct RawSessionDisplay {
+    /// Show a workspace's sidebar session row even with a single session.
+    sidebar_always: Option<bool>,
+    /// Draw a tab-strip segment even with a single session.
+    tabs_always: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 struct RawUi {
     sidebar_background: Option<RgbStr>,
     sidebar_foreground: Option<RgbStr>,
@@ -859,6 +881,7 @@ struct RawUi {
     /// What closing the on-screen workspace's last session does:
     /// "respawn" (default) | "navigate".
     last_session_close: Option<String>,
+    session_display: RawSessionDisplay,
     delta_path: Option<String>,
     icons: RawUiIcons,
     wsl: RawUiWsl,
@@ -990,6 +1013,10 @@ impl RawConfig {
                 self.ui.confirm_session_close.as_deref(),
             ),
             last_session_close: parse_last_session_close(self.ui.last_session_close.as_deref()),
+            session_display: SessionDisplay {
+                sidebar_always: self.ui.session_display.sidebar_always.unwrap_or(false),
+                tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
+            },
             icons: UiIcons {
                 search: self.ui.icons.search.unwrap_or_else(|| DEFAULT_SEARCH_ICON.into()),
             },
@@ -1469,5 +1496,39 @@ program = "second"
         let config = raw.into_config();
         assert!(config.profiles.is_empty());
         assert_eq!(config.default_profile, None);
+    }
+
+    #[test]
+    fn session_display_defaults_to_hidden() {
+        let ui = ui_from_toml("");
+        assert!(!ui.session_display.sidebar_always);
+        assert!(!ui.session_display.tabs_always);
+    }
+
+    #[test]
+    fn session_display_parses_both_flags() {
+        let ui = ui_from_toml("[ui.session_display]\nsidebar_always = true\ntabs_always = true");
+        assert!(ui.session_display.sidebar_always);
+        assert!(ui.session_display.tabs_always);
+    }
+
+    #[test]
+    fn session_display_partial_table_leaves_the_other_flag_off() {
+        let ui = ui_from_toml("[ui.session_display]\nsidebar_always = true");
+        assert!(ui.session_display.sidebar_always);
+        assert!(!ui.session_display.tabs_always);
+    }
+
+    /// alacritree.toml merges over alacritty.toml key-by-key, so setting one
+    /// flag per file must yield both.
+    #[test]
+    fn session_display_merges_key_by_key() {
+        let base: toml::Value =
+            toml::from_str("[ui.session_display]\nsidebar_always = true").unwrap();
+        let over: toml::Value = toml::from_str("[ui.session_display]\ntabs_always = true").unwrap();
+        let raw: RawConfig = merge(base, over).try_into().unwrap();
+        let sd = raw.into_config().ui.session_display;
+        assert!(sd.sidebar_always);
+        assert!(sd.tabs_always);
     }
 }

--- a/alacritree/src/input.rs
+++ b/alacritree/src/input.rs
@@ -24,7 +24,7 @@ pub fn event_to_bytes(event: &Event, mode: TermMode) -> Option<Vec<u8>> {
     }
 }
 
-fn key_to_bytes(key: Key, mods: Modifiers, mode: TermMode) -> Option<Vec<u8>> {
+pub fn key_to_bytes(key: Key, mods: Modifiers, mode: TermMode) -> Option<Vec<u8>> {
     if should_build_kitty(key, mods, mode)
         && let Some(bytes) = kitty_sequence(key, mods)
     {

--- a/alacritree/src/ipc.rs
+++ b/alacritree/src/ipc.rs
@@ -91,6 +91,13 @@ pub enum IpcRequest {
         project_root: PathBuf,
         branch: String,
     },
+    /// Run a named key-binding action (`FocusLeft`, `ToggleLeftSidebar`, …)
+    /// as if its key had been pressed.  `bindings::parse_action` defines the
+    /// accepted names, so every action a key can be bound to is reachable
+    /// over the socket without a dedicated request.
+    RunAction {
+        action: String,
+    },
 }
 
 pub type IpcResult = Result<Value, String>;

--- a/alacritree/src/ipc.rs
+++ b/alacritree/src/ipc.rs
@@ -135,7 +135,30 @@ pub fn spawn_listener(ctx: egui::Context) -> std::io::Result<(SocketHandle, Rece
     // no other thread is reading the environment concurrently.
     unsafe { std::env::set_var(SOCKET_ENV, listener.0.path()) };
 
+    // Only WSLENV-listed variables cross the wsl.exe boundary — in either
+    // direction.  Listing the socket lets programs in a distro find this
+    // instance, whether they read the variable themselves or exec the
+    // Windows CLI through interop (which inherits the distro's view).  No
+    // conversion flag: a pipe name is not a path WSL should translate.
+    #[cfg(windows)]
+    unsafe {
+        std::env::set_var("WSLENV", wslenv_with_socket(std::env::var("WSLENV").ok().as_deref()))
+    };
+
     Ok(listener)
+}
+
+/// `WSLENV` extended with [`SOCKET_ENV`], preserving whatever the user
+/// already shares across the boundary.
+#[cfg(any(test, windows))]
+fn wslenv_with_socket(current: Option<&str>) -> String {
+    match current {
+        None | Some("") => SOCKET_ENV.to_string(),
+        Some(v) if v.split(':').any(|entry| entry.split('/').next() == Some(SOCKET_ENV)) => {
+            v.to_string()
+        },
+        Some(v) => format!("{v}:{SOCKET_ENV}"),
+    }
 }
 
 /// Listen on a caller-chosen path, without advertising it.
@@ -441,6 +464,17 @@ pub fn listen_for_test(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wslenv_gains_the_socket_exactly_once() {
+        assert_eq!(wslenv_with_socket(None), SOCKET_ENV);
+        assert_eq!(wslenv_with_socket(Some("")), SOCKET_ENV);
+        assert_eq!(wslenv_with_socket(Some("LESS:FOO/p")), format!("LESS:FOO/p:{SOCKET_ENV}"));
+        // Already listed — with or without conversion flags — stays as-is.
+        assert_eq!(wslenv_with_socket(Some(SOCKET_ENV)), SOCKET_ENV);
+        let flagged = format!("{SOCKET_ENV}/u:LESS");
+        assert_eq!(wslenv_with_socket(Some(&flagged)), flagged);
+    }
 
     /// The client/server round trip over whatever transport the platform uses:
     /// framing, dispatch to the app thread, and the reply.  Discovery by

--- a/alacritree/src/mcp.rs
+++ b/alacritree/src/mcp.rs
@@ -256,6 +256,17 @@ fn tool_definitions() -> Value {
                 "required": ["root"],
             },
         },
+        {
+            "name": "run_action",
+            "description": "Run one of alacritree's named key-binding actions by name, as if its key had been pressed — e.g. FocusLeft, FocusRight, ToggleLeftSidebar, SelectNextWorkspace, ScrollPageDown. Any action accepted in [[keyboard.bindings]] works; unknown names return an error. FocusLeft/FocusRight switch panel focus directly, without the key passthrough a real key press can trigger.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": { "type": "string", "description": "Action name as accepted in [[keyboard.bindings]]." },
+                },
+                "required": ["action"],
+            },
+        },
     ])
 }
 
@@ -285,6 +296,7 @@ mod tests {
             IpcRequest::AddProject { path: repo() },
             IpcRequest::RemoveProject { root: repo() },
             IpcRequest::RenameProject { root: repo(), label: None },
+            IpcRequest::RunAction { action: "FocusLeft".into() },
         ]
     }
 
@@ -303,6 +315,7 @@ mod tests {
             IpcRequest::AddProject { .. } => "add_project",
             IpcRequest::RemoveProject { .. } => "remove_project",
             IpcRequest::RenameProject { .. } => "rename_project",
+            IpcRequest::RunAction { .. } => "run_action",
         }
     }
 

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -117,6 +117,9 @@ struct AgentCache {
     process_glyph: Option<char>,
     /// Whether anything is running in the terminal beyond the shell itself.
     foreground_job: bool,
+    /// Whether a split-managing TUI (vim, tmux) is running in the terminal;
+    /// see [`Session::nav_tui_running`].
+    nav_tui: bool,
 }
 
 const AGENT_CACHE_TTL: Duration = Duration::from_millis(1000);
@@ -177,6 +180,18 @@ fn agent_glyph_by_name(names: impl IntoIterator<Item = impl AsRef<str>>) -> Opti
         let n = n.as_ref().to_ascii_lowercase();
         AGENT_PROCESS_GLYPHS.iter().find(|(name, _)| n.starts_with(name)).map(|(_, g)| *g)
     })
+}
+
+/// TUIs that manage their own splits and cooperate with FocusLeft/
+/// FocusRight: the key is forwarded while one runs, and the TUI calls
+/// `alacritree action Focus…` over IPC once it has no window left in that
+/// direction.  Matches Linux `comm` values (`tmux: client`) and Windows
+/// image names (`nvim.exe`) alike; gvim stays out — it owns its own
+/// window and never runs inside the terminal.
+#[cfg(any(test, target_os = "linux", windows))]
+fn is_nav_tui_name(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n.starts_with("nvim") || n.starts_with("vim") || n.starts_with("tmux")
 }
 
 /// Match full command lines against the agent map — picks up
@@ -380,6 +395,34 @@ fn foreground_process_glyph(_shell_pid: u32) -> Option<char> {
     None
 }
 
+/// Whether a split-managing TUI owns the terminal: the process holding the
+/// foreground group is one of the recognized names.
+#[cfg(target_os = "linux")]
+fn foreground_nav_tui(shell_pid: u32) -> bool {
+    let Some(tpgid) = read_tpgid(shell_pid) else {
+        return false;
+    };
+    if tpgid <= 0 {
+        return false;
+    }
+    std::fs::read_to_string(format!("/proc/{tpgid}/comm"))
+        .is_ok_and(|comm| is_nav_tui_name(comm.trim()))
+}
+
+/// Windows has no foreground process group, so a nav TUI anywhere in the
+/// shell's descendant tree counts — the same approximation the agent
+/// glyph uses.
+#[cfg(windows)]
+fn foreground_nav_tui(shell_pid: u32) -> bool {
+    windows_process_probe::probe(shell_pid).2
+}
+
+#[cfg(not(any(target_os = "linux", windows)))]
+fn foreground_nav_tui(_shell_pid: u32) -> bool {
+    // Same gap as the glyph probe: macOS isn't wired up yet.
+    false
+}
+
 /// Terminal options derived from the user config.
 pub fn term_config(config: &Config) -> TermConfig {
     TermConfig {
@@ -421,7 +464,7 @@ mod windows_process_probe {
 
     use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
-    use super::{agent_glyph_by_cmdline, agent_glyph_by_name, process_tree_pids};
+    use super::{agent_glyph_by_cmdline, agent_glyph_by_name, is_nav_tui_name, process_tree_pids};
 
     /// Slightly under `AGENT_CACHE_TTL` so the first session to tick
     /// refreshes and the rest reuse the same table.
@@ -429,9 +472,9 @@ mod windows_process_probe {
 
     static SNAPSHOT: Mutex<Option<(Instant, System)>> = Mutex::new(None);
 
-    /// Agent glyph found in the shell's descendant tree, plus whether the
-    /// shell has any descendants at all.
-    pub(super) fn probe(shell_pid: u32) -> (Option<char>, bool) {
+    /// Agent glyph found in the shell's descendant tree, whether the shell
+    /// has any descendants at all, and whether one of them is a nav TUI.
+    pub(super) fn probe(shell_pid: u32) -> (Option<char>, bool, bool) {
         let mut guard = SNAPSHOT.lock().unwrap_or_else(PoisonError::into_inner);
         if guard.as_ref().is_none_or(|(at, _)| at.elapsed() >= SNAPSHOT_TTL) {
             let mut sys = guard.take().map(|(_, sys)| sys).unwrap_or_default();
@@ -453,10 +496,14 @@ mod windows_process_probe {
         let has_children = tree.len() > 1;
         let tree: Vec<Pid> = tree.into_iter().map(Pid::from_u32).collect();
 
-        let names =
-            tree.iter().filter_map(|pid| sys.process(*pid)).map(|p| p.name().to_string_lossy());
-        if let Some(glyph) = agent_glyph_by_name(names) {
-            return (Some(glyph), has_children);
+        let names: Vec<String> = tree
+            .iter()
+            .filter_map(|pid| sys.process(*pid))
+            .map(|p| p.name().to_string_lossy().into_owned())
+            .collect();
+        let nav_tui = names.iter().any(|n| is_nav_tui_name(n));
+        if let Some(glyph) = agent_glyph_by_name(&names) {
+            return (Some(glyph), has_children, nav_tui);
         }
 
         // Names missed: fetch command lines for just the tree to catch
@@ -470,7 +517,7 @@ mod windows_process_probe {
             .iter()
             .filter_map(|pid| sys.process(*pid))
             .map(|p| p.cmd().iter().map(|a| a.to_string_lossy()).collect::<Vec<_>>().join(" "));
-        (agent_glyph_by_cmdline(cmds), has_children)
+        (agent_glyph_by_cmdline(cmds), has_children, nav_tui)
     }
 }
 
@@ -704,20 +751,33 @@ impl Session {
         self.process_probe().0
     }
 
-    fn process_probe(&self) -> (Option<char>, bool) {
+    /// Whether a split-managing TUI (vim, tmux) is running in this terminal
+    /// — the FocusLeft/FocusRight passthrough signal.  Identity comes from
+    /// the process probe rather than the terminal title: a title-based
+    /// signal needs every cooperating program to publish a recognizable
+    /// value, and Windows' ConPTY interleaves the console title into the
+    /// stream, so a launcher touching it after vim starts clobbers vim's
+    /// own title until vim re-emits it.
+    pub fn nav_tui_running(&self) -> bool {
+        self.process_probe().2
+    }
+
+    fn process_probe(&self) -> (Option<char>, bool, bool) {
         let cached = self.agent_cache.get();
         let fresh = cached.polled_at.is_some_and(|t| t.elapsed() < AGENT_CACHE_TTL);
         if fresh {
-            return (cached.process_glyph, cached.foreground_job);
+            return (cached.process_glyph, cached.foreground_job, cached.nav_tui);
         }
         let glyph = self.shell_pid.and_then(foreground_process_glyph);
         let foreground_job = self.shell_pid.is_some_and(shell_has_foreground_job);
+        let nav_tui = self.shell_pid.is_some_and(foreground_nav_tui);
         self.agent_cache.set(AgentCache {
             polled_at: Some(Instant::now()),
             process_glyph: glyph,
             foreground_job,
+            nav_tui,
         });
-        (glyph, foreground_job)
+        (glyph, foreground_job, nav_tui)
     }
 
     /// Text dump of the visible screen plus up to `scrollback_lines` of
@@ -1132,6 +1192,21 @@ mod tests {
         assert_eq!(agent_glyph_by_name(["pwsh.exe", "git.exe"]), None);
         assert_eq!(agent_glyph_by_name(["not-claude.exe"]), None);
         assert_eq!(agent_glyph_by_name(std::iter::empty::<&str>()), None);
+    }
+
+    #[test]
+    fn nav_tui_name_match_covers_both_platforms_naming() {
+        // Windows image names.
+        assert!(is_nav_tui_name("nvim.exe"));
+        assert!(is_nav_tui_name("NVIM.EXE"));
+        assert!(is_nav_tui_name("vim.exe"));
+        // Linux comm values.
+        assert!(is_nav_tui_name("nvim"));
+        assert!(is_nav_tui_name("tmux: client"));
+        // gvim owns its own window — it never runs inside the terminal.
+        assert!(!is_nav_tui_name("gvim.exe"));
+        assert!(!is_nav_tui_name("chezmoi.exe"));
+        assert!(!is_nav_tui_name("pwsh.exe"));
     }
 
     #[test]

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -194,6 +194,16 @@ fn is_nav_tui_name(name: &str) -> bool {
     n.starts_with("nvim") || n.starts_with("vim") || n.starts_with("tmux")
 }
 
+/// `wsl.exe` (and its `wslhost`/`wslrelay` helpers) mark a session whose
+/// real process tree lives on the Linux side, where this probe cannot see.
+/// Assume the inside cooperates like a nav TUI: the key is forwarded, and
+/// programs in the distro hand focus back by exec'ing the Windows CLI
+/// (`alacritree.exe action Focus…`) through WSL interop.
+#[cfg(any(test, windows))]
+fn is_wsl_boundary_name(name: &str) -> bool {
+    name.to_ascii_lowercase().starts_with("wsl")
+}
+
 /// Match full command lines against the agent map — picks up
 /// `node ...\claude-code\cli.js`-style wrappers that hide behind their
 /// runtime's name, same as the Linux cmdline pass.
@@ -464,7 +474,10 @@ mod windows_process_probe {
 
     use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
-    use super::{agent_glyph_by_cmdline, agent_glyph_by_name, is_nav_tui_name, process_tree_pids};
+    use super::{
+        agent_glyph_by_cmdline, agent_glyph_by_name, is_nav_tui_name, is_wsl_boundary_name,
+        process_tree_pids,
+    };
 
     /// Slightly under `AGENT_CACHE_TTL` so the first session to tick
     /// refreshes and the rest reuse the same table.
@@ -501,7 +514,7 @@ mod windows_process_probe {
             .filter_map(|pid| sys.process(*pid))
             .map(|p| p.name().to_string_lossy().into_owned())
             .collect();
-        let nav_tui = names.iter().any(|n| is_nav_tui_name(n));
+        let nav_tui = names.iter().any(|n| is_nav_tui_name(n) || is_wsl_boundary_name(n));
         if let Some(glyph) = agent_glyph_by_name(&names) {
             return (Some(glyph), has_children, nav_tui);
         }
@@ -1207,6 +1220,14 @@ mod tests {
         assert!(!is_nav_tui_name("gvim.exe"));
         assert!(!is_nav_tui_name("chezmoi.exe"));
         assert!(!is_nav_tui_name("pwsh.exe"));
+    }
+
+    #[test]
+    fn wsl_boundary_match_covers_the_helper_processes() {
+        assert!(is_wsl_boundary_name("wsl.exe"));
+        assert!(is_wsl_boundary_name("wslhost.exe"));
+        assert!(is_wsl_boundary_name("WSLRELAY.EXE"));
+        assert!(!is_wsl_boundary_name("pwsh.exe"));
     }
 
     #[test]


### PR DESCRIPTION
Two additions to the alacritree crate.

**Session-display visibility.** A new `[ui.session_display]` table (`sidebar_always`, `tabs_always`, both default `false`) forces single-session workspaces to show their sidebar session row and tab-strip segment instead of waiting for the two-session threshold. Two new bindable actions, `ToggleSessionRows` and `ToggleSessionTabs`, flip the corresponding runtime state (config is the startup default; toggles are not persisted). Both actions can share one key to flip rows and tabs together.

**Directional pane focus.** New `FocusLeft`/`FocusRight` actions (unbound by default) move keyboard focus across `ProjectsSidebar ↔ Terminal ↔ GitSidebar`; the git sidebar gains visual focus (accent-colored header). While the terminal is focused, the move defers to a split-managing TUI running inside it — vim/nvim/tmux, recognized by a process probe (foreground process group on Linux, shell descendant tree on Windows via the existing throttled snapshot), the same detection tmux's and kitty's navigator integrations use. No terminal-title protocol: title-based detection was unreliable on Windows, where ConPTY interleaves synthesized console-title updates that can shadow the TUI's own title. The decision logic is a pure function with table-driven tests; passthrough reuses `input::key_to_bytes`, so kitty-protocol modes are respected. The macOS probe is not wired yet, matching the existing agent-glyph probes. WSL sessions are an opaque boundary the probe cannot see across, so they always forward the key; programs in the distro hand focus back by exec'ing the Windows CLI through interop, and `ALACRITREE_SOCKET` is appended to `WSLENV` so it crosses the boundary both ways.

**Actions over IPC.** A `run_action` request (`alacritree action <name>` on the CLI, `run_action` MCP tool) runs any name `[[keyboard.bindings]]` accepts, as if its key had been pressed — every current and future binding action becomes scriptable with no new IPC surface. This closes the loop for the TUI side of directional focus: a Navigator.nvim custom multiplexer (or a tmux `run-shell` binding) at its last split can ask alacritree to move panel focus. `FocusLeft`/`FocusRight` arriving over IPC skip the TUI passthrough — the caller is the inner program declaring it is out of windows, and re-synthesizing the key would bounce it straight back. Verified live against a running instance: actions dispatch on the UI thread, unknown names reply with an error, and an nvim libuv client drove panel focus over the pipe.

Defaults preserve current behavior: flags off, actions unbound. 352 tests passing, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

