### PR TITLE
[3] feat(shortcuts): add a searchable shortcuts window on F1

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -22,6 +22,7 @@ use crate::paste;
 use crate::pr_status::PrCache;
 use crate::projects::{Project, Worktree, project_json};
 use crate::session::{Session, SessionId, SessionKind, TermSize};
+use crate::shortcuts_window;
 use crate::sidebar_nav::{self, SidebarRow};
 use crate::state::{self, PersistedProject};
 use crate::terminal_view;
@@ -163,6 +164,12 @@ pub struct AlacritreeApp {
     /// The focus toggle opened a hidden git sidebar; returning focus closes it
     /// again so a keyboard round trip leaves the layout untouched.
     git_sidebar_auto_shown: bool,
+    /// The F1 shortcuts overlay.  Transient: never persisted.
+    shortcuts_window_open: bool,
+    shortcuts_query: String,
+    /// One-shot: give the search box focus on the next window paint (set on
+    /// open and by `/`), mirroring the `*_cursor_moved` one-shots.
+    shortcuts_focus_search: bool,
     sessions: Vec<Session>,
     current_workspace: WorkspaceKey,
     active_session: HashMap<WorkspaceKey, SessionId>,
@@ -439,6 +446,9 @@ impl AlacritreeApp {
             git_rows: Vec::new(),
             git_branch_base: None,
             git_sidebar_auto_shown: false,
+            shortcuts_window_open: false,
+            shortcuts_query: String::new(),
+            shortcuts_focus_search: false,
             sessions: Vec::new(),
             current_workspace: None,
             active_session: HashMap::new(),
@@ -998,7 +1008,8 @@ impl AlacritreeApp {
     /// text input.  Matched events are consumed unless every matched action
     /// is `ReceiveChar` (alacritty's pass-through marker).
     fn handle_shortcuts(&mut self, ctx: &Context) {
-        let sidebar_focused = self.focus == PaneFocus::ProjectsSidebar;
+        let sidebar_focused =
+            self.focus == PaneFocus::ProjectsSidebar && !self.shortcuts_window_open;
         let actions: Vec<BindingAction> = ctx.input_mut(|i| {
             let mut actions = Vec::new();
             i.events.retain(|ev| {
@@ -1613,6 +1624,13 @@ impl AlacritreeApp {
             },
             BindingAction::Named(NamedAction::SidebarPreviousProject) => {
                 self.sidebar_cursor_project_jump(-1)
+            },
+            BindingAction::Named(NamedAction::ShowShortcuts) => {
+                self.shortcuts_window_open = !self.shortcuts_window_open;
+                if self.shortcuts_window_open {
+                    self.shortcuts_query.clear();
+                    self.shortcuts_focus_search = true;
+                }
             },
             BindingAction::Named(NamedAction::FocusProjectsSidebar) => {
                 if self.focus != PaneFocus::ProjectsSidebar {
@@ -4227,6 +4245,119 @@ impl AlacritreeApp {
         }
     }
 
+    /// The F1 shortcuts overlay: every effective app binding plus the
+    /// hardcoded sidebar keys, filtered live by the search box.  An
+    /// informational overlay, not a modal — bindings keep dispatching, which
+    /// is also how the ShowShortcuts key toggles it closed.
+    fn show_shortcuts_window(&mut self, ctx: &Context) {
+        let theme = self.theme;
+        let s = theme.ui_scale;
+
+        // Keys pressed mid-composition drive the IME's candidate window, not this
+        // window, so leave Esc and `/` in the event queue for it to see.
+        if self.ime.preedit().is_none() {
+            // Esc narrows before it closes: drain it ahead of the TextEdit,
+            // which would otherwise only drop focus.
+            if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
+                if self.shortcuts_query.is_empty() {
+                    self.shortcuts_window_open = false;
+                    return;
+                }
+                self.shortcuts_query.clear();
+            }
+            // `/` re-focuses the search box instead of typing into it.
+            let slash = ctx.input_mut(|i| {
+                let mut hit = false;
+                i.events.retain(|ev| {
+                    let is_slash = matches!(ev, egui::Event::Text(t) if t == "/");
+                    hit |= is_slash;
+                    !is_slash
+                });
+                hit
+            });
+            if slash {
+                self.shortcuts_focus_search = true;
+            }
+        }
+
+        egui::Window::new(RichText::new("Keyboard shortcuts").color(theme.text).strong())
+            .id(egui::Id::new("alacritree_shortcuts_window"))
+            .frame(modal_frame(&theme))
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .collapsible(false)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.set_width(480.0 * s);
+                ui.spacing_mut().item_spacing.y = 4.0 * s;
+
+                let search = ui.add(
+                    egui::TextEdit::singleline(&mut self.shortcuts_query)
+                        .hint_text("type to search — / refocuses, Esc clears")
+                        .desired_width(f32::INFINITY),
+                );
+                if std::mem::take(&mut self.shortcuts_focus_search) {
+                    search.request_focus();
+                }
+
+                let query = self.shortcuts_query.clone();
+                let app_rows: Vec<_> = shortcuts_window::named_rows(&self.config.bindings)
+                    .into_iter()
+                    .filter(|r| shortcuts_window::row_matches(&query, r))
+                    .collect();
+                let nav_rows: Vec<_> = shortcuts_window::sidebar_nav_rows()
+                    .into_iter()
+                    .filter(|r| shortcuts_window::row_matches(&query, r))
+                    .collect();
+
+                egui::ScrollArea::vertical().max_height(420.0 * s).show(ui, |ui| {
+                    if app_rows.is_empty() && nav_rows.is_empty() {
+                        ui.label(RichText::new("no matches").color(theme.text_dim));
+                        return;
+                    }
+                    if !app_rows.is_empty() {
+                        ui.label(RichText::new("App shortcuts").color(theme.text_muted).small());
+                        egui::Grid::new("shortcuts_app_grid").num_columns(2).striped(true).show(
+                            ui,
+                            |ui| {
+                                for row in &app_rows {
+                                    ui.label(
+                                        RichText::new(&row.keys).color(theme.accent).monospace(),
+                                    );
+                                    ui.vertical(|ui| {
+                                        ui.label(RichText::new(&row.description).color(theme.text));
+                                        ui.label(
+                                            RichText::new(&row.name).color(theme.text_dim).small(),
+                                        );
+                                    });
+                                    ui.end_row();
+                                }
+                            },
+                        );
+                    }
+                    if !nav_rows.is_empty() {
+                        ui.add_space(6.0 * s);
+                        ui.label(
+                            RichText::new("Sidebar navigation (while a panel has focus)")
+                                .color(theme.text_muted)
+                                .small(),
+                        );
+                        egui::Grid::new("shortcuts_nav_grid").num_columns(2).striped(true).show(
+                            ui,
+                            |ui| {
+                                for row in &nav_rows {
+                                    ui.label(
+                                        RichText::new(&row.keys).color(theme.accent).monospace(),
+                                    );
+                                    ui.label(RichText::new(&row.description).color(theme.text));
+                                    ui.end_row();
+                                }
+                            },
+                        );
+                    }
+                });
+            });
+    }
+
     fn run_pending_delete(&mut self, ctx: &Context) {
         let Some(req) = self.pending_delete.take() else {
             return;
@@ -4851,10 +4982,14 @@ impl eframe::App for AlacritreeApp {
         // not the app — alacritty's key_input returns early the same way,
         // above binding dispatch.
         if !modal_open && self.ime.preedit().is_none() {
-            match self.focus {
-                PaneFocus::ProjectsSidebar => self.handle_sidebar_nav(ctx),
-                PaneFocus::GitSidebar => self.handle_git_sidebar_nav(ctx),
-                PaneFocus::Terminal => {},
+            // While the shortcuts overlay is open, typed text belongs to its
+            // search box — the panel filters must not intercept it.
+            if !self.shortcuts_window_open {
+                match self.focus {
+                    PaneFocus::ProjectsSidebar => self.handle_sidebar_nav(ctx),
+                    PaneFocus::GitSidebar => self.handle_git_sidebar_nav(ctx),
+                    PaneFocus::Terminal => {},
+                }
             }
             self.handle_shortcuts(ctx);
         }
@@ -4917,7 +5052,7 @@ impl eframe::App for AlacritreeApp {
                     ui,
                     session,
                     &self.config,
-                    !modal_open && self.focus == PaneFocus::Terminal,
+                    !modal_open && !self.shortcuts_window_open && self.focus == PaneFocus::Terminal,
                     &mut self.builtin_glyphs,
                     ime,
                     &mut self.color_glyphs,
@@ -4952,6 +5087,9 @@ impl eframe::App for AlacritreeApp {
         }
         if self.quit_dialog_open {
             self.show_quit_dialog(ctx);
+        }
+        if self.shortcuts_window_open && !modal_open {
+            self.show_shortcuts_window(ctx);
         }
 
         self.reap_exited_sessions(ctx);

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -4301,7 +4301,7 @@ impl AlacritreeApp {
             }
         }
 
-        egui::Window::new(RichText::new("Keyboard shortcuts").color(theme.text).strong())
+        let win = egui::Window::new(RichText::new("Keyboard shortcuts").color(theme.text).strong())
             .id(egui::Id::new("alacritree_shortcuts_window"))
             .frame(modal_frame(&theme))
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
@@ -4392,6 +4392,12 @@ impl AlacritreeApp {
                     }
                 });
             });
+        // An informational overlay dismisses like a context menu: a click
+        // that lands outside it closes it (the click still reaches whatever
+        // it landed on, since the overlay is not modal).
+        if win.is_some_and(|w| w.response.clicked_elsewhere()) {
+            self.shortcuts_window_open = false;
+        }
     }
 
     fn run_pending_delete(&mut self, ctx: &Context) {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -4330,7 +4330,12 @@ impl AlacritreeApp {
                     .filter(|r| shortcuts_window::row_matches(&query, r))
                     .collect();
 
-                egui::ScrollArea::vertical().max_height(list_height).show(ui, |ui| {
+                // auto_shrink would size the scroll area to the grids'
+                // content, leaving a dead margin between the rows and the
+                // window edge; fill the window's width instead.
+                let scroll =
+                    egui::ScrollArea::vertical().max_height(list_height).auto_shrink([false, true]);
+                scroll.show(ui, |ui| {
                     if scroll_delta != 0.0 {
                         ui.scroll_with_delta(egui::vec2(0.0, scroll_delta));
                     }
@@ -4348,6 +4353,10 @@ impl AlacritreeApp {
                                         RichText::new(&row.keys).color(theme.accent).monospace(),
                                     );
                                     ui.vertical(|ui| {
+                                        // Stretch the last column to the
+                                        // window edge so the stripes span the
+                                        // whole row, not just the text.
+                                        ui.set_min_width(ui.available_width());
                                         ui.label(RichText::new(&row.description).color(theme.text));
                                         ui.label(
                                             RichText::new(&row.name).color(theme.text_dim).small(),
@@ -4372,7 +4381,10 @@ impl AlacritreeApp {
                                     ui.label(
                                         RichText::new(&row.keys).color(theme.accent).monospace(),
                                     );
-                                    ui.label(RichText::new(&row.description).color(theme.text));
+                                    ui.vertical(|ui| {
+                                        ui.set_min_width(ui.available_width());
+                                        ui.label(RichText::new(&row.description).color(theme.text));
+                                    });
                                     ui.end_row();
                                 }
                             },

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -4252,10 +4252,31 @@ impl AlacritreeApp {
     fn show_shortcuts_window(&mut self, ctx: &Context) {
         let theme = self.theme;
         let s = theme.ui_scale;
+        let list_height = 420.0 * s;
+        let mut scroll_delta = 0.0;
 
         // Keys pressed mid-composition drive the IME's candidate window, not this
         // window, so leave Esc and `/` in the event queue for it to see.
         if self.ime.preedit().is_none() {
+            // The search box keeps keyboard focus, so scrolling keys are
+            // consumed here before the TextEdit swallows them; the wheel
+            // shouldn't be the only way to reach rows below the fold.
+            scroll_delta = ctx.input_mut(|i| {
+                let mut delta = 0.0;
+                if i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp) {
+                    delta += 40.0 * s;
+                }
+                if i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown) {
+                    delta -= 40.0 * s;
+                }
+                if i.consume_key(egui::Modifiers::NONE, egui::Key::PageUp) {
+                    delta += list_height;
+                }
+                if i.consume_key(egui::Modifiers::NONE, egui::Key::PageDown) {
+                    delta -= list_height;
+                }
+                delta
+            });
             // Esc narrows before it closes: drain it ahead of the TextEdit,
             // which would otherwise only drop focus.
             if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
@@ -4309,7 +4330,10 @@ impl AlacritreeApp {
                     .filter(|r| shortcuts_window::row_matches(&query, r))
                     .collect();
 
-                egui::ScrollArea::vertical().max_height(420.0 * s).show(ui, |ui| {
+                egui::ScrollArea::vertical().max_height(list_height).show(ui, |ui| {
+                    if scroll_delta != 0.0 {
+                        ui.scroll_with_delta(egui::vec2(0.0, scroll_delta));
+                    }
                     if app_rows.is_empty() && nav_rows.is_empty() {
                         ui.label(RichText::new("no matches").color(theme.text_dim));
                         return;

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -84,6 +84,65 @@ impl NamedAction {
                 | Self::SidebarPreviousProject
         )
     }
+
+    /// The name `parse_action` accepts for this action — what a user writes
+    /// in `[[keyboard.bindings]]`, and the label the shortcuts window shows.
+    pub fn config_name(&self) -> String {
+        match self {
+            Self::SelectTab(n) => format!("SelectTab{n}"),
+            Self::SpawnProfile(n) => format!("SpawnProfile{n}"),
+            other => format!("{other:?}"),
+        }
+    }
+
+    /// One-line human description for the shortcuts window.
+    pub fn description(&self) -> String {
+        match self {
+            Self::Paste => "Paste from the clipboard".into(),
+            Self::PasteSelection => "Paste from the primary (X11) selection".into(),
+            Self::Copy => "Copy the selection to the clipboard".into(),
+            Self::CopySelection => "Copy the selection to the primary selection".into(),
+            Self::ScrollPageUp => "Scroll the scrollback one page up".into(),
+            Self::ScrollPageDown => "Scroll the scrollback one page down".into(),
+            Self::ScrollHalfPageUp => "Scroll the scrollback half a page up".into(),
+            Self::ScrollHalfPageDown => "Scroll the scrollback half a page down".into(),
+            Self::ScrollLineUp => "Scroll the scrollback one line up".into(),
+            Self::ScrollLineDown => "Scroll the scrollback one line down".into(),
+            Self::ScrollToTop => "Scroll to the top of the scrollback".into(),
+            Self::ScrollToBottom => "Scroll to the bottom of the scrollback".into(),
+            Self::ClearHistory => "Clear the scrollback buffer".into(),
+            Self::SpawnNewInstance => "Open a new shell session in the current workspace".into(),
+            Self::IncreaseFontSize => "Increase the font size".into(),
+            Self::DecreaseFontSize => "Decrease the font size".into(),
+            Self::ResetFontSize => "Reset the font size".into(),
+            Self::ToggleFullscreen => "Toggle fullscreen".into(),
+            Self::ToggleMaximized => "Toggle the maximized window state".into(),
+            Self::Minimize => "Minimize the window".into(),
+            Self::SelectNextTab => "Cycle to the next session in the workspace".into(),
+            Self::SelectPreviousTab => "Cycle to the previous session in the workspace".into(),
+            Self::SelectTab(n) => format!("Select session {n} in the current workspace"),
+            Self::SelectLastTab => "Select the last session in the current workspace".into(),
+            Self::ToggleLeftSidebar => "Toggle the projects sidebar".into(),
+            Self::ToggleRightSidebar => "Toggle the git sidebar".into(),
+            Self::SelectNextWorkspace => "Switch to the next workspace".into(),
+            Self::SelectPreviousWorkspace => "Switch to the previous workspace".into(),
+            Self::AddProject => "Add a project to the sidebar".into(),
+            Self::ToggleSidebarFocus => "Toggle keyboard focus between terminal and sidebar".into(),
+            Self::CloseSession => "Close the cursored or active session".into(),
+            Self::SidebarTop => "Move the sidebar cursor to the first row".into(),
+            Self::SidebarBottom => "Move the sidebar cursor to the last row".into(),
+            Self::SidebarNextProject => "Jump the sidebar cursor to the next project".into(),
+            Self::SidebarPreviousProject => {
+                "Jump the sidebar cursor to the previous project".into()
+            },
+            Self::FocusProjectsSidebar => "Focus the projects sidebar".into(),
+            Self::FocusGitSidebar => "Focus the git sidebar".into(),
+            Self::FocusTerminal => "Focus the terminal".into(),
+            Self::SpawnProfile(n) => format!("Open a session with shell profile {n}"),
+            Self::Quit => "Open the quit confirmation dialog".into(),
+            Self::NoOp | Self::ReceiveChar => String::new(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -56,6 +56,7 @@ pub enum NamedAction {
     SidebarBottom,
     SidebarNextProject,
     SidebarPreviousProject,
+    ShowShortcuts,
     FocusProjectsSidebar,
     FocusGitSidebar,
     FocusTerminal,
@@ -140,6 +141,7 @@ impl NamedAction {
             Self::FocusTerminal => "Focus the terminal".into(),
             Self::SpawnProfile(n) => format!("Open a session with shell profile {n}"),
             Self::Quit => "Open the quit confirmation dialog".into(),
+            Self::ShowShortcuts => "Show this shortcuts window".into(),
             Self::NoOp | Self::ReceiveChar => String::new(),
         }
     }
@@ -293,6 +295,11 @@ fn default_bindings() -> Vec<KeyBinding> {
             key: Key::PageUp,
             mods: Modifiers::NONE,
             action: BindingAction::Named(SidebarPreviousProject),
+        },
+        KeyBinding {
+            key: Key::F1,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(ShowShortcuts),
         },
         KeyBinding { key: Key::G, mods: ctrl_shift, action: BindingAction::Named(FocusGitSidebar) },
         KeyBinding { key: Key::W, mods: ctrl_shift, action: BindingAction::Named(CloseSession) },
@@ -605,6 +612,7 @@ fn parse_action(name: &str) -> BindingAction {
         "SidebarBottom" => BindingAction::Named(SidebarBottom),
         "SidebarNextProject" => BindingAction::Named(SidebarNextProject),
         "SidebarPreviousProject" => BindingAction::Named(SidebarPreviousProject),
+        "ShowShortcuts" => BindingAction::Named(ShowShortcuts),
         "FocusProjectsSidebar" => BindingAction::Named(FocusProjectsSidebar),
         "FocusGitSidebar" => BindingAction::Named(FocusGitSidebar),
         "FocusTerminal" => BindingAction::Named(FocusTerminal),
@@ -938,5 +946,15 @@ mod tests {
         for a in [CloseSession, ScrollToTop, ScrollPageUp, ToggleSidebarFocus, Quit] {
             assert!(!a.is_sidebar_scoped(), "{a:?}");
         }
+    }
+
+    #[test]
+    fn show_shortcuts_is_a_default_f1_binding_and_parses() {
+        let b = parse_bindings(vec![]);
+        assert_eq!(named_matches(&b, Key::F1, Modifiers::NONE), vec![NamedAction::ShowShortcuts]);
+        assert!(matches!(
+            parse_action("ShowShortcuts"),
+            BindingAction::Named(NamedAction::ShowShortcuts)
+        ));
     }
 }

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -24,6 +24,7 @@ mod paste;
 mod pr_status;
 mod projects;
 mod session;
+mod shortcuts_window;
 mod sidebar_nav;
 mod stale_exe;
 mod state;

--- a/alacritree/src/shortcuts_window.rs
+++ b/alacritree/src/shortcuts_window.rs
@@ -1,0 +1,167 @@
+//! Data model for the searchable shortcuts window: the effective binding
+//! rows, the static sidebar-navigation entries, and the fuzzy matcher the
+//! search box filters them with.  Pure — painting lives in `app.rs`.
+
+use crate::bindings::{BindingAction, KeyBinding, NamedAction};
+
+/// One line in the shortcuts window.
+pub struct ShortcutRow {
+    pub keys: String,
+    pub name: String,
+    pub description: String,
+}
+
+/// Case-insensitive subsequence match — `csw` finds `Ctrl+Shift+W`.  An
+/// empty query matches everything, so the unfiltered window needs no
+/// special case.
+pub fn fuzzy_match(query: &str, haystack: &str) -> bool {
+    let mut hay = haystack.chars().flat_map(char::to_lowercase);
+    query.chars().flat_map(char::to_lowercase).all(|q| hay.any(|h| h == q))
+}
+
+// Matched per field rather than on a joined "keys name description" string:
+// concatenating would let query letters bleed across field boundaries (e.g.
+// "font" spuriously matching "f" in a Shift key plus "o"/"n"/"t" scattered
+// across the name and description of an unrelated row).
+pub fn row_matches(query: &str, row: &ShortcutRow) -> bool {
+    fuzzy_match(query, &row.keys)
+        || fuzzy_match(query, &row.name)
+        || fuzzy_match(query, &row.description)
+}
+
+/// The effective app-shortcut rows: `parse_bindings` already replaced
+/// shadowed defaults with the user's same-trigger bindings, so every Named
+/// entry here genuinely fires.  `NoOp`/`ReceiveChar` unbind rather than
+/// bind and `Chars`/`Unsupported` aren't app shortcuts — no rows for them.
+pub fn named_rows(bindings: &[KeyBinding]) -> Vec<ShortcutRow> {
+    bindings
+        .iter()
+        .filter_map(|b| {
+            let BindingAction::Named(action) = &b.action else {
+                return None;
+            };
+            if matches!(action, NamedAction::NoOp | NamedAction::ReceiveChar) {
+                return None;
+            }
+            Some(ShortcutRow {
+                keys: format_shortcut(b.key, b.mods),
+                name: action.config_name(),
+                description: action.description(),
+            })
+        })
+        .collect()
+}
+
+fn format_shortcut(key: egui::Key, mods: egui::Modifiers) -> String {
+    egui::KeyboardShortcut::new(mods, key)
+        .format(&egui::ModifierNames::NAMES, cfg!(target_os = "macos"))
+}
+
+fn nav_row(keys: &str, description: &str) -> ShortcutRow {
+    ShortcutRow { keys: keys.into(), name: String::new(), description: description.into() }
+}
+
+/// The hardcoded sidebar keys (`handle_sidebar_nav` / `PanelFilter`), which
+/// the binding table never sees.  Kept in sync by hand; they change rarely.
+pub fn sidebar_nav_rows() -> Vec<ShortcutRow> {
+    vec![
+        nav_row("Up / Down", "Move the cursor"),
+        nav_row("Right", "Expand a project, or open the cursored session"),
+        nav_row("Left", "Collapse a project, or jump to the parent row"),
+        nav_row("Enter", "Activate the cursored row"),
+        nav_row("Escape", "Clear the filter, or return focus to the terminal"),
+        nav_row("/", "Start fuzzy-filtering the panel's rows"),
+        nav_row("s", "Projects panel: show only workspaces with open sessions"),
+        nav_row("a", "Projects panel: show only workspaces needing attention"),
+        nav_row("m / d / u", "Git panel: show only modified / deleted / untracked files"),
+        nav_row("Backspace", "Delete the last filter character (while filtering)"),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bindings::{NamedAction, RawBinding, parse_bindings};
+
+    fn raw_action(key: &str, mods: Option<&str>, action: &str) -> RawBinding {
+        RawBinding {
+            key: key.into(),
+            mods: mods.map(Into::into),
+            mode: None,
+            chars: None,
+            action: Some(action.into()),
+            command: None,
+        }
+    }
+
+    #[test]
+    fn fuzzy_match_is_a_case_insensitive_subsequence() {
+        assert!(fuzzy_match("", "anything"));
+        assert!(fuzzy_match("csw", "Ctrl+Shift+W CloseSession"));
+        assert!(fuzzy_match("CLOSE", "close the cursored session"));
+        // Subsequence, not substring: letters may be spread out…
+        assert!(fuzzy_match("cse", "CloseSession"));
+        // …but order matters and letters aren't reused.
+        assert!(!fuzzy_match("wsc", "Ctrl+Shift+W"));
+        assert!(!fuzzy_match("zz", "\u{2318}z"));
+    }
+
+    #[test]
+    fn named_rows_lists_defaults_with_descriptions() {
+        let rows = named_rows(&parse_bindings(vec![]));
+        let close =
+            rows.iter().find(|r| r.name == "CloseSession").expect("CloseSession missing from rows");
+        assert_eq!(close.keys, "Ctrl+Shift+W");
+        assert!(!close.description.is_empty());
+        // Chars defaults (Shift+Tab -> CSI Z) are terminal plumbing, not
+        // app shortcuts: no row.
+        assert!(!rows.iter().any(|r| r.keys == "Shift+Tab"));
+    }
+
+    #[test]
+    fn named_rows_honors_user_overrides_and_unbinds() {
+        let rows = named_rows(&parse_bindings(vec![
+            raw_action("W", Some("Control|Shift"), "Quit"),
+            raw_action("B", Some("Control"), "ReceiveChar"),
+        ]));
+        // The rebound trigger shows the user's action only.
+        let w: Vec<_> = rows.iter().filter(|r| r.keys == "Ctrl+Shift+W").collect();
+        assert_eq!(w.len(), 1);
+        assert_eq!(w[0].name, "Quit");
+        // A key freed with ReceiveChar disappears entirely.
+        assert!(!rows.iter().any(|r| r.keys == "Ctrl+B"));
+    }
+
+    #[test]
+    fn every_named_action_row_has_a_nonempty_description() {
+        for row in named_rows(&parse_bindings(vec![])) {
+            assert!(!row.description.is_empty(), "{} has no description", row.name);
+        }
+        // Parametrized actions too, which no default binding covers.
+        assert!(!NamedAction::SelectTab(3).description().is_empty());
+        assert!(!NamedAction::SpawnProfile(2).description().is_empty());
+        assert_eq!(NamedAction::SelectTab(3).config_name(), "SelectTab3");
+    }
+
+    #[test]
+    fn sidebar_nav_rows_cover_the_hardcoded_keys() {
+        let rows = sidebar_nav_rows();
+        for key in ["Up / Down", "Enter", "Escape", "/"] {
+            assert!(rows.iter().any(|r| r.keys == key), "{key} missing");
+        }
+        assert!(rows.iter().all(|r| !r.description.is_empty()));
+    }
+
+    #[test]
+    fn row_matches_searches_keys_name_and_description() {
+        let row = ShortcutRow {
+            keys: "Ctrl+Shift+W".into(),
+            name: "CloseSession".into(),
+            description: "Close the cursored or active session".into(),
+        };
+        assert!(row_matches("ctrl+shift", &row));
+        assert!(row_matches("closesess", &row));
+        assert!(row_matches("cursored", &row));
+        assert!(!row_matches("font", &row));
+    }
+}

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -60,6 +60,7 @@ and your TOML entries are checked first — so your config overrides any default
 | `Ctrl+Shift+W`       | Close the cursored session (sidebar) or the current shell |
 | `Home` / `End`       | Sidebar focused: cursor to the first / last row       |
 | `PageUp` / `PageDown`| Sidebar focused: jump to the previous / next project  |
+| `F1`                 | Toggle the searchable shortcuts window                |
 
 ### Additional defaults on macOS
 
@@ -137,6 +138,10 @@ entry. Names match alacritty's own action names, so existing configs port over.
 All four sidebar actions act only while the projects sidebar has keyboard
 focus; anywhere else their keys pass through to the terminal untouched, so
 the unmodified defaults don't shadow Home/End/PageUp/PageDown in TUIs.
+- `ShowShortcuts` — toggle a searchable window listing every effective
+  binding. Type to fuzzy-filter, `/` refocuses the search box, `Escape`
+  clears the query and then closes. The default `F1` shadows `F1` for
+  terminal apps; rebind or free it with `ReceiveChar` if you need it there.
 - `SpawnProfile1` … `SpawnProfile9` — spawn the Nth `[[ui.profiles]]` entry
   in the current workspace. Out-of-range indices show an error toast.
   Example binding:

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -140,8 +140,10 @@ focus; anywhere else their keys pass through to the terminal untouched, so
 the unmodified defaults don't shadow Home/End/PageUp/PageDown in TUIs.
 - `ShowShortcuts` — toggle a searchable window listing every effective
   binding. Type to fuzzy-filter, `/` refocuses the search box, `Escape`
-  clears the query and then closes. The default `F1` shadows `F1` for
-  terminal apps; rebind or free it with `ReceiveChar` if you need it there.
+  clears the query and then closes, and `Up`/`Down`/`PageUp`/`PageDown`
+  scroll the list without leaving the search box. The default `F1` shadows
+  `F1` for terminal apps; rebind or free it with `ReceiveChar` if you need
+  it there.
 - `SpawnProfile1` … `SpawnProfile9` — spawn the Nth `[[ui.profiles]]` entry
   in the current workspace. Out-of-range indices show an error toast.
   Example binding:

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -141,9 +141,9 @@ the unmodified defaults don't shadow Home/End/PageUp/PageDown in TUIs.
 - `ShowShortcuts` — toggle a searchable window listing every effective
   binding. Type to fuzzy-filter, `/` refocuses the search box, `Escape`
   clears the query and then closes, and `Up`/`Down`/`PageUp`/`PageDown`
-  scroll the list without leaving the search box. The default `F1` shadows
-  `F1` for terminal apps; rebind or free it with `ReceiveChar` if you need
-  it there.
+  scroll the list without leaving the search box. Clicking outside the
+  window closes it. The default `F1` shadows `F1` for terminal apps;
+  rebind or free it with `ReceiveChar` if you need it there.
 - `SpawnProfile1` … `SpawnProfile9` — spawn the Nth `[[ui.profiles]]` entry
   in the current workspace. Out-of-range indices show an error toast.
   Example binding:


### PR DESCRIPTION
## What

- `ShowShortcuts` (rebindable, default `F1`) toggles a centered overlay listing every *effective* app binding — user overrides shadow defaults, `ReceiveChar`/`NoOp` unbinds drop out — with a one-line description per action, plus the hardcoded sidebar-navigation keys.
- Typing fuzzy-filters live (case-insensitive subsequence, e.g. `csw` finds `Ctrl+Shift+W`); `/` refocuses the search box; `Escape` clears the query, then closes; a click outside the window also closes it.
- `Up`/`Down`/`PageUp`/`PageDown` scroll the list without leaving the search box, so browsing doesn't depend on search or the mouse wheel; rows span the full window width.
- The window is an overlay, not a modal: binding dispatch keeps running (that's how F1 toggles it closed), but while open the panel filters and terminal input are muted so typed text reaches only the search box, and it hides under real modals.
- New pure `shortcuts_window` module (row model + matcher); painting stays in `app.rs`.

Known trade-off: the default `F1` shadows F1 for terminal TUIs. It's rebindable, and `ReceiveChar` frees the key entirely (documented).

## Testing

`cargo test -p alacritree` green (338 passed); unit tests cover the fuzzy matcher semantics, effective-binding rows (defaults, overrides, unbinds), description coverage for every action, and the static nav rows. Docs updated in `docs/keyboard-shortcuts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
