### PR TITLE
[2] feat(bindings): add CloseSession and sidebar navigation actions

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -998,12 +998,25 @@ impl AlacritreeApp {
     /// text input.  Matched events are consumed unless every matched action
     /// is `ReceiveChar` (alacritty's pass-through marker).
     fn handle_shortcuts(&mut self, ctx: &Context) {
+        let sidebar_focused = self.focus == PaneFocus::ProjectsSidebar;
         let actions: Vec<BindingAction> = ctx.input_mut(|i| {
             let mut actions = Vec::new();
             i.events.retain(|ev| {
                 if let egui::Event::Key { key, pressed: true, modifiers, .. } = ev {
                     let matched =
                         crate::bindings::all_matches(&self.config.bindings, *key, *modifiers);
+                    // Sidebar-cursor actions only exist while the sidebar owns focus;
+                    // anywhere else their keys (unmodified Home/End/PageUp/PageDown) are
+                    // terminal input.  Stacked user bindings can mix a sidebar action with
+                    // a global one on a single trigger, so filter per action — and if
+                    // nothing else matched, let the event through untouched.
+                    let matched: Vec<_> = matched
+                        .into_iter()
+                        .filter(|a| {
+                            sidebar_focused
+                                || !matches!(a, BindingAction::Named(n) if n.is_sidebar_scoped())
+                        })
+                        .collect();
                     if !matched.is_empty() {
                         let suppress_chars = matched
                             .iter()
@@ -1103,6 +1116,37 @@ impl AlacritreeApp {
             },
         };
         self.set_sidebar_cursor(sidebar_nav::step(&rows, &cursor, delta));
+    }
+
+    /// Home/End for the sidebar cursor: first or last of the rows the arrow
+    /// keys step over (the filtered set while a filter is active).
+    fn sidebar_cursor_to_edge(&mut self, top: bool) {
+        let rows = self.current_project_rows();
+        let target = if top { rows.first() } else { rows.last() };
+        if let Some(row) = target.cloned() {
+            self.set_sidebar_cursor(row);
+        }
+    }
+
+    /// PageUp/PageDown for the sidebar cursor: the nearest project header
+    /// above/below, clamped at the extremes.  A stale cursor reseats on the
+    /// first row, same as `apply_sidebar_nav`.
+    fn sidebar_cursor_project_jump(&mut self, delta: i32) {
+        let rows = self.current_project_rows();
+        let Some(cursor) = self.sidebar_cursor.clone().filter(|c| rows.contains(c)) else {
+            if let Some(first) = rows.first() {
+                self.set_sidebar_cursor(first.clone());
+            }
+            return;
+        };
+        let target = if delta > 0 {
+            sidebar_nav::next_project(&rows, &cursor)
+        } else {
+            sidebar_nav::previous_project(&rows, &cursor)
+        };
+        if let Some(row) = target {
+            self.set_sidebar_cursor(row);
+        }
     }
 
     /// Rows the sidebar cursor steps over this frame: the fuzzy/toggle-filtered
@@ -1561,6 +1605,14 @@ impl AlacritreeApp {
                 if let Some(id) = target {
                     self.request_close_session(ctx, id);
                 }
+            },
+            BindingAction::Named(NamedAction::SidebarTop) => self.sidebar_cursor_to_edge(true),
+            BindingAction::Named(NamedAction::SidebarBottom) => self.sidebar_cursor_to_edge(false),
+            BindingAction::Named(NamedAction::SidebarNextProject) => {
+                self.sidebar_cursor_project_jump(1)
+            },
+            BindingAction::Named(NamedAction::SidebarPreviousProject) => {
+                self.sidebar_cursor_project_jump(-1)
             },
             BindingAction::Named(NamedAction::FocusProjectsSidebar) => {
                 if self.focus != PaneFocus::ProjectsSidebar {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1548,8 +1548,17 @@ impl AlacritreeApp {
                 PaneFocus::GitSidebar => self.focus_sidebar(),
             },
             BindingAction::Named(NamedAction::CloseSession) => {
-                if let Some(idx) = self.active_session_index() {
-                    let id = self.sessions[idx].id;
+                let cursored = if self.focus == PaneFocus::ProjectsSidebar {
+                    match &self.sidebar_cursor {
+                        Some(SidebarRow::Session(id)) => Some(*id),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                let target = cursored
+                    .or_else(|| self.active_session_index().map(|idx| self.sessions[idx].id));
+                if let Some(id) = target {
                     self.request_close_session(ctx, id);
                 }
             },

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -52,6 +52,10 @@ pub enum NamedAction {
     AddProject,
     ToggleSidebarFocus,
     CloseSession,
+    SidebarTop,
+    SidebarBottom,
+    SidebarNextProject,
+    SidebarPreviousProject,
     FocusProjectsSidebar,
     FocusGitSidebar,
     FocusTerminal,
@@ -64,6 +68,22 @@ pub enum NamedAction {
     /// us) but suppress_chars stays off so the key still reaches the PTY.
     /// Mirrors `Action::ReceiveChar` in `alacritty/src/input/keyboard.rs`.
     ReceiveChar,
+}
+
+impl NamedAction {
+    /// Actions that drive the projects-sidebar cursor.  Their default keys
+    /// (unmodified Home/End/PageUp/PageDown) are terminal input the rest of
+    /// the time, so dispatch must not consume them unless the sidebar owns
+    /// focus.
+    pub fn is_sidebar_scoped(&self) -> bool {
+        matches!(
+            self,
+            Self::SidebarTop
+                | Self::SidebarBottom
+                | Self::SidebarNextProject
+                | Self::SidebarPreviousProject
+        )
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -194,6 +214,26 @@ fn default_bindings() -> Vec<KeyBinding> {
             key: Key::B,
             mods: ctrl_shift,
             action: BindingAction::Named(ToggleSidebarFocus),
+        },
+        KeyBinding {
+            key: Key::Home,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(SidebarTop),
+        },
+        KeyBinding {
+            key: Key::End,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(SidebarBottom),
+        },
+        KeyBinding {
+            key: Key::PageDown,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(SidebarNextProject),
+        },
+        KeyBinding {
+            key: Key::PageUp,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(SidebarPreviousProject),
         },
         KeyBinding { key: Key::G, mods: ctrl_shift, action: BindingAction::Named(FocusGitSidebar) },
         KeyBinding { key: Key::W, mods: ctrl_shift, action: BindingAction::Named(CloseSession) },
@@ -502,6 +542,10 @@ fn parse_action(name: &str) -> BindingAction {
         "AddProject" => BindingAction::Named(AddProject),
         "ToggleSidebarFocus" => BindingAction::Named(ToggleSidebarFocus),
         "CloseSession" => BindingAction::Named(CloseSession),
+        "SidebarTop" => BindingAction::Named(SidebarTop),
+        "SidebarBottom" => BindingAction::Named(SidebarBottom),
+        "SidebarNextProject" => BindingAction::Named(SidebarNextProject),
+        "SidebarPreviousProject" => BindingAction::Named(SidebarPreviousProject),
         "FocusProjectsSidebar" => BindingAction::Named(FocusProjectsSidebar),
         "FocusGitSidebar" => BindingAction::Named(FocusGitSidebar),
         "FocusTerminal" => BindingAction::Named(FocusTerminal),
@@ -805,5 +849,35 @@ mod tests {
             parse_action("CloseSession"),
             BindingAction::Named(NamedAction::CloseSession)
         ));
+    }
+
+    #[test]
+    fn sidebar_nav_actions_have_unmodified_defaults_and_parse() {
+        let b = parse_bindings(vec![]);
+        for (key, expected, name) in [
+            (Key::Home, NamedAction::SidebarTop, "SidebarTop"),
+            (Key::End, NamedAction::SidebarBottom, "SidebarBottom"),
+            (Key::PageDown, NamedAction::SidebarNextProject, "SidebarNextProject"),
+            (Key::PageUp, NamedAction::SidebarPreviousProject, "SidebarPreviousProject"),
+        ] {
+            assert_eq!(named_matches(&b, key, Modifiers::NONE), vec![expected], "{name}");
+            assert!(
+                matches!(parse_action(name), BindingAction::Named(a) if a == expected),
+                "{name} does not parse"
+            );
+        }
+    }
+
+    /// Only the four sidebar cursor actions are focus-scoped: everything
+    /// else (CloseSession included) must keep firing from the terminal.
+    #[test]
+    fn only_sidebar_cursor_actions_are_sidebar_scoped() {
+        use NamedAction::*;
+        for a in [SidebarTop, SidebarBottom, SidebarNextProject, SidebarPreviousProject] {
+            assert!(a.is_sidebar_scoped(), "{a:?}");
+        }
+        for a in [CloseSession, ScrollToTop, ScrollPageUp, ToggleSidebarFocus, Quit] {
+            assert!(!a.is_sidebar_scoped(), "{a:?}");
+        }
     }
 }

--- a/alacritree/src/sidebar_nav.rs
+++ b/alacritree/src/sidebar_nav.rs
@@ -85,6 +85,20 @@ pub fn left_target(rows: &[SidebarRow], cursor: &SidebarRow) -> Option<SidebarRo
     }
 }
 
+/// The nearest project header strictly after `cursor` — the PageDown-style
+/// project jump.  `None` when no header follows or the cursor has vanished
+/// from `rows` (the caller reseats it, as `step` callers do).
+pub fn next_project(rows: &[SidebarRow], cursor: &SidebarRow) -> Option<SidebarRow> {
+    let pos = rows.iter().position(|r| r == cursor)?;
+    rows[pos + 1..].iter().find(|r| matches!(r, SidebarRow::Project(_))).cloned()
+}
+
+/// The nearest project header strictly before `cursor`.
+pub fn previous_project(rows: &[SidebarRow], cursor: &SidebarRow) -> Option<SidebarRow> {
+    let pos = rows.iter().position(|r| r == cursor)?;
+    rows[..pos].iter().rev().find(|r| matches!(r, SidebarRow::Project(_))).cloned()
+}
+
 /// Where the cursor lands when the sidebar gains focus: the active session's
 /// row when it's currently listed in the sidebar, otherwise the current
 /// workspace's row, its project header when that project is collapsed, or
@@ -481,5 +495,57 @@ mod tests {
         // Empty rows always fall back to None.
         assert_eq!(ensure_cursor(&[], Some(&SidebarRow::Home)), None);
         assert_eq!(ensure_cursor(&[], None), None);
+    }
+
+    #[test]
+    fn next_project_jumps_to_the_nearest_header_below() {
+        let projects = vec![project("/a", true, &["/a/wt1"]), project("/b", true, &["/b/wt1"])];
+        let rows = visible_rows(&projects, &no_sessions());
+        assert_eq!(
+            next_project(&rows, &SidebarRow::Home),
+            Some(SidebarRow::Project(PathBuf::from("/a")))
+        );
+        assert_eq!(
+            next_project(&rows, &SidebarRow::Worktree(PathBuf::from("/a/wt1"))),
+            Some(SidebarRow::Project(PathBuf::from("/b")))
+        );
+        // No header below the last project's subtree: stay put (None).
+        assert_eq!(next_project(&rows, &SidebarRow::Worktree(PathBuf::from("/b/wt1"))), None);
+    }
+
+    #[test]
+    fn previous_project_jumps_to_the_nearest_header_above() {
+        let projects = vec![project("/a", true, &["/a/wt1"]), project("/b", true, &["/b/wt1"])];
+        let rows = visible_rows(&projects, &no_sessions());
+        assert_eq!(
+            previous_project(&rows, &SidebarRow::Worktree(PathBuf::from("/b/wt1"))),
+            Some(SidebarRow::Project(PathBuf::from("/b")))
+        );
+        assert_eq!(
+            previous_project(&rows, &SidebarRow::Project(PathBuf::from("/b"))),
+            Some(SidebarRow::Project(PathBuf::from("/a")))
+        );
+        // Nothing above the first header or on Home: None.
+        assert_eq!(previous_project(&rows, &SidebarRow::Project(PathBuf::from("/a"))), None);
+        assert_eq!(previous_project(&rows, &SidebarRow::Home), None);
+    }
+
+    #[test]
+    fn project_jumps_from_session_rows_and_vanished_cursors() {
+        let projects = vec![project("/a", true, &["/a/wt1"]), project("/b", true, &["/b/wt1"])];
+        let sessions = HashMap::from([(Some(PathBuf::from("/a/wt1")), vec![7])]);
+        let rows = visible_rows(&projects, &sessions);
+        assert_eq!(
+            next_project(&rows, &SidebarRow::Session(7)),
+            Some(SidebarRow::Project(PathBuf::from("/b")))
+        );
+        assert_eq!(
+            previous_project(&rows, &SidebarRow::Session(7)),
+            Some(SidebarRow::Project(PathBuf::from("/a")))
+        );
+        // A cursor no longer in the rows has no anchor: None, caller reseats.
+        let gone = SidebarRow::Worktree(PathBuf::from("/gone"));
+        assert_eq!(next_project(&rows, &gone), None);
+        assert_eq!(previous_project(&rows, &gone), None);
     }
 }

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -57,7 +57,7 @@ and your TOML entries are checked first — so your config overrides any default
 | `Shift+Tab`          | Send `CSI Z` (reverse tab — readline/vim)             |
 | `Alt+Shift+Tab`      | Send `ESC` + `CSI Z`                                  |
 | `Ctrl+Shift+B`       | Toggle keyboard focus between terminal and sidebar    |
-| `Ctrl+Shift+W`       | Close the active session in the current workspace     |
+| `Ctrl+Shift+W`       | Close the cursored session (sidebar) or the current shell |
 
 ### Additional defaults on macOS
 
@@ -120,12 +120,13 @@ entry. Names match alacritty's own action names, so existing configs port over.
 - `SelectTab1` … `SelectTab9` — select the Nth session in the current
   workspace. Out-of-range indices are ignored.
 - `SelectLastTab` — select the last session in the current workspace.
-- `CloseSession` — close the active session in the current workspace.
-  Honors the `confirm_session_close` policy (may open a confirmation
-  dialog; `"busy"` prompts only while a process is running). When the
-  workspace's last session closes, `ui.last_session_close` decides what
-  follows: `"respawn"` (default) recycles a shell in place, `"navigate"`
-  moves to the project's main checkout or home.
+- `CloseSession` — close the session under the sidebar cursor when the sidebar
+  is focused on one, otherwise the active session in the current workspace.
+  Honors the `confirm_session_close` policy (may open a confirmation dialog;
+  `"busy"` prompts only while a process is running). When the workspace's
+  last session closes, `ui.last_session_close` decides what follows:
+  `"respawn"` (default) recycles a shell in place, `"navigate"` moves to the
+  project's main checkout or home.
 - `SpawnProfile1` … `SpawnProfile9` — spawn the Nth `[[ui.profiles]]` entry
   in the current workspace. Out-of-range indices show an error toast.
   Example binding:

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -58,6 +58,8 @@ and your TOML entries are checked first — so your config overrides any default
 | `Alt+Shift+Tab`      | Send `ESC` + `CSI Z`                                  |
 | `Ctrl+Shift+B`       | Toggle keyboard focus between terminal and sidebar    |
 | `Ctrl+Shift+W`       | Close the cursored session (sidebar) or the current shell |
+| `Home` / `End`       | Sidebar focused: cursor to the first / last row       |
+| `PageUp` / `PageDown`| Sidebar focused: jump to the previous / next project  |
 
 ### Additional defaults on macOS
 
@@ -127,6 +129,14 @@ entry. Names match alacritty's own action names, so existing configs port over.
   last session closes, `ui.last_session_close` decides what follows:
   `"respawn"` (default) recycles a shell in place, `"navigate"` moves to the
   project's main checkout or home.
+- `SidebarTop` / `SidebarBottom` — move the sidebar cursor to the first / last
+  visible row.
+- `SidebarPreviousProject` / `SidebarNextProject` — jump the sidebar cursor to
+  the nearest project header above / below.
+
+All four sidebar actions act only while the projects sidebar has keyboard
+focus; anywhere else their keys pass through to the terminal untouched, so
+the unmodified defaults don't shadow Home/End/PageUp/PageDown in TUIs.
 - `SpawnProfile1` … `SpawnProfile9` — spawn the Nth `[[ui.profiles]]` entry
   in the current workspace. Out-of-range indices show an error toast.
   Example binding:


### PR DESCRIPTION
## DO NOT MERGE YET

**Stacked on #101** (`feat/searchable-sidebars`) — this branch is based on it, so the diff includes #101's commits until it merges. Review only the last 3 commits. Merge #101 first, then this.

## What

- `CloseSession` (rebindable, default `Ctrl+Shift+W`): closes the session under the sidebar cursor when the projects sidebar is focused on one, otherwise the active session in the current workspace. Honors the `confirm_session_close` policy.
- Four rebindable sidebar-cursor actions with unmodified default keys: `SidebarTop`/`SidebarBottom` (Home/End — first/last row) and `SidebarPreviousProject`/`SidebarNextProject` (PageUp/PageDown — jump between project headers, non-wrapping, respects an active `/` filter).
- The sidebar actions are focus-scoped: with the terminal focused their keys pass through as CSI input instead of being consumed by the binding table, so Home/End/PageUp/PageDown still work in TUIs. Stacked user bindings that mix a sidebar action with a global one on a single trigger are filtered per action.

## Testing

`cargo test -p alacritree` green (313 passed); new unit tests cover the default bindings, config-name parsing, the focus-scope predicate, and the project-jump helpers (extremes, session rows, vanished cursor). Docs updated in `docs/keyboard-shortcuts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)