### PR TITLE
[1] feat: close the last session without respawn

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use crate::bindings::{BindingAction, NamedAction};
 use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
-use crate::config::Config;
+use crate::config::{Config, LastSessionClose};
 use crate::doppler;
 use crate::git_nav::{self, GitSection, SectionCount};
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, GitStatus, StatusCache};
@@ -760,12 +760,22 @@ impl AlacritreeApp {
         }
 
         // Closing the on-screen workspace's last session must not strand the
-        // view on an empty pane, and respawning in place would make the last
-        // session unclosable — fall back to the project main, then home.
+        // view on an empty pane. What happens instead is policy: `respawn`
+        // recycles a shell in place (the last session is by design
+        // unclosable), `navigate` falls back to the project main, then home.
         let remaining: Vec<(WorkspaceKey, SessionId)> =
             self.sessions.iter().map(|s| (s.working_directory.clone(), s.id)).collect();
         let main = workspace.as_deref().and_then(|p| project_main_for(&self.projects, p));
-        match close_fallback(&workspace, &self.current_workspace, &remaining, main) {
+        let verdict = close_fallback(&workspace, &self.current_workspace, &remaining, main);
+        if verdict != CloseFallback::Stay
+            && self.config.ui.last_session_close == LastSessionClose::Respawn
+        {
+            if let Err(e) = self.spawn_session(ctx, workspace) {
+                self.last_error = Some(format!("failed to spawn shell: {e}"));
+            }
+            return;
+        }
+        match verdict {
             CloseFallback::Stay => {},
             CloseFallback::Activate(main) => {
                 // The fallback verified a session exists there, so this

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2891,6 +2891,7 @@ fn modal_button(
     })
     .inner
     .on_hover_cursor(egui::CursorIcon::PointingHand)
+}
 
 /// Section header count: `visible of total` while a filter narrows the panel,
 /// the plain total otherwise.

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -718,10 +718,8 @@ impl AlacritreeApp {
         if self.active_session_index().is_some() {
             return;
         }
-        let ws_idx = self.workspace_session_indices(&self.current_workspace);
-        if let Some(&idx) = ws_idx.first() {
-            let id = self.sessions[idx].id;
-            self.active_session.insert(self.current_workspace.clone(), id);
+        self.adopt_active_session();
+        if self.active_session_index().is_some() {
             return;
         }
         if let Err(e) = self.spawn_session(ctx, self.current_workspace.clone()) {
@@ -729,7 +727,19 @@ impl AlacritreeApp {
         }
     }
 
-    fn close_session(&mut self, id: SessionId) {
+    /// Re-attach to an existing session when the active id went stale
+    /// (closed or reaped this frame). Never spawns: an emptied on-screen
+    /// workspace either navigated away in `close_session` or shows the
+    /// "no session" placeholder.
+    fn adopt_active_session(&mut self) {
+        let ws_idx = self.workspace_session_indices(&self.current_workspace);
+        if let Some(&idx) = ws_idx.first() {
+            let id = self.sessions[idx].id;
+            self.active_session.insert(self.current_workspace.clone(), id);
+        }
+    }
+
+    fn close_session(&mut self, ctx: &Context, id: SessionId) {
         let Some(idx) = self.sessions.iter().position(|s| s.id == id) else {
             return;
         };
@@ -741,23 +751,40 @@ impl AlacritreeApp {
                 self.sessions.iter().find(|s| s.working_directory == workspace).map(|s| s.id);
             match fallback {
                 Some(new_id) => {
-                    self.active_session.insert(workspace, new_id);
+                    self.active_session.insert(workspace.clone(), new_id);
                 },
                 None => {
                     self.active_session.remove(&workspace);
                 },
             }
         }
+
+        // Closing the on-screen workspace's last session must not strand the
+        // view on an empty pane, and respawning in place would make the last
+        // session unclosable — fall back to the project main, then home.
+        let remaining: Vec<(WorkspaceKey, SessionId)> =
+            self.sessions.iter().map(|s| (s.working_directory.clone(), s.id)).collect();
+        let main = workspace.as_deref().and_then(|p| project_main_for(&self.projects, p));
+        match close_fallback(&workspace, &self.current_workspace, &remaining, main) {
+            CloseFallback::Stay => {},
+            CloseFallback::Activate(main) => {
+                // The fallback verified a session exists there, so this
+                // adopts rather than spawns.
+                self.current_workspace = Some(main);
+                self.ensure_active_session(ctx);
+            },
+            CloseFallback::Home => self.activate_home(ctx),
+        }
     }
 
-    fn request_close_session(&mut self, id: SessionId) {
+    fn request_close_session(&mut self, ctx: &Context, id: SessionId) {
         let Some(session) = self.sessions.iter().find(|s| s.id == id) else {
             return;
         };
         if self.config.ui.confirm_session_close.requires_prompt(session.is_busy()) {
             self.pending_session_close = Some(id);
         } else {
-            self.close_session(id);
+            self.close_session(ctx, id);
         }
     }
 
@@ -1507,7 +1534,7 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::CloseSession) => {
                 if let Some(idx) = self.active_session_index() {
                     let id = self.sessions[idx].id;
-                    self.request_close_session(id);
+                    self.request_close_session(ctx, id);
                 }
             },
             BindingAction::Named(NamedAction::FocusProjectsSidebar) => {
@@ -2231,13 +2258,13 @@ impl AlacritreeApp {
         }
         if let Some((ws, id)) = activate_session_request.take() {
             // A stale id (session reaped this frame) self-heals next frame:
-            // active_session_index() misses and ensure_active_session picks
-            // an existing shell or spawns one.
+            // active_session_index() misses and adopt_active_session picks
+            // an existing shell, or the empty-workspace placeholder shows.
             self.current_workspace = ws.clone();
             self.active_session.insert(ws, id);
         }
         if let Some(id) = close_session_request.take() {
-            self.request_close_session(id);
+            self.request_close_session(ctx, id);
         }
         if let Some(ws) = spawn_shell_request.take() {
             // Spawning activates the workspace and the new session, matching
@@ -3438,6 +3465,48 @@ fn sidebar_session_ids(pairs: &[(WorkspaceKey, SessionId)], ws: &WorkspaceKey) -
     if ids.len() < 2 { Vec::new() } else { ids }
 }
 
+/// Where the view goes after a session's removal.
+#[derive(Debug, PartialEq)]
+enum CloseFallback {
+    /// Removal didn't empty the on-screen workspace — no navigation.
+    Stay,
+    /// Switch to the project's main checkout, which still has a session.
+    Activate(PathBuf),
+    /// Switch to home; `activate_home` spawns a shell there if none exists.
+    Home,
+}
+
+/// Post-close navigation for the workspace that just lost a session.
+/// `remaining` is the session list after removal; `main_checkout` is the
+/// removed workspace's project main (None when the workspace *is* the main,
+/// is home, or belongs to no known project). Pure over (workspace, id)
+/// pairs for the same reason as `sidebar_session_ids`.
+fn close_fallback(
+    removed_ws: &WorkspaceKey,
+    current_ws: &WorkspaceKey,
+    remaining: &[(WorkspaceKey, SessionId)],
+    main_checkout: Option<PathBuf>,
+) -> CloseFallback {
+    if removed_ws != current_ws || remaining.iter().any(|(w, _)| w == removed_ws) {
+        return CloseFallback::Stay;
+    }
+    match main_checkout {
+        Some(main) if remaining.iter().any(|(w, _)| w.as_deref() == Some(main.as_path())) => {
+            CloseFallback::Activate(main)
+        },
+        _ => CloseFallback::Home,
+    }
+}
+
+/// The owning project's main checkout for `ws`, or None when `ws` already
+/// is the main (including non-git roots, whose single pseudo-worktree is
+/// its own main) or belongs to no known project.
+fn project_main_for(projects: &[Project], ws: &Path) -> Option<PathBuf> {
+    let project = projects.iter().find(|p| p.worktrees.iter().any(|w| w.path == ws))?;
+    let main = project.worktrees.iter().find(|w| w.is_main)?;
+    if main.path == ws { None } else { Some(main.path.clone()) }
+}
+
 /// Agent glyphs usually come from the title's own leading char
 /// (`Session::agent_glyph`), and the session row paints that glyph as its
 /// status icon right next to the title — showing it in both places doubles
@@ -3692,11 +3761,11 @@ fn session_row(
 }
 
 impl AlacritreeApp {
-    fn reap_exited_sessions(&mut self) {
+    fn reap_exited_sessions(&mut self, ctx: &Context) {
         let exited_ids: Vec<SessionId> =
             self.sessions.iter().filter(|s| s.is_exited()).map(|s| s.id).collect();
         for id in exited_ids {
-            self.close_session(id);
+            self.close_session(ctx, id);
         }
     }
 
@@ -3962,7 +4031,7 @@ impl AlacritreeApp {
 
         if confirm_via_key || confirmed {
             self.pending_session_close = None;
-            self.close_session(id);
+            self.close_session(ctx, id);
             return;
         }
         if cancel_via_key || cancelled || modal.should_close() {
@@ -4597,7 +4666,7 @@ impl AlacritreeApp {
                 if !self.sessions.iter().any(|s| s.id == session_id) {
                     return Err(format!("no session with id {session_id}"));
                 }
-                self.close_session(session_id);
+                self.close_session(ctx, session_id);
                 Ok(json!({ "closed": session_id }))
             },
             Req::SendText { session_id, text } => {
@@ -4748,7 +4817,7 @@ impl eframe::App for AlacritreeApp {
                 }
 
                 if self.active_session_index().is_none() {
-                    self.ensure_active_session(ctx);
+                    self.adopt_active_session();
                 }
 
                 let Some(idx) = self.active_session_index() else {
@@ -4803,7 +4872,7 @@ impl eframe::App for AlacritreeApp {
             self.show_quit_dialog(ctx);
         }
 
-        self.reap_exited_sessions();
+        self.reap_exited_sessions(ctx);
     }
 }
 
@@ -4944,6 +5013,104 @@ mod tests {
 
         let two_match = vec![(ws("/a"), 1), (ws("/other"), 2), (ws("/a"), 3)];
         assert_eq!(sidebar_session_ids(&two_match, &ws("/a")), vec![1, 3]);
+    }
+
+    use crate::projects::{Project, Worktree};
+
+    /// A project whose main checkout is `root`, plus secondary worktrees.
+    fn project_with(root: &str, extra: &[&str]) -> Project {
+        let wt = |path: &str, is_main: bool| Worktree {
+            name: path.to_string(),
+            path: PathBuf::from(path),
+            branch: None,
+            is_main,
+            prunable: false,
+        };
+        Project {
+            root: PathBuf::from(root),
+            name: "p".to_string(),
+            label: None,
+            default_branch: None,
+            worktrees: std::iter::once(wt(root, true))
+                .chain(extra.iter().map(|p| wt(p, false)))
+                .collect(),
+            expanded: true,
+            shell_override: None,
+        }
+    }
+
+    #[test]
+    fn fallback_prefers_project_main_with_live_session() {
+        let remaining = vec![(ws("/repo"), 1)];
+        assert_eq!(
+            close_fallback(
+                &ws("/repo/wt"),
+                &ws("/repo/wt"),
+                &remaining,
+                Some(PathBuf::from("/repo"))
+            ),
+            CloseFallback::Activate(PathBuf::from("/repo"))
+        );
+    }
+
+    #[test]
+    fn fallback_goes_home_when_project_main_has_no_session() {
+        let remaining = vec![(ws("/other"), 1)];
+        assert_eq!(
+            close_fallback(
+                &ws("/repo/wt"),
+                &ws("/repo/wt"),
+                &remaining,
+                Some(PathBuf::from("/repo"))
+            ),
+            CloseFallback::Home
+        );
+    }
+
+    #[test]
+    fn fallback_goes_home_from_the_project_main_itself() {
+        // project_main_for returns None when ws is the main checkout, so the
+        // decision sees no main to activate.
+        assert_eq!(close_fallback(&ws("/repo"), &ws("/repo"), &[], None), CloseFallback::Home);
+    }
+
+    #[test]
+    fn fallback_goes_home_from_home() {
+        assert_eq!(close_fallback(&None, &None, &[], None), CloseFallback::Home);
+    }
+
+    #[test]
+    fn fallback_stays_on_background_workspace_close() {
+        assert_eq!(
+            close_fallback(&ws("/repo/wt"), &None, &[], Some(PathBuf::from("/repo"))),
+            CloseFallback::Stay
+        );
+    }
+
+    #[test]
+    fn fallback_stays_when_siblings_survive() {
+        let remaining = vec![(ws("/repo/wt"), 2)];
+        assert_eq!(
+            close_fallback(
+                &ws("/repo/wt"),
+                &ws("/repo/wt"),
+                &remaining,
+                Some(PathBuf::from("/repo"))
+            ),
+            CloseFallback::Stay
+        );
+    }
+
+    #[test]
+    fn project_main_resolves_for_secondary_worktrees_only() {
+        let projects = vec![project_with("/repo", &["/repo-wt/feat"])];
+        assert_eq!(
+            project_main_for(&projects, Path::new("/repo-wt/feat")),
+            Some(PathBuf::from("/repo"))
+        );
+        // The main itself and unknown paths have no fallback target.
+        assert_eq!(project_main_for(&projects, Path::new("/repo")), None);
+        assert_eq!(project_main_for(&projects, Path::new("/elsewhere")), None);
     }
 
     fn req(file: &str, source: DiffSource) -> DiffRequest {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -772,8 +772,14 @@ impl AlacritreeApp {
                 // adopts rather than spawns.
                 self.current_workspace = Some(main);
                 self.ensure_active_session(ctx);
+                // Adopting an existing session produces no PTY events, so
+                // nothing else would wake the next paint.
+                ctx.request_repaint();
             },
-            CloseFallback::Home => self.activate_home(ctx),
+            CloseFallback::Home => {
+                self.activate_home(ctx);
+                ctx.request_repaint();
+            },
         }
     }
 
@@ -2600,19 +2606,21 @@ impl AlacritreeApp {
             return;
         };
         let new_key = diff_key(&req);
-        let already_showing = self.sessions.iter().any(|s| {
+        let existing = self.sessions.iter().find(|s| {
             s.working_directory.as_deref() == Some(&workspace)
-                && matches!(&s.kind, SessionKind::Diff { key } if key == &new_key)
+                && matches!(&s.kind, SessionKind::Diff { .. })
         });
-        self.sessions.retain(|s| {
-            !(matches!(s.kind, SessionKind::Diff { .. })
-                && s.working_directory.as_deref() == Some(&workspace))
-        });
-        if already_showing {
-            // Active-session fallback to the workspace's shell happens next
-            // frame: `active_session_index()` returns None for the stale id, and
-            // `ensure_active_session` picks up an existing shell or spawns one.
-            return;
+        if let Some(session) = existing {
+            let id = session.id;
+            if matches!(&session.kind, SessionKind::Diff { key } if key == &new_key) {
+                // Routing through close_session applies the same
+                // sibling-promotion and fallback navigation as any other
+                // close, so toggling off the diff pane never strands the
+                // workspace on an empty view.
+                self.close_session(ctx, id);
+                return;
+            }
+            self.sessions.retain(|s| s.id != id);
         }
 
         let delta_override = self.config.delta_path.clone();
@@ -4157,10 +4165,13 @@ impl AlacritreeApp {
         // Drop sessions whose cwd is the worktree before deleting it; the PTY
         // would otherwise block the directory removal on some filesystems.
         self.sessions.retain(|s| s.working_directory.as_deref() != Some(&req.worktree_path));
-        if self.current_workspace.as_deref() == Some(&req.worktree_path) {
-            self.current_workspace = None;
-        }
         self.active_session.remove(&Some(req.worktree_path.clone()));
+        if self.current_workspace.as_deref() == Some(&req.worktree_path) {
+            // Deleting the on-screen worktree is an explicit user action, so
+            // home should greet with a live shell rather than the "no
+            // session" placeholder.
+            self.activate_home(ctx);
+        }
 
         // The git removal (shellouts, branch delete, doppler cleanup) is slow
         // enough to stutter paint, so run it off-thread and adopt the result in

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1504,6 +1504,12 @@ impl AlacritreeApp {
                 // to the left one rather than doing nothing.
                 PaneFocus::GitSidebar => self.focus_sidebar(),
             },
+            BindingAction::Named(NamedAction::CloseSession) => {
+                if let Some(idx) = self.active_session_index() {
+                    let id = self.sessions[idx].id;
+                    self.request_close_session(id);
+                }
+            },
             BindingAction::Named(NamedAction::FocusProjectsSidebar) => {
                 if self.focus != PaneFocus::ProjectsSidebar {
                     self.focus_sidebar();

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -51,6 +51,7 @@ pub enum NamedAction {
     SelectPreviousWorkspace,
     AddProject,
     ToggleSidebarFocus,
+    CloseSession,
     FocusProjectsSidebar,
     FocusGitSidebar,
     FocusTerminal,
@@ -195,6 +196,7 @@ fn default_bindings() -> Vec<KeyBinding> {
             action: BindingAction::Named(ToggleSidebarFocus),
         },
         KeyBinding { key: Key::G, mods: ctrl_shift, action: BindingAction::Named(FocusGitSidebar) },
+        KeyBinding { key: Key::W, mods: ctrl_shift, action: BindingAction::Named(CloseSession) },
         KeyBinding { key: Key::T, mods: ctrl, action: BindingAction::Named(SpawnNewInstance) },
         KeyBinding { key: Key::Q, mods: ctrl, action: BindingAction::Named(Quit) },
     ]);
@@ -499,6 +501,7 @@ fn parse_action(name: &str) -> BindingAction {
         "SelectPreviousWorkspace" => BindingAction::Named(SelectPreviousWorkspace),
         "AddProject" => BindingAction::Named(AddProject),
         "ToggleSidebarFocus" => BindingAction::Named(ToggleSidebarFocus),
+        "CloseSession" => BindingAction::Named(CloseSession),
         "FocusProjectsSidebar" => BindingAction::Named(FocusProjectsSidebar),
         "FocusGitSidebar" => BindingAction::Named(FocusGitSidebar),
         "FocusTerminal" => BindingAction::Named(FocusTerminal),
@@ -785,5 +788,22 @@ mod tests {
                 "{name} parsed to {action:?}"
             );
         }
+    }
+
+    #[test]
+    fn close_session_is_a_default_ctrl_shift_w_binding() {
+        let b = parse_bindings(vec![]);
+        assert_eq!(
+            named_matches(&b, Key::W, Modifiers::CTRL | Modifiers::SHIFT),
+            vec![NamedAction::CloseSession]
+        );
+    }
+
+    #[test]
+    fn close_session_parses_from_config_name() {
+        assert!(matches!(
+            parse_action("CloseSession"),
+            BindingAction::Named(NamedAction::CloseSession)
+        ));
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -208,7 +208,8 @@ pub struct Palette {
 pub enum ConfirmSessionClose {
     #[default]
     Never,
-    /// Prompt only when the session looks busy (agent glyph or spinner title).
+    /// Prompt only when the session looks busy (running process, agent
+    /// glyph, or spinner title).
     Busy,
     Always,
 }
@@ -254,6 +255,30 @@ impl Default for UiIcons {
     }
 }
 
+/// What happens when the on-screen workspace's last session closes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LastSessionClose {
+    /// Recycle a shell in place — the workspace always has a live session,
+    /// so the last session is by design unclosable.
+    #[default]
+    Respawn,
+    /// Move to the project's main checkout when it has a live session,
+    /// otherwise home (which spawns a shell only if it has none).
+    Navigate,
+}
+
+fn parse_last_session_close(raw: Option<&str>) -> LastSessionClose {
+    match raw {
+        None => LastSessionClose::default(),
+        Some("respawn") => LastSessionClose::Respawn,
+        Some("navigate") => LastSessionClose::Navigate,
+        Some(other) => {
+            log::warn!("unknown ui.last_session_close value {other:?}, using \"respawn\"");
+            LastSessionClose::default()
+        },
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct UiTheme {
     pub sidebar_background: Option<Color32>,
@@ -264,6 +289,8 @@ pub struct UiTheme {
     pub notifications: bool,
     /// Ask before the sidebar's per-session `×` kills the PTY.
     pub confirm_session_close: ConfirmSessionClose,
+    /// What closing the last session in the on-screen workspace does.
+    pub last_session_close: LastSessionClose,
     pub icons: UiIcons,
 }
 
@@ -276,6 +303,7 @@ impl Default for UiTheme {
             sidebar_accent: None,
             notifications: true,
             confirm_session_close: ConfirmSessionClose::Never,
+            last_session_close: LastSessionClose::Respawn,
             icons: UiIcons::default(),
         }
     }
@@ -828,6 +856,9 @@ struct RawUi {
     /// When the sidebar × on a session row asks before killing the PTY:
     /// "never" (default) | "busy" | "always".
     confirm_session_close: Option<String>,
+    /// What closing the on-screen workspace's last session does:
+    /// "respawn" (default) | "navigate".
+    last_session_close: Option<String>,
     delta_path: Option<String>,
     icons: RawUiIcons,
     wsl: RawUiWsl,
@@ -958,6 +989,7 @@ impl RawConfig {
             confirm_session_close: parse_confirm_session_close(
                 self.ui.confirm_session_close.as_deref(),
             ),
+            last_session_close: parse_last_session_close(self.ui.last_session_close.as_deref()),
             icons: UiIcons {
                 search: self.ui.icons.search.unwrap_or_else(|| DEFAULT_SEARCH_ICON.into()),
             },
@@ -1238,6 +1270,28 @@ mod tests {
     fn search_icon_defaults_and_overrides() {
         assert_eq!(ui_from_toml("").icons.search, DEFAULT_SEARCH_ICON);
         assert_eq!(ui_from_toml("[ui.icons]\nsearch = \"\u{f002}\"").icons.search, "\u{f002}");
+    }
+
+    #[test]
+    fn last_session_close_defaults_to_respawn() {
+        let ui = ui_from_toml("");
+        assert_eq!(ui.last_session_close, LastSessionClose::Respawn);
+    }
+
+    #[test]
+    fn last_session_close_parses_all_values() {
+        for (raw, expected) in
+            [("respawn", LastSessionClose::Respawn), ("navigate", LastSessionClose::Navigate)]
+        {
+            let ui = ui_from_toml(&format!("[ui]\nlast_session_close = \"{raw}\""));
+            assert_eq!(ui.last_session_close, expected, "value {raw:?}");
+        }
+    }
+
+    #[test]
+    fn last_session_close_invalid_falls_back_to_respawn() {
+        let ui = ui_from_toml("[ui]\nlast_session_close = \"panic\"");
+        assert_eq!(ui.last_session_close, LastSessionClose::Respawn);
     }
 
     #[test]

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -115,6 +115,8 @@ struct AgentCache {
     polled_at: Option<Instant>,
     /// Static glyph for the foreground process if it's a recognized agent.
     process_glyph: Option<char>,
+    /// Whether anything is running in the terminal beyond the shell itself.
+    foreground_job: bool,
 }
 
 const AGENT_CACHE_TTL: Duration = Duration::from_millis(1000);
@@ -319,13 +321,46 @@ fn read_cmdline(pid: u32) -> Option<String> {
 /// `/proc/<pid>/stat` is `pid (comm) state ppid pgrp session tty_nr tpgid …`.
 /// `comm` may contain spaces and unmatched parens, so split on the *last* `)`
 /// before tokenizing the rest.
-#[cfg(target_os = "linux")]
-fn read_tpgid(shell_pid: u32) -> Option<i32> {
-    let stat = std::fs::read_to_string(format!("/proc/{shell_pid}/stat")).ok()?;
+#[cfg(any(target_os = "linux", test))]
+fn stat_pgrp_tpgid(stat: &str) -> Option<(i32, i32)> {
     let close = stat.rfind(')')?;
     let after = &stat[close + 1..];
     // After `comm`: state(0) ppid(1) pgrp(2) session(3) tty_nr(4) tpgid(5).
-    after.split_whitespace().nth(5)?.parse::<i32>().ok()
+    let mut fields = after.split_whitespace();
+    let pgrp = fields.nth(2)?.parse::<i32>().ok()?;
+    let tpgid = fields.nth(2)?.parse::<i32>().ok()?;
+    Some((pgrp, tpgid))
+}
+
+#[cfg(target_os = "linux")]
+fn read_tpgid(shell_pid: u32) -> Option<i32> {
+    let stat = std::fs::read_to_string(format!("/proc/{shell_pid}/stat")).ok()?;
+    stat_pgrp_tpgid(&stat).map(|(_, tpgid)| tpgid)
+}
+
+/// The shell is its own foreground process group when idle; the terminal's
+/// foreground group differing from the shell's own group means a job owns
+/// the terminal right now.
+#[cfg(target_os = "linux")]
+fn shell_has_foreground_job(shell_pid: u32) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{shell_pid}/stat")) else {
+        return false;
+    };
+    stat_pgrp_tpgid(&stat).is_some_and(|(pgrp, tpgid)| tpgid > 0 && tpgid != pgrp)
+}
+
+/// Windows has no foreground process group, so "a job is running" is
+/// approximated as the shell having any descendant process — the same
+/// approximation the agent glyph uses.
+#[cfg(windows)]
+fn shell_has_foreground_job(shell_pid: u32) -> bool {
+    windows_process_probe::probe(shell_pid).1
+}
+
+#[cfg(not(any(target_os = "linux", windows)))]
+fn shell_has_foreground_job(_shell_pid: u32) -> bool {
+    // No probe wired (macOS would need `tcgetpgrp` on the PTY master).
+    false
 }
 
 /// Windows has no foreground process group, so "foreground" is approximated
@@ -335,7 +370,7 @@ fn read_tpgid(shell_pid: u32) -> Option<i32> {
 /// heuristic would flicker.
 #[cfg(windows)]
 fn foreground_process_glyph(shell_pid: u32) -> Option<char> {
-    windows_process_probe::agent_glyph_under(shell_pid)
+    windows_process_probe::probe(shell_pid).0
 }
 
 #[cfg(not(any(target_os = "linux", windows)))]
@@ -394,7 +429,9 @@ mod windows_process_probe {
 
     static SNAPSHOT: Mutex<Option<(Instant, System)>> = Mutex::new(None);
 
-    pub(super) fn agent_glyph_under(shell_pid: u32) -> Option<char> {
+    /// Agent glyph found in the shell's descendant tree, plus whether the
+    /// shell has any descendants at all.
+    pub(super) fn probe(shell_pid: u32) -> (Option<char>, bool) {
         let mut guard = SNAPSHOT.lock().unwrap_or_else(PoisonError::into_inner);
         if guard.as_ref().is_none_or(|(at, _)| at.elapsed() >= SNAPSHOT_TTL) {
             let mut sys = guard.take().map(|(_, sys)| sys).unwrap_or_default();
@@ -413,12 +450,13 @@ mod windows_process_probe {
             .map(|(pid, p)| (pid.as_u32(), p.parent().map(|pp| pp.as_u32())))
             .collect();
         let tree = process_tree_pids(&table, shell_pid);
+        let has_children = tree.len() > 1;
         let tree: Vec<Pid> = tree.into_iter().map(Pid::from_u32).collect();
 
         let names =
             tree.iter().filter_map(|pid| sys.process(*pid)).map(|p| p.name().to_string_lossy());
         if let Some(glyph) = agent_glyph_by_name(names) {
-            return Some(glyph);
+            return (Some(glyph), has_children);
         }
 
         // Names missed: fetch command lines for just the tree to catch
@@ -432,7 +470,7 @@ mod windows_process_probe {
             .iter()
             .filter_map(|pid| sys.process(*pid))
             .map(|p| p.cmd().iter().map(|a| a.to_string_lossy()).collect::<Vec<_>>().join(" "));
-        agent_glyph_by_cmdline(cmds)
+        (agent_glyph_by_cmdline(cmds), has_children)
     }
 }
 
@@ -654,22 +692,32 @@ impl Session {
         title_glyph
     }
 
-    /// A session "looks busy" when its foreground process is a recognized
-    /// agent or its title is in a spinner state — the signal the sidebar's
-    /// close-confirmation policy keys on.
+    /// A session "looks busy" when a process is running in the terminal
+    /// (a foreground job on Linux, any descendant of the shell on Windows),
+    /// its foreground process is a recognized agent, or its title is in a
+    /// spinner state — the signal the close-confirmation policy keys on.
     pub fn is_busy(&self) -> bool {
-        looks_busy(self.agent_glyph(), &self.title)
+        self.process_probe().1 || looks_busy(self.agent_glyph(), &self.title)
     }
 
     fn process_agent_glyph(&self) -> Option<char> {
+        self.process_probe().0
+    }
+
+    fn process_probe(&self) -> (Option<char>, bool) {
         let cached = self.agent_cache.get();
         let fresh = cached.polled_at.is_some_and(|t| t.elapsed() < AGENT_CACHE_TTL);
         if fresh {
-            return cached.process_glyph;
+            return (cached.process_glyph, cached.foreground_job);
         }
         let glyph = self.shell_pid.and_then(foreground_process_glyph);
-        self.agent_cache.set(AgentCache { polled_at: Some(Instant::now()), process_glyph: glyph });
-        glyph
+        let foreground_job = self.shell_pid.is_some_and(shell_has_foreground_job);
+        self.agent_cache.set(AgentCache {
+            polled_at: Some(Instant::now()),
+            process_glyph: glyph,
+            foreground_job,
+        });
+        (glyph, foreground_job)
     }
 
     /// Text dump of the visible screen plus up to `scrollback_lines` of
@@ -1016,6 +1064,18 @@ mod tests {
     fn idle_when_no_glyph_and_plain_title() {
         assert!(!looks_busy(None, "~/projects/alacritree"));
         assert!(!looks_busy(None, ""));
+    }
+
+    #[test]
+    fn stat_parse_extracts_pgrp_and_tpgid_past_a_parenthesized_comm() {
+        let stat = "1234 (my (weird) shell) S 1 1234 1234 34816 5678 0 42";
+        assert_eq!(stat_pgrp_tpgid(stat), Some((1234, 5678)));
+    }
+
+    #[test]
+    fn stat_parse_rejects_truncated_or_malformed_lines() {
+        assert_eq!(stat_pgrp_tpgid("garbage with no paren"), None);
+        assert_eq!(stat_pgrp_tpgid("1 (sh) S 1 2"), None);
     }
 
     #[test]

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -57,6 +57,7 @@ and your TOML entries are checked first — so your config overrides any default
 | `Shift+Tab`          | Send `CSI Z` (reverse tab — readline/vim)             |
 | `Alt+Shift+Tab`      | Send `ESC` + `CSI Z`                                  |
 | `Ctrl+Shift+B`       | Toggle keyboard focus between terminal and sidebar    |
+| `Ctrl+Shift+W`       | Close the active session in the current workspace     |
 
 ### Additional defaults on macOS
 
@@ -119,6 +120,9 @@ entry. Names match alacritty's own action names, so existing configs port over.
 - `SelectTab1` … `SelectTab9` — select the Nth session in the current
   workspace. Out-of-range indices are ignored.
 - `SelectLastTab` — select the last session in the current workspace.
+- `CloseSession` — close the active session in the current workspace.
+  Honors the `confirm_session_close` policy (may open a confirmation
+  dialog).
 - `SpawnProfile1` … `SpawnProfile9` — spawn the Nth `[[ui.profiles]]` entry
   in the current workspace. Out-of-range indices show an error toast.
   Example binding:

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -122,7 +122,10 @@ entry. Names match alacritty's own action names, so existing configs port over.
 - `SelectLastTab` — select the last session in the current workspace.
 - `CloseSession` — close the active session in the current workspace.
   Honors the `confirm_session_close` policy (may open a confirmation
-  dialog).
+  dialog; `"busy"` prompts only while a process is running). When the
+  workspace's last session closes, `ui.last_session_close` decides what
+  follows: `"respawn"` (default) recycles a shell in place, `"navigate"`
+  moves to the project's main checkout or home.
 - `SpawnProfile1` … `SpawnProfile9` — spawn the Nth `[[ui.profiles]]` entry
   in the current workspace. Out-of-range indices show an error toast.
   Example binding:


### PR DESCRIPTION
Closing a workspace's last session was impossible: the per-frame recovery respawned a shell in place the moment one closed, and closing had no keyboard path. This PR adds a close keybinding, makes every close path (sidebar ×, keybinding, MCP/CLI, shell exit with any status) funnel through one policy, and makes that policy configurable.

## What changed

- **`CloseSession` binding action** — rebindable, default `Ctrl+Shift+W`, closes the active session through `request_close_session` so the `confirm_session_close` policy applies. Documented in `docs/keyboard-shortcuts.md`.
- **`ui.last_session_close = "respawn" | "navigate"`** — what closing the on-screen workspace's last session does. `respawn` (default, the long-standing behavior) recycles a shell in place; `navigate` moves to the owning project's main checkout if it has a live session, otherwise home (which spawns a shell only as the last resort). Background closes and closes with surviving siblings keep the existing sibling-promotion behavior either way. Decision logic lives in pure, unit-tested helpers (`close_fallback`, `project_main_for`).
- **`confirm_session_close = "busy"` now means "something is running"** — the shell's foreground process group on Linux, any descendant process on Windows (no foreground concept there), riding the existing throttled probe; agent glyphs and spinner titles remain a subset. An idle shell closes without prompting.
- **Adopt-only frame recovery** — the central panel re-attaches to an existing session when the active id goes stale but never spawns; explicit activation paths (row clicks, `Ctrl+T`, spawn buttons) keep spawning.
- **Bypass paths aligned** — worktree deletion lands on home with a live shell, and toggling a diff pane off routes through `close_session` so it follows the same policy.
- **Ride-along compile fix** — the squash merge of #102 dropped `modal_button`'s closing brace, leaving master unable to compile; the first commit restores it.

## Testing

- 326 tests green on the rebased branch (14 new: 7 fallback-decision, 2 binding, 3 config parse, 2 stat-parser); every commit type-checks individually.
- Live smoke test via IPC on an isolated instance (with `navigate`): fresh launch, home last-close respawn, worktree→main, worktree→home, background close (no navigation), sibling promotion, and shell-exit reap all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
