### PR TITLE
[5] feat(ui): sidebar appearance customization

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2126,19 +2126,28 @@ impl AlacritreeApp {
             let mut rows = Vec::with_capacity(project.worktrees.len());
             for wt in &project.worktrees {
                 let info = if pr_enabled && project.expanded {
-                    // The right sidebar polls the same path's PR cache using
-                    // the live `StatusCache` branch (recomputed every ~1.5s),
-                    // while this snapshot is only refreshed at discover/refresh
-                    // time. Two pollers of one path must agree on a branch or
-                    // each drain flips `entry.branch` and they invalidate each
-                    // other's lookups forever after an in-terminal checkout —
-                    // so prefer the live cache here too, falling back to the
-                    // snapshot only where no cache exists yet.
-                    let branch = self
-                        .git_status
-                        .get(&wt.path)
-                        .and_then(|cache| cache.current_branch())
-                        .or(wt.branch.as_deref());
+                    // The right sidebar polls only the active workspace's PR
+                    // cache, using the live `StatusCache` branch (recomputed
+                    // every ~1.5s). Two pollers of the same path must agree on
+                    // a branch or each drain flips `entry.branch` and they
+                    // invalidate each other's lookups forever after an
+                    // in-terminal checkout — so share the live cache there.
+                    // For every other worktree there is only one poller (this
+                    // one), and its cache is created once a workspace goes
+                    // active but never re-polled or pruned after it goes
+                    // inactive again: reading it here would freeze the branch
+                    // at whatever it was on last visit and shadow later
+                    // `refresh_project` updates to `wt.branch`. Use the
+                    // refresh-responsive snapshot instead.
+                    let is_active = self.current_workspace.as_deref() == Some(&wt.path);
+                    let branch = if is_active {
+                        self.git_status
+                            .get(&wt.path)
+                            .and_then(|cache| cache.current_branch())
+                            .or(wt.branch.as_deref())
+                    } else {
+                        wt.branch.as_deref()
+                    };
                     self.pr_cache.poll(&wt.path, branch, ctx)
                 } else {
                     None

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2126,7 +2126,20 @@ impl AlacritreeApp {
             let mut rows = Vec::with_capacity(project.worktrees.len());
             for wt in &project.worktrees {
                 let info = if pr_enabled && project.expanded {
-                    self.pr_cache.poll(&wt.path, wt.branch.as_deref(), ctx)
+                    // The right sidebar polls the same path's PR cache using
+                    // the live `StatusCache` branch (recomputed every ~1.5s),
+                    // while this snapshot is only refreshed at discover/refresh
+                    // time. Two pollers of one path must agree on a branch or
+                    // each drain flips `entry.branch` and they invalidate each
+                    // other's lookups forever after an in-terminal checkout —
+                    // so prefer the live cache here too, falling back to the
+                    // snapshot only where no cache exists yet.
+                    let branch = self
+                        .git_status
+                        .get(&wt.path)
+                        .and_then(|cache| cache.current_branch())
+                        .or(wt.branch.as_deref());
+                    self.pr_cache.poll(&wt.path, branch, ctx)
                 } else {
                     None
                 };

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use crate::bindings::{BindingAction, NamedAction};
 use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
-use crate::config::{Config, LastSessionClose};
+use crate::config::{Config, FontConfig, LastSessionClose, UiFont};
 use crate::doppler;
 use crate::git_nav::{self, GitSection, SectionCount};
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, GitStatus, StatusCache};
@@ -66,6 +66,21 @@ struct Theme {
     ui_scale: f32,
 }
 
+/// Logical-pixel (normal, heading) sizes for UI text.  `[ui.font] size`
+/// overrides the normal size directly (same pt→px conversion as
+/// `FontConfig::egui_size`); the heading keeps its existing ratio to normal
+/// text.  Unset, both fall back to the `[font]`-derived values unchanged.
+fn ui_text_px(font: &FontConfig, ui_font: &UiFont) -> (f32, f32) {
+    match ui_font.size {
+        Some(pt) => {
+            let normal = pt * 96.0 / 72.0;
+            let heading = normal * (FontConfig::UI_HEADING_RATIO / FontConfig::UI_NORMAL_RATIO);
+            (normal, heading)
+        },
+        None => (font.ui_normal_px(), font.ui_heading_px()),
+    }
+}
+
 impl Theme {
     fn from_config(config: &Config) -> Self {
         let terminal_bg = rgb_to_color32(config.palette.bg);
@@ -75,6 +90,7 @@ impl Theme {
         let accent =
             config.ui.sidebar_accent.unwrap_or_else(|| rgb_to_color32(config.palette.normal[4])); // ANSI blue
         let border = config.ui.sidebar_border.unwrap_or_else(|| lighten(sidebar_bg, 0.10));
+        let (font_normal, font_heading) = ui_text_px(&config.font, &config.ui_font);
         Self {
             terminal_bg,
             sidebar_bg,
@@ -86,9 +102,9 @@ impl Theme {
             text_muted: blend_toward(text, sidebar_bg, 0.55),
             accent,
             attention: rgb_to_color32(config.palette.normal[3]), // ANSI yellow
-            font_heading: config.font.ui_heading_px(),
-            font_normal: config.font.ui_normal_px(),
-            ui_scale: config.font.ui_normal_px() / 11.25,
+            font_heading,
+            font_normal,
+            ui_scale: font_normal / 11.25,
         }
     }
 }
@@ -5796,5 +5812,26 @@ mod tests {
             Some("pwsh"),
         );
         assert_eq!(d, ShellDecision::Profile("pwsh".into()));
+    }
+
+    #[test]
+    fn ui_text_px_defaults_to_terminal_derivation() {
+        let font = crate::config::FontConfig::default();
+        let (normal, heading) = ui_text_px(&font, &crate::config::UiFont::default());
+        assert_eq!(normal, font.ui_normal_px());
+        assert_eq!(heading, font.ui_heading_px());
+    }
+
+    #[test]
+    fn ui_text_px_overrides_from_ui_font_size() {
+        let font = crate::config::FontConfig::default();
+        let ui = crate::config::UiFont { family: None, size: Some(12.0) };
+        let (normal, heading) = ui_text_px(&font, &ui);
+        assert_eq!(normal, 16.0); // 12 pt × 96/72
+        assert_eq!(
+            heading,
+            16.0 * (crate::config::FontConfig::UI_HEADING_RATIO
+                / crate::config::FontConfig::UI_NORMAL_RATIO)
+        );
     }
 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -415,7 +415,11 @@ impl AlacritreeApp {
     pub fn new(cc: &CreationContext<'_>, config: Config) -> Self {
         let theme = Theme::from_config(&config);
 
-        let font_chain = crate::fonts::install_terminal_fonts(&cc.egui_ctx, &config.font);
+        let font_chain = crate::fonts::install_terminal_fonts(
+            &cc.egui_ctx,
+            &config.font,
+            config.ui_font.family.as_deref(),
+        );
         let color_glyph_budget_mb = config.font.color_glyph_cache_mb;
 
         let mut visuals = egui::Visuals::dark();

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -5340,6 +5340,9 @@ impl eframe::App for AlacritreeApp {
         if self.show_right_sidebar {
             let r = self.show_git_sidebar(ctx, panel_frame);
             paint_panel_border(ctx, r.left(), r.y_range(), theme.sidebar_border);
+            if theme.focus_outline.sidebar && !modal_open && self.focus == PaneFocus::GitSidebar {
+                paint_focus_outline(ctx, r, &theme);
+            }
         }
 
         let central = egui::CentralPanel::default()

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use crate::bindings::{BindingAction, NamedAction};
 use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
-use crate::config::{Config, FontConfig, LastSessionClose, UiFont};
+use crate::config::{Config, FontConfig, Icons, LastSessionClose, UiFont};
 use crate::doppler;
 use crate::git_nav::{self, GitSection, SectionCount};
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, GitStatus, StatusCache};
@@ -2072,6 +2072,7 @@ impl AlacritreeApp {
         let creating: Vec<(usize, String)> =
             self.pending_creates.iter().map(|c| (c.project_idx, c.branch.clone())).collect();
         let distros = wsl::distros();
+        let icons = self.config.ui.icons.clone();
         let profile_names: Vec<String> =
             self.config.profiles.iter().map(|p| p.name.clone()).collect();
         let mut shell_override_changed: Option<PathBuf> = None;
@@ -2125,6 +2126,7 @@ impl AlacritreeApp {
                             cursor_moved,
                             home_attention,
                             home_agent_glyph,
+                            &icons,
                             &theme,
                         );
                         if home_action.activate {
@@ -2138,7 +2140,7 @@ impl AlacritreeApp {
                                 &cursor_row,
                                 Some(SidebarRow::Session(id)) if *id == row.id
                             );
-                            let act = session_row(ui, row, is_cursor, cursor_moved, &theme);
+                            let act = session_row(ui, row, is_cursor, cursor_moved, &icons, &theme);
                             if act.activate {
                                 activate_session_request.set(Some((None, row.id)));
                             }
@@ -2185,7 +2187,11 @@ impl AlacritreeApp {
                                     drag_handle(ui, &theme)
                                         .dnd_set_drag_payload(DraggedProject(project.root.clone()));
                                 }
-                                let arrow = if project.expanded { "▾" } else { "▸" };
+                                let arrow = if project.expanded {
+                                    icons.project_expanded.as_str()
+                                } else {
+                                    icons.project_collapsed.as_str()
+                                };
                                 if icon_button(ui, arrow, theme.text_dim, &theme).clicked() {
                                     project.expanded = !project.expanded;
                                     expand_toggled = Some((project.root.clone(), project.expanded));
@@ -2380,6 +2386,7 @@ impl AlacritreeApp {
                                     wt_attention,
                                     wt_glyph,
                                     is_deleting,
+                                    &icons,
                                     &theme,
                                 );
                                 if action.activate {
@@ -2420,7 +2427,14 @@ impl AlacritreeApp {
                                         &cursor_row,
                                         Some(SidebarRow::Session(id)) if *id == row.id
                                     );
-                                    let act = session_row(ui, row, is_cursor, cursor_moved, &theme);
+                                    let act = session_row(
+                                        ui,
+                                        row,
+                                        is_cursor,
+                                        cursor_moved,
+                                        &icons,
+                                        &theme,
+                                    );
                                     if act.activate {
                                         activate_session_request
                                             .set(Some((Some(wt.path.clone()), row.id)));
@@ -2431,7 +2445,7 @@ impl AlacritreeApp {
                                 }
                             }
                             for (_, branch) in creating.iter().filter(|(pi, _)| *pi == idx) {
-                                creating_row(ui, branch, &theme);
+                                creating_row(ui, branch, &icons, &theme);
                             }
                             ui.add_space(4.0);
                         }
@@ -3599,6 +3613,7 @@ fn home_row(
     scroll_into_view: bool,
     attention: bool,
     agent_glyph: Option<char>,
+    icons: &Icons,
     theme: &Theme,
 ) -> HomeAction {
     // Reserve a slot *before* the labels so the hover bg paints beneath them.
@@ -3613,7 +3628,14 @@ fn home_row(
             row_with_trailing(
                 ui,
                 |ui| {
-                    paint_row_status_icon(ui, theme, attention, agent_glyph, "⌂", is_active);
+                    paint_row_status_icon(
+                        ui,
+                        theme,
+                        attention,
+                        agent_glyph,
+                        &icons.home,
+                        is_active,
+                    );
                     ui.label(
                         RichText::new("Home")
                             .color(if is_active { theme.text } else { theme.text_dim })
@@ -3763,14 +3785,14 @@ fn session_row_title(title: &str, agent_glyph: Option<char>) -> String {
 /// spinner stands in until `poll_pending_creates` refreshes the project and the
 /// real worktree row takes its place.  Indentation and the leading glyph match
 /// `worktree_row` so it lines up with its future sibling.
-fn creating_row(ui: &mut egui::Ui, branch: &str, theme: &Theme) {
+fn creating_row(ui: &mut egui::Ui, branch: &str, icons: &Icons, theme: &Theme) {
     let s = theme.ui_scale;
     let frame = Frame::default().inner_margin(Margin { left: 16, right: 0, top: 3, bottom: 3 });
     frame.show(ui, |ui| {
         row_with_trailing(
             ui,
             |ui| {
-                ui.label(RichText::new("○").color(theme.text_muted).size(10.0 * s));
+                ui.label(RichText::new(&icons.worktree).color(theme.text_muted).size(10.0 * s));
                 ui.add(
                     egui::Label::new(RichText::new(branch).color(theme.text_muted).small())
                         .truncate(),
@@ -3792,6 +3814,7 @@ fn worktree_row(
     attention: bool,
     agent_glyph: Option<char>,
     deleting: bool,
+    icons: &Icons,
     theme: &Theme,
 ) -> WorktreeAction {
     // Reserve a slot *before* the labels so the hover bg paints beneath them.
@@ -3807,7 +3830,7 @@ fn worktree_row(
     let frame = Frame::default().inner_margin(Margin { left: 16, right: 0, top: 3, bottom: 3 });
     let resp = frame
         .show(ui, |ui| {
-            let default_icon = if wt.is_main { "●" } else { "○" };
+            let default_icon = if wt.is_main { &icons.worktree_main } else { &icons.worktree };
             let name_color = if wt.prunable || deleting {
                 theme.text_muted
             } else if is_active {
@@ -3920,6 +3943,7 @@ fn session_row(
     row: &SessionRowData,
     is_cursor: bool,
     scroll_into_view: bool,
+    icons: &Icons,
     theme: &Theme,
 ) -> SessionRowAction {
     // Reserve a slot *before* the labels so the hover bg paints beneath them.
@@ -3942,7 +3966,7 @@ fn session_row(
                         theme,
                         row.needs_attention,
                         row.agent_glyph,
-                        "▪",
+                        &icons.session,
                         row.is_active,
                     );
                     ui.add(

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -39,6 +39,14 @@ pub type WorkspaceKey = Option<PathBuf>;
 static NOTIFY_TX: OnceLock<Mutex<Sender<WorkspaceKey>>> = OnceLock::new();
 
 #[derive(Clone, Copy)]
+struct FocusOutlineTheme {
+    sidebar: bool,
+    terminal: bool,
+    color: Color32,
+    thickness: f32,
+}
+
+#[derive(Clone, Copy)]
 struct Theme {
     terminal_bg: Color32,
     sidebar_bg: Color32,
@@ -69,6 +77,7 @@ struct Theme {
     /// historical 11.25-logical-pixel baseline so unmodified config keeps the
     /// existing layout proportions.
     ui_scale: f32,
+    focus_outline: FocusOutlineTheme,
 }
 
 /// Logical-pixel (normal, heading) sizes for UI text.  `[ui.font] size`
@@ -115,6 +124,12 @@ impl Theme {
             font_heading,
             font_normal,
             ui_scale: font_normal / 11.25,
+            focus_outline: FocusOutlineTheme {
+                sidebar: config.ui.focus_outline.sidebar,
+                terminal: config.ui.focus_outline.terminal,
+                color: config.ui.focus_outline.color.unwrap_or(accent),
+                thickness: config.ui.focus_outline.thickness,
+            },
         }
     }
 }
@@ -135,6 +150,20 @@ fn paint_panel_border(ctx: &Context, x: f32, y_range: egui::Rangef, color: Color
     let layer =
         egui::LayerId::new(egui::Order::Middle, egui::Id::new(("sidebar_border", x.to_bits())));
     ctx.layer_painter(layer).vline(x, y_range, Stroke::new(1.0_f32, color));
+}
+
+fn paint_focus_outline(ctx: &Context, rect: egui::Rect, theme: &Theme) {
+    let fo = theme.focus_outline;
+    let layer = egui::LayerId::new(
+        egui::Order::Middle,
+        egui::Id::new(("focus_outline", rect.min.x.to_bits())),
+    );
+    ctx.layer_painter(layer).rect_stroke(
+        rect,
+        0.0,
+        Stroke::new(fo.thickness, fo.color),
+        egui::StrokeKind::Inside,
+    );
 }
 
 fn blend_toward(c: Color32, target: Color32, amount: f32) -> Color32 {
@@ -5278,6 +5307,12 @@ impl eframe::App for AlacritreeApp {
         if self.show_left_sidebar {
             let r = self.show_project_sidebar(ctx, panel_frame.clone());
             paint_panel_border(ctx, r.right(), r.y_range(), theme.sidebar_border);
+            if theme.focus_outline.sidebar
+                && !modal_open
+                && self.focus == PaneFocus::ProjectsSidebar
+            {
+                paint_focus_outline(ctx, r, &theme);
+            }
         }
 
         if self.show_right_sidebar {
@@ -5285,7 +5320,7 @@ impl eframe::App for AlacritreeApp {
             paint_panel_border(ctx, r.left(), r.y_range(), theme.sidebar_border);
         }
 
-        egui::CentralPanel::default()
+        let central = egui::CentralPanel::default()
             .frame(Frame::default().fill(central_fill).inner_margin(Margin::same(0)))
             .show(ctx, |ui| {
                 self.show_tab_strip(ui);
@@ -5336,6 +5371,9 @@ impl eframe::App for AlacritreeApp {
                     self.focus_terminal();
                 }
             });
+        if theme.focus_outline.terminal && !modal_open && self.focus == PaneFocus::Terminal {
+            paint_focus_outline(ctx, central.response.rect, &theme);
+        }
 
         if self.pending_create.is_some() {
             self.show_create_dialog(ctx);

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -19,7 +19,7 @@ use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, GitStatus, St
 use crate::ipc;
 use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
-use crate::pr_status::PrCache;
+use crate::pr_status::{PrCache, PrInfo, PrState};
 use crate::projects::{Project, Worktree, project_json};
 use crate::session::{Session, SessionId, SessionKind, TermSize};
 use crate::shortcuts_window;
@@ -52,6 +52,11 @@ struct Theme {
     /// "Needs attention" highlight.  Distinct from `accent` ("active
     /// workspace") so the two signals don't read as the same thing.
     attention: Color32,
+    /// PR badge colors, mapped to GitHub's conventions from the ANSI palette.
+    pr_open: Color32,
+    pr_draft: Color32,
+    pr_merged: Color32,
+    pr_closed: Color32,
     /// Logical-pixel size for headings (titles like "Projects", "Git").
     /// `FontConfig::UI_HEADING_RATIO` of the terminal font size.
     font_heading: f32,
@@ -90,6 +95,7 @@ impl Theme {
         let accent =
             config.ui.sidebar_accent.unwrap_or_else(|| rgb_to_color32(config.palette.normal[4])); // ANSI blue
         let border = config.ui.sidebar_border.unwrap_or_else(|| lighten(sidebar_bg, 0.10));
+        let text_muted = blend_toward(text, sidebar_bg, 0.55);
         let (font_normal, font_heading) = ui_text_px(&config.font, &config.ui_font);
         Self {
             terminal_bg,
@@ -99,9 +105,13 @@ impl Theme {
             row_active_bg: lighten(sidebar_bg, 0.10),
             text,
             text_dim: blend_toward(text, sidebar_bg, 0.35),
-            text_muted: blend_toward(text, sidebar_bg, 0.55),
+            text_muted,
             accent,
             attention: rgb_to_color32(config.palette.normal[3]), // ANSI yellow
+            pr_open: rgb_to_color32(config.palette.normal[2]),   // green
+            pr_draft: text_muted,
+            pr_merged: rgb_to_color32(config.palette.normal[5]), // magenta
+            pr_closed: rgb_to_color32(config.palette.normal[1]), // red
             font_heading,
             font_normal,
             ui_scale: font_normal / 11.25,
@@ -2078,6 +2088,23 @@ impl AlacritreeApp {
         let mut shell_override_changed: Option<PathBuf> = None;
         let mut label_cleared: Option<PathBuf> = None;
         let mut rename_request: Option<RenameState> = None;
+        // Polled up front, expanded projects only: collapsed projects cost no gh
+        // processes, and the panel closure borrows `projects` mutably so the cache
+        // cannot be polled from inside it.
+        let pr_enabled = self.config.ui.pr_status;
+        let mut pr_infos: Vec<Vec<Option<PrInfo>>> = Vec::with_capacity(self.projects.len());
+        for project in &self.projects {
+            let mut rows = Vec::with_capacity(project.worktrees.len());
+            for wt in &project.worktrees {
+                let info = if pr_enabled && project.expanded {
+                    self.pr_cache.poll(&wt.path, wt.branch.as_deref(), ctx)
+                } else {
+                    None
+                };
+                rows.push(info);
+            }
+            pr_infos.push(rows);
+        }
 
         let panel_resp = SidePanel::left("left_sidebar")
             .resizable(true)
@@ -2380,6 +2407,10 @@ impl AlacritreeApp {
                                 let action = worktree_row(
                                     ui,
                                     wt,
+                                    pr_infos
+                                        .get(idx)
+                                        .and_then(|v| v.get(wt_idx))
+                                        .and_then(Option::as_ref),
                                     is_active,
                                     is_cursor,
                                     cursor_moved,
@@ -3805,9 +3836,24 @@ fn creating_row(ui: &mut egui::Ui, branch: &str, icons: &Icons, theme: &Theme) {
     });
 }
 
+/// Badge glyph, color, and tooltip word for a PR state.
+fn pr_badge<'a>(
+    icons: &'a Icons,
+    theme: &Theme,
+    state: PrState,
+) -> (&'a str, Color32, &'static str) {
+    match state {
+        PrState::Open => (&icons.pr_open, theme.pr_open, "open"),
+        PrState::Draft => (&icons.pr_draft, theme.pr_draft, "draft"),
+        PrState::Merged => (&icons.pr_merged, theme.pr_merged, "merged"),
+        PrState::Closed => (&icons.pr_closed, theme.pr_closed, "closed"),
+    }
+}
+
 fn worktree_row(
     ui: &mut egui::Ui,
     wt: &Worktree,
+    pr: Option<&PrInfo>,
     is_active: bool,
     is_cursor: bool,
     scroll_into_view: bool,
@@ -3883,6 +3929,19 @@ fn worktree_row(
                     spawn_rect = Some(btn.rect);
                     if btn.clicked() {
                         spawn_clicked = true;
+                    }
+                    if let Some(info) = pr {
+                        let (glyph, color, word) = pr_badge(icons, theme, info.state);
+                        let (rect, resp) = ui
+                            .allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
+                        ui.painter().text(
+                            rect.center(),
+                            egui::Align2::CENTER_CENTER,
+                            glyph,
+                            egui::FontId::proportional(10.0 * theme.ui_scale),
+                            color,
+                        );
+                        resp.on_hover_text(format!("PR #{} — {word}", info.number));
                     }
                 },
             );

--- a/alacritree/src/color_glyph.rs
+++ b/alacritree/src/color_glyph.rs
@@ -339,7 +339,7 @@ mod tests {
             .collect(),
             ..FontConfig::default()
         };
-        let chain = crate::fonts::install_terminal_fonts(ctx, &font);
+        let chain = crate::fonts::install_terminal_fonts(ctx, &font, None);
 
         let renders_emoji = chain.iter().find_map(|face| {
             let data = std::fs::read(&face.path).ok()?;
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     fn plain_text_is_left_to_egui() {
         let ctx = Context::default();
-        let chain = crate::fonts::install_terminal_fonts(&ctx, &FontConfig::default());
+        let chain = crate::fonts::install_terminal_fonts(&ctx, &FontConfig::default(), None);
         let mut cache = ColorGlyphCache::new(chain, 10);
         for c in ['A', 'z', '0', '─', '│'] {
             assert!(cache.get(&ctx, c, &metrics(), 1).is_none(), "{c} took the colour path");

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -307,8 +307,9 @@ pub struct Icons {
 }
 
 /// `[ui.focus_outline]`: stroke a border around a panel while it owns
-/// keyboard focus.  Per-panel toggles, shared color/thickness; both toggles
-/// default off so unmodified config keeps today's look.
+/// keyboard focus.  Per-panel toggles (`sidebar` covers both side panels),
+/// shared color/thickness; both toggles default off so unmodified config
+/// keeps today's look.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FocusOutline {
     pub sidebar: bool,

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -306,6 +306,26 @@ pub struct Icons {
     pub pr_closed: String,
 }
 
+/// `[ui.focus_outline]`: stroke a border around a panel while it owns
+/// keyboard focus.  Per-panel toggles, shared color/thickness; both toggles
+/// default off so unmodified config keeps today's look.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FocusOutline {
+    pub sidebar: bool,
+    pub terminal: bool,
+    /// `None` falls back to the theme accent at resolution time.
+    pub color: Option<Color32>,
+    /// Absolute logical pixels (deliberately not ui_scale-multiplied);
+    /// clamped to ≥ 0.5.
+    pub thickness: f32,
+}
+
+impl Default for FocusOutline {
+    fn default() -> Self {
+        Self { sidebar: false, terminal: false, color: None, thickness: 1.0 }
+    }
+}
+
 impl Default for Icons {
     fn default() -> Self {
         Self {
@@ -343,6 +363,7 @@ pub struct UiTheme {
     /// no auth, or no PR silently paints nothing.
     pub pr_status: bool,
     pub icons: Icons,
+    pub focus_outline: FocusOutline,
 }
 
 impl Default for UiTheme {
@@ -358,6 +379,7 @@ impl Default for UiTheme {
             session_display: SessionDisplay::default(),
             pr_status: true,
             icons: Icons::default(),
+            focus_outline: FocusOutline::default(),
         }
     }
 }
@@ -950,6 +972,15 @@ struct RawUiFont {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
+struct RawFocusOutline {
+    sidebar: Option<bool>,
+    terminal: Option<bool>,
+    color: Option<RgbStr>,
+    thickness: Option<f32>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 struct RawUi {
     sidebar_background: Option<RgbStr>,
     sidebar_foreground: Option<RgbStr>,
@@ -970,6 +1001,7 @@ struct RawUi {
     wsl: RawUiWsl,
     profiles: Vec<RawProfile>,
     default_profile: Option<String>,
+    focus_outline: RawFocusOutline,
 }
 
 /// One `[[ui.profiles]]` entry.  Fields are optional so a malformed entry
@@ -1102,6 +1134,12 @@ impl RawConfig {
             },
             pr_status: self.ui.pr_status.unwrap_or(true),
             icons: build_icons(self.ui.icons),
+            focus_outline: FocusOutline {
+                sidebar: self.ui.focus_outline.sidebar.unwrap_or(false),
+                terminal: self.ui.focus_outline.terminal.unwrap_or(false),
+                color: self.ui.focus_outline.color.map(|v| rgb_to_color32(v.0)),
+                thickness: self.ui.focus_outline.thickness.map_or(1.0, |t| t.max(0.5)),
+            },
         };
 
         // ---- Font ----
@@ -1677,5 +1715,32 @@ program = "second"
     fn pr_status_defaults_on_and_parses_off() {
         assert!(ui_from_toml("").pr_status);
         assert!(!ui_from_toml("[ui]\npr_status = false").pr_status);
+    }
+
+    #[test]
+    fn focus_outline_defaults_off() {
+        let fo = ui_from_toml("").focus_outline;
+        assert!(!fo.sidebar);
+        assert!(!fo.terminal);
+        assert_eq!(fo.color, None);
+        assert_eq!(fo.thickness, 1.0);
+    }
+
+    #[test]
+    fn focus_outline_parses_all_fields() {
+        let fo = ui_from_toml(
+            "[ui.focus_outline]\nsidebar = true\nterminal = true\ncolor = \"#89b4fa\"\nthickness = 2.5",
+        )
+        .focus_outline;
+        assert!(fo.sidebar);
+        assert!(fo.terminal);
+        assert_eq!(fo.color, Some(Color32::from_rgb(0x89, 0xb4, 0xfa)));
+        assert_eq!(fo.thickness, 2.5);
+    }
+
+    #[test]
+    fn focus_outline_thickness_clamps() {
+        let fo = ui_from_toml("[ui.focus_outline]\nthickness = 0.1").focus_outline;
+        assert_eq!(fo.thickness, 0.5);
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -359,8 +359,9 @@ pub struct UiTheme {
     /// Show single-session sidebar rows / tab segments ([`SessionDisplay`]).
     pub session_display: SessionDisplay,
     /// Paint PR-status badges on worktree rows (and poll `gh` for expanded
-    /// projects' worktrees).  Best-effort like the diff-base lookup: no `gh`,
-    /// no auth, or no PR silently paints nothing.
+    /// projects' worktrees).  Off by default so an unmodified config spawns
+    /// no `gh` processes; when enabled it is best-effort like the diff-base
+    /// lookup: no `gh`, no auth, or no PR silently paints nothing.
     pub pr_status: bool,
     pub icons: Icons,
     pub focus_outline: FocusOutline,
@@ -377,7 +378,7 @@ impl Default for UiTheme {
             confirm_session_close: ConfirmSessionClose::Never,
             last_session_close: LastSessionClose::Respawn,
             session_display: SessionDisplay::default(),
-            pr_status: true,
+            pr_status: false,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
         }
@@ -1132,7 +1133,7 @@ impl RawConfig {
                 sidebar_always: self.ui.session_display.sidebar_always.unwrap_or(false),
                 tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
             },
-            pr_status: self.ui.pr_status.unwrap_or(true),
+            pr_status: self.ui.pr_status.unwrap_or(false),
             icons: build_icons(self.ui.icons),
             focus_outline: FocusOutline {
                 sidebar: self.ui.focus_outline.sidebar.unwrap_or(false),
@@ -1716,9 +1717,9 @@ program = "second"
     }
 
     #[test]
-    fn pr_status_defaults_on_and_parses_off() {
-        assert!(ui_from_toml("").pr_status);
-        assert!(!ui_from_toml("[ui]\npr_status = false").pr_status);
+    fn pr_status_defaults_off_and_parses_on() {
+        assert!(!ui_from_toml("").pr_status);
+        assert!(ui_from_toml("[ui]\npr_status = true").pr_status);
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -242,20 +242,6 @@ fn parse_confirm_session_close(raw: Option<&str>) -> ConfirmSessionClose {
 /// resolves through the system fallback chain `fonts.rs` registers.
 const DEFAULT_SEARCH_ICON: &str = "⌕";
 
-/// Sidebar glyphs overridable via `[ui.icons]`, for users whose fonts carry
-/// nicer symbols (Nerd Fonts etc.).
-#[derive(Debug, Clone)]
-pub struct UiIcons {
-    /// Glyph prefixing the sidebar search prompt.
-    pub search: String,
-}
-
-impl Default for UiIcons {
-    fn default() -> Self {
-        Self { search: DEFAULT_SEARCH_ICON.into() }
-    }
-}
-
 /// What happens when the on-screen workspace's last session closes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LastSessionClose {
@@ -300,6 +286,44 @@ pub struct UiFont {
     pub size: Option<f32>,
 }
 
+/// Sidebar status glyphs, each independently overridable from `[ui.icons]`.
+/// Overrides are trimmed and a blank value falls back to the default, so a
+/// row marker can never be rendered empty.  Action buttons (×, +, ↻, ⇅) are
+/// controls, not status, and stay fixed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Icons {
+    /// Glyph prefixing the sidebar search prompt.
+    pub search: String,
+    pub worktree_main: String,
+    pub worktree: String,
+    pub session: String,
+    pub home: String,
+    pub project_expanded: String,
+    pub project_collapsed: String,
+    pub pr_open: String,
+    pub pr_draft: String,
+    pub pr_merged: String,
+    pub pr_closed: String,
+}
+
+impl Default for Icons {
+    fn default() -> Self {
+        Self {
+            search: DEFAULT_SEARCH_ICON.into(),
+            worktree_main: "●".into(),
+            worktree: "○".into(),
+            session: "▪".into(),
+            home: "⌂".into(),
+            project_expanded: "▾".into(),
+            project_collapsed: "▸".into(),
+            pr_open: "⬤".into(),
+            pr_draft: "◯".into(),
+            pr_merged: "⬤".into(),
+            pr_closed: "⬤".into(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct UiTheme {
     pub sidebar_background: Option<Color32>,
@@ -314,7 +338,7 @@ pub struct UiTheme {
     pub last_session_close: LastSessionClose,
     /// Show single-session sidebar rows / tab segments ([`SessionDisplay`]).
     pub session_display: SessionDisplay,
-    pub icons: UiIcons,
+    pub icons: Icons,
 }
 
 impl Default for UiTheme {
@@ -328,7 +352,7 @@ impl Default for UiTheme {
             confirm_session_close: ConfirmSessionClose::Never,
             last_session_close: LastSessionClose::Respawn,
             session_display: SessionDisplay::default(),
-            icons: UiIcons::default(),
+            icons: Icons::default(),
         }
     }
 }
@@ -851,15 +875,6 @@ struct RawIndexed {
     color: RgbStr,
 }
 
-/// `[ui.icons]`: sidebar glyph overrides.  Any string works, so Nerd Font
-/// users can substitute their own icons.
-#[derive(Debug, Default, Deserialize)]
-#[serde(default)]
-struct RawUiIcons {
-    /// Glyph prefixing the sidebar search prompt.
-    search: Option<String>,
-}
-
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 struct RawUiWsl {
@@ -868,6 +883,48 @@ struct RawUiWsl {
     /// from inside a distro); `wsl.exe --cd` translates with the distro's
     /// real mount table regardless of this value.
     automount_root: Option<String>,
+}
+
+/// `[ui.icons]`: sidebar glyph overrides.  Any string works, so Nerd Font
+/// users can substitute their own icons.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RawIcons {
+    search: Option<String>,
+    worktree_main: Option<String>,
+    worktree: Option<String>,
+    session: Option<String>,
+    home: Option<String>,
+    project_expanded: Option<String>,
+    project_collapsed: Option<String>,
+    pr_open: Option<String>,
+    pr_draft: Option<String>,
+    pr_merged: Option<String>,
+    pr_closed: Option<String>,
+}
+
+/// A trimmed, non-blank override — or the default.
+fn icon_or(raw: Option<String>, default: &str) -> String {
+    raw.map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn build_icons(raw: RawIcons) -> Icons {
+    let d = Icons::default();
+    Icons {
+        search: icon_or(raw.search, &d.search),
+        worktree_main: icon_or(raw.worktree_main, &d.worktree_main),
+        worktree: icon_or(raw.worktree, &d.worktree),
+        session: icon_or(raw.session, &d.session),
+        home: icon_or(raw.home, &d.home),
+        project_expanded: icon_or(raw.project_expanded, &d.project_expanded),
+        project_collapsed: icon_or(raw.project_collapsed, &d.project_collapsed),
+        pr_open: icon_or(raw.pr_open, &d.pr_open),
+        pr_draft: icon_or(raw.pr_draft, &d.pr_draft),
+        pr_merged: icon_or(raw.pr_merged, &d.pr_merged),
+        pr_closed: icon_or(raw.pr_closed, &d.pr_closed),
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -902,7 +959,7 @@ struct RawUi {
     last_session_close: Option<String>,
     session_display: RawSessionDisplay,
     delta_path: Option<String>,
-    icons: RawUiIcons,
+    icons: RawIcons,
     font: RawUiFont,
     wsl: RawUiWsl,
     profiles: Vec<RawProfile>,
@@ -1037,9 +1094,7 @@ impl RawConfig {
                 sidebar_always: self.ui.session_display.sidebar_always.unwrap_or(false),
                 tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
             },
-            icons: UiIcons {
-                search: self.ui.icons.search.unwrap_or_else(|| DEFAULT_SEARCH_ICON.into()),
-            },
+            icons: build_icons(self.ui.icons),
         };
 
         // ---- Font ----
@@ -1582,5 +1637,32 @@ program = "second"
     fn blank_ui_font_family_is_ignored() {
         let config = parse("[ui.font]\nfamily = \"  \"");
         assert_eq!(config.ui_font.family, None);
+    }
+
+    #[test]
+    fn icons_default_to_todays_glyphs() {
+        let ui = ui_from_toml("");
+        assert_eq!(ui.icons, Icons::default());
+        assert_eq!(ui.icons.worktree_main, "●");
+        assert_eq!(ui.icons.worktree, "○");
+        assert_eq!(ui.icons.session, "▪");
+        assert_eq!(ui.icons.home, "⌂");
+        assert_eq!(ui.icons.project_expanded, "▾");
+        assert_eq!(ui.icons.project_collapsed, "▸");
+    }
+
+    #[test]
+    fn icon_overrides_apply_and_trim() {
+        let ui = ui_from_toml("[ui.icons]\nworktree = \" W \"\nhome = \"H\"");
+        assert_eq!(ui.icons.worktree, "W");
+        assert_eq!(ui.icons.home, "H");
+        assert_eq!(ui.icons.worktree_main, "●", "untouched fields keep defaults");
+    }
+
+    #[test]
+    fn blank_icon_override_falls_back() {
+        let ui = ui_from_toml("[ui.icons]\nworktree_main = \"   \"\nsession = \"\"");
+        assert_eq!(ui.icons.worktree_main, "●");
+        assert_eq!(ui.icons.session, "▪");
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -338,6 +338,10 @@ pub struct UiTheme {
     pub last_session_close: LastSessionClose,
     /// Show single-session sidebar rows / tab segments ([`SessionDisplay`]).
     pub session_display: SessionDisplay,
+    /// Paint PR-status badges on worktree rows (and poll `gh` for expanded
+    /// projects' worktrees).  Best-effort like the diff-base lookup: no `gh`,
+    /// no auth, or no PR silently paints nothing.
+    pub pr_status: bool,
     pub icons: Icons,
 }
 
@@ -352,6 +356,7 @@ impl Default for UiTheme {
             confirm_session_close: ConfirmSessionClose::Never,
             last_session_close: LastSessionClose::Respawn,
             session_display: SessionDisplay::default(),
+            pr_status: true,
             icons: Icons::default(),
         }
     }
@@ -960,6 +965,7 @@ struct RawUi {
     session_display: RawSessionDisplay,
     delta_path: Option<String>,
     icons: RawIcons,
+    pr_status: Option<bool>,
     font: RawUiFont,
     wsl: RawUiWsl,
     profiles: Vec<RawProfile>,
@@ -1094,6 +1100,7 @@ impl RawConfig {
                 sidebar_always: self.ui.session_display.sidebar_always.unwrap_or(false),
                 tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
             },
+            pr_status: self.ui.pr_status.unwrap_or(true),
             icons: build_icons(self.ui.icons),
         };
 
@@ -1664,5 +1671,11 @@ program = "second"
         let ui = ui_from_toml("[ui.icons]\nworktree_main = \"   \"\nsession = \"\"");
         assert_eq!(ui.icons.worktree_main, "●");
         assert_eq!(ui.icons.session, "▪");
+    }
+
+    #[test]
+    fn pr_status_defaults_on_and_parses_off() {
+        assert!(ui_from_toml("").pr_status);
+        assert!(!ui_from_toml("[ui]\npr_status = false").pr_status);
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -1694,6 +1694,10 @@ program = "second"
         assert_eq!(ui.icons.home, "⌂");
         assert_eq!(ui.icons.project_expanded, "▾");
         assert_eq!(ui.icons.project_collapsed, "▸");
+        assert_eq!(ui.icons.pr_open, "⬤");
+        assert_eq!(ui.icons.pr_draft, "◯");
+        assert_eq!(ui.icons.pr_merged, "⬤");
+        assert_eq!(ui.icons.pr_closed, "⬤");
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -26,6 +26,7 @@ use crate::bindings::{self, KeyBinding};
 pub struct Config {
     pub palette: Palette,
     pub ui: UiTheme,
+    pub ui_font: UiFont,
     pub workspace: WorkspaceConfig,
     pub font: FontConfig,
     pub cursor: CursorConfig,
@@ -289,6 +290,16 @@ pub struct SessionDisplay {
     pub tabs_always: bool,
 }
 
+/// alacritree-only `[ui.font]`: font family/size for the chrome (sidebars,
+/// modals — everything that isn't the terminal grid).  Both fields default
+/// to deriving from `[font]`, so an absent table changes nothing.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct UiFont {
+    pub family: Option<String>,
+    /// Typographic points, same unit as `[font] size`; clamped to ≥ 1.0.
+    pub size: Option<f32>,
+}
+
 #[derive(Debug, Clone)]
 pub struct UiTheme {
     pub sidebar_background: Option<Color32>,
@@ -364,6 +375,7 @@ impl Default for Config {
         Self {
             palette: Palette::default(),
             ui: UiTheme::default(),
+            ui_font: UiFont::default(),
             workspace: WorkspaceConfig::default(),
             font: FontConfig::default(),
             cursor: CursorConfig::default(),
@@ -869,6 +881,13 @@ struct RawSessionDisplay {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
+struct RawUiFont {
+    family: Option<String>,
+    size: Option<f32>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 struct RawUi {
     sidebar_background: Option<RgbStr>,
     sidebar_foreground: Option<RgbStr>,
@@ -884,6 +903,7 @@ struct RawUi {
     session_display: RawSessionDisplay,
     delta_path: Option<String>,
     icons: RawUiIcons,
+    font: RawUiFont,
     wsl: RawUiWsl,
     profiles: Vec<RawProfile>,
     default_profile: Option<String>,
@@ -1138,6 +1158,12 @@ impl RawConfig {
             .filter(|r| r.starts_with('/') && r.len() > 1)
             .unwrap_or_else(|| "/mnt".to_string());
 
+        // ---- UI Font ----
+        let ui_font = UiFont {
+            family: self.ui.font.family.clone().filter(|f| !f.trim().is_empty()),
+            size: self.ui.font.size.map(|s| s.max(1.0)),
+        };
+
         // ---- Profiles ----
         let profiles = build_profiles(self.ui.profiles);
         let default_profile = self.ui.default_profile.filter(|n| {
@@ -1151,6 +1177,7 @@ impl RawConfig {
         Config {
             palette,
             ui,
+            ui_font,
             workspace,
             font,
             cursor,
@@ -1530,5 +1557,30 @@ program = "second"
         let sd = raw.into_config().ui.session_display;
         assert!(sd.sidebar_always);
         assert!(sd.tabs_always);
+    }
+
+    #[test]
+    fn ui_font_defaults_to_none() {
+        let config = parse("");
+        assert_eq!(config.ui_font, UiFont::default());
+    }
+
+    #[test]
+    fn ui_font_parses_family_and_size() {
+        let config = parse("[ui.font]\nfamily = \"Inter\"\nsize = 12.5");
+        assert_eq!(config.ui_font.family.as_deref(), Some("Inter"));
+        assert_eq!(config.ui_font.size, Some(12.5));
+    }
+
+    #[test]
+    fn ui_font_size_clamps_to_one() {
+        let config = parse("[ui.font]\nsize = 0.1");
+        assert_eq!(config.ui_font.size, Some(1.0));
+    }
+
+    #[test]
+    fn blank_ui_font_family_is_ignored() {
+        let config = parse("[ui.font]\nfamily = \"  \"");
+        assert_eq!(config.ui_font.family, None);
     }
 }

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -36,6 +36,11 @@ const BOLD_FONT_ID: &str = "alacritree_terminal_bold";
 const ITALIC_FONT_ID: &str = "alacritree_terminal_italic";
 const BOLD_ITALIC_FONT_ID: &str = "alacritree_terminal_bold_italic";
 
+const UI_FONT_ID: &str = "alacritree_ui_normal";
+/// Temporary family the UI chain is assembled under before being spliced to
+/// the head of `Proportional`; removed again so it never leaks to egui.
+const UI_FAMILY: &str = "alacritree_ui";
+
 #[derive(Clone, Copy)]
 enum Variant {
     Normal,
@@ -574,10 +579,62 @@ fn fallback_tweak(primary_ratio: Option<f32>, data: &[u8], index: u32) -> FontTw
     FontTweak { scale, ..FontTweak::default() }
 }
 
+/// Put the `[ui.font]` family — and its own fallback chain — ahead of the
+/// terminal font in egui's `Proportional` family, so all chrome text prefers
+/// it.  `Monospace` (the grid) is untouched.  Returns `false` and leaves the
+/// definitions unchanged when the family cannot be resolved or read, in which
+/// case the chrome keeps using the terminal font.
+fn install_ui_font(defs: &mut FontDefinitions, family_or_path: &str, fonts: &SystemFonts) -> bool {
+    let Some(resolved) = resolve_face(family_or_path, None, Variant::Normal, fonts) else {
+        log::warn!("could not resolve ui font '{family_or_path}'; keeping the terminal font");
+        return false;
+    };
+    let bytes = match map_font_file(&resolved.path) {
+        Ok(b) => b,
+        Err(e) => {
+            log::warn!("could not read ui font file {}: {e}", resolved.path.display());
+            return false;
+        },
+    };
+    insert_face(defs, UI_FONT_ID, bytes);
+    let ui_family = FontFamily::Name(UI_FAMILY.into());
+    defs.families.insert(ui_family.clone(), vec![UI_FONT_ID.to_string()]);
+
+    // Its own book: the UI chain must not leak into the terminal's normal
+    // chain (which feeds the colour-glyph renderer), and fallback height
+    // normalization must anchor to the UI face, not the terminal face.
+    let mut book = FallbackBook::default();
+    book.loaded_paths.insert(resolved.path.clone());
+    book.primary_height_ratio = face_height_ratio(bytes, resolved.face_index);
+    let targets = [ui_family.clone()];
+    register_fallback_faces(
+        defs,
+        family_or_path,
+        None,
+        Variant::Normal,
+        &targets,
+        fonts,
+        &mut book,
+    );
+
+    // Splice the assembled UI chain ahead of everything already in
+    // `Proportional` (terminal font + its fallbacks).
+    let ui_ids = defs.families.remove(&ui_family).unwrap_or_default();
+    let prop = defs.families.entry(FontFamily::Proportional).or_default();
+    for id in ui_ids.into_iter().rev() {
+        prop.insert(0, id);
+    }
+    true
+}
+
 /// Register the terminal faces with egui and return the normal-variant
 /// fallback chain, in the order egui consults it, for the colour glyph
 /// renderer to resolve against.
-pub fn install_terminal_fonts(ctx: &Context, font: &FontConfig) -> Vec<ChainFace> {
+pub fn install_terminal_fonts(
+    ctx: &Context,
+    font: &FontConfig,
+    ui_family: Option<&str>,
+) -> Vec<ChainFace> {
     let (normal, bold, italic, bold_italic) =
         (&font.normal, &font.bold, &font.italic, &font.bold_italic);
     let family = normal.family.as_deref().unwrap_or(DEFAULT_FAMILY);
@@ -671,6 +728,10 @@ pub fn install_terminal_fonts(ctx: &Context, font: &FontConfig) -> Vec<ChainFace
     for (family, style, variant, targets) in seeds {
         register_user_fallbacks(&mut defs, &font.fallback, variant, targets, &fonts, &mut book);
         register_fallback_faces(&mut defs, family, style, variant, targets, &fonts, &mut book);
+    }
+
+    if let Some(ui_family) = ui_family {
+        install_ui_font(&mut defs, ui_family, &fonts);
     }
 
     ctx.set_fonts(defs);
@@ -1122,6 +1183,38 @@ mod tests {
         assert!(defs.families[&FontFamily::Name(BOLD_FAMILY.into())].contains(id));
 
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn ui_font_heads_the_proportional_family() {
+        let path = std::env::temp_dir().join("alacritree_test_ui_font.ttf");
+        std::fs::write(&path, b"registration only maps bytes").unwrap();
+
+        let mut defs = FontDefinitions::default();
+        let fonts = SystemFonts::with_cache_dir(None);
+        let mono_before = defs.families[&FontFamily::Monospace].clone();
+
+        assert!(install_ui_font(&mut defs, path.to_string_lossy().as_ref(), &fonts));
+
+        let prop = &defs.families[&FontFamily::Proportional];
+        assert_eq!(prop.first().map(String::as_str), Some(UI_FONT_ID));
+        // The grid's family is untouched.
+        assert_eq!(defs.families[&FontFamily::Monospace], mono_before);
+        // The temporary splice family does not leak into the definitions.
+        assert!(!defs.families.contains_key(&FontFamily::Name(UI_FAMILY.into())));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn unresolvable_ui_font_changes_nothing() {
+        let mut defs = FontDefinitions::default();
+        let fonts = SystemFonts::with_cache_dir(None);
+        let before = defs.families[&FontFamily::Proportional].clone();
+
+        assert!(!install_ui_font(&mut defs, "alacritree-no-such-ui-family-9f3a", &fonts));
+
+        assert_eq!(defs.families[&FontFamily::Proportional], before);
     }
 
     // epaint clones the whole buffer of every `Cow::Owned` face it parses, so

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -58,7 +58,7 @@ struct Entry {
 }
 
 struct LookupResult {
-    branch: Option<String>,
+    branch: String,
     info: Option<PrInfo>,
 }
 
@@ -88,39 +88,51 @@ impl PrCache {
         // refresh — a result that just arrived shouldn't be ignored.
         if let Some(rx) = entry.pending.as_ref() {
             if let Ok(result) = rx.try_recv() {
-                entry.branch = result.branch;
+                entry.branch = Some(result.branch);
                 entry.info = result.info;
                 entry.queried_at = Some(Instant::now());
                 entry.pending = None;
             }
         }
 
-        let branch_matches = entry.branch.as_deref() == branch;
-        let fresh = entry.queried_at.map_or(false, |when| when.elapsed() < TTL);
-        let needs_refresh = !branch_matches || !fresh;
+        // A `None` poll (the git-status compute hasn't produced a branch
+        // yet, or never will) carries no information about the current
+        // branch, so it must not evict or refresh a lookup keyed to a real
+        // one from another caller — just read whatever is cached.
+        let Some(branch) = branch else {
+            return entry.info.clone();
+        };
 
-        if needs_refresh && entry.pending.is_none() {
+        let invalidate = should_invalidate(entry.branch.as_deref(), Some(branch));
+        let fresh = entry.queried_at.map_or(false, |when| when.elapsed() < TTL);
+
+        if (invalidate || !fresh) && entry.pending.is_none() {
             // Clear stale data immediately on branch switch so we don't show
             // a PR base that belongs to a different branch.
-            if !branch_matches {
+            if invalidate {
                 entry.info = None;
             }
-            entry.pending =
-                Some(spawn_lookup(path.to_path_buf(), branch.map(str::to_string), ctx.clone()));
+            entry.pending = Some(spawn_lookup(path.to_path_buf(), branch.to_string(), ctx.clone()));
         }
 
         entry.info.clone()
     }
 }
 
-fn spawn_lookup(
-    path: PathBuf,
-    branch: Option<String>,
-    ctx: egui::Context,
-) -> Receiver<LookupResult> {
+/// A `None` incoming branch never invalidates — the caller has nothing to
+/// compare against. A `Some` branch that disagrees with the cached one means
+/// a real branch switch and must invalidate.
+fn should_invalidate(cached_branch: Option<&str>, incoming_branch: Option<&str>) -> bool {
+    match incoming_branch {
+        None => false,
+        Some(_) => cached_branch != incoming_branch,
+    }
+}
+
+fn spawn_lookup(path: PathBuf, branch: String, ctx: egui::Context) -> Receiver<LookupResult> {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
-        let info = branch.as_deref().and_then(|b| query_gh(&path, b));
+        let info = query_gh(&path, &branch);
         let _ = tx.send(LookupResult { branch, info });
         ctx.request_repaint();
     });
@@ -224,5 +236,53 @@ mod tests {
         let stdout =
             br#"{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}"#;
         assert_eq!(parse_gh_output(stdout).unwrap().state, PrState::Open);
+    }
+
+    fn sample_info() -> PrInfo {
+        PrInfo {
+            number: 7,
+            base_branch: "main".to_string(),
+            url: "https://github.com/o/r/pull/7".to_string(),
+            state: PrState::Open,
+        }
+    }
+
+    #[test]
+    fn none_branch_does_not_invalidate_a_cached_branch() {
+        assert!(!should_invalidate(Some("b"), None));
+    }
+
+    #[test]
+    fn mismatched_branch_invalidates() {
+        assert!(should_invalidate(Some("b"), Some("a")));
+    }
+
+    #[test]
+    fn matching_branch_does_not_invalidate() {
+        assert!(!should_invalidate(Some("b"), Some("b")));
+    }
+
+    #[test]
+    fn polling_with_none_retains_info_from_a_completed_some_branch_lookup() {
+        let mut cache = PrCache::new();
+        let path = PathBuf::from("/repo");
+        cache.entries.insert(
+            path.clone(),
+            Entry {
+                branch: Some("b".to_string()),
+                info: Some(sample_info()),
+                queried_at: Some(Instant::now()),
+                pending: None,
+            },
+        );
+
+        let ctx = egui::Context::default();
+        let result = cache.poll(&path, None, &ctx);
+
+        assert_eq!(result.map(|info| info.number), Some(7));
+        let entry = cache.entries.get(&path).unwrap();
+        assert_eq!(entry.branch.as_deref(), Some("b"));
+        assert!(entry.info.is_some(), "None poll must not clear the cached info");
+        assert!(entry.pending.is_none(), "None poll must not spawn a competing lookup");
     }
 }

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -24,11 +24,22 @@ use crate::wsl;
 /// `gh` on every status refresh.
 const TTL: Duration = Duration::from_secs(300);
 
+/// GitHub's PR lifecycle, folded to what the sidebar paints.  `gh` reports
+/// draftness as a separate boolean, so OPEN splits into Open/Draft here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrState {
+    Open,
+    Draft,
+    Merged,
+    Closed,
+}
+
 #[derive(Debug, Clone)]
 pub struct PrInfo {
     pub number: u64,
     pub base_branch: String,
     pub url: String,
+    pub state: PrState,
 }
 
 #[derive(Default)]
@@ -116,6 +127,17 @@ fn spawn_lookup(
     rx
 }
 
+fn pr_state(state: &str, is_draft: bool) -> PrState {
+    match state {
+        "MERGED" => PrState::Merged,
+        "CLOSED" => PrState::Closed,
+        "OPEN" if is_draft => PrState::Draft,
+        // Unknown states paint as open rather than vanishing; gh's enum is
+        // stable, so this is a forward-compatibility hedge, not a real case.
+        _ => PrState::Open,
+    }
+}
+
 /// Ask `gh` for the PR associated with `branch` in `path`.  Returns `None`
 /// on any failure mode (no `gh`, not authenticated, no PR, non-GitHub
 /// remote, ...).  The branch is passed as a positional selector so the
@@ -138,7 +160,7 @@ fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
         },
     };
     let output = cmd
-        .args(["pr", "view", branch, "--json", "number,baseRefName,url"])
+        .args(["pr", "view", branch, "--json", "number,baseRefName,url,state,isDraft"])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .stdin(Stdio::null())
@@ -155,7 +177,9 @@ fn parse_gh_output(stdout: &[u8]) -> Option<PrInfo> {
     let number = value.get("number")?.as_u64()?;
     let base = value.get("baseRefName")?.as_str()?.to_string();
     let url = value.get("url")?.as_str()?.to_string();
-    Some(PrInfo { number, base_branch: base, url })
+    let state = value.get("state").and_then(|v| v.as_str()).unwrap_or("OPEN");
+    let is_draft = value.get("isDraft").and_then(|v| v.as_bool()).unwrap_or(false);
+    Some(PrInfo { number, base_branch: base, url, state: pr_state(state, is_draft) })
 }
 
 #[cfg(test)]
@@ -175,5 +199,30 @@ mod tests {
     #[test]
     fn rejects_empty_output() {
         assert!(parse_gh_output(b"").is_none());
+    }
+
+    #[test]
+    fn parses_pr_states() {
+        for (json_state, is_draft, expected) in [
+            ("OPEN", false, PrState::Open),
+            ("OPEN", true, PrState::Draft),
+            ("MERGED", false, PrState::Merged),
+            ("CLOSED", false, PrState::Closed),
+            ("SOMETHING_NEW", false, PrState::Open),
+        ] {
+            let stdout = format!(
+                r#"{{"baseRefName":"main","number":1,"url":"https://github.com/o/r/pull/1","state":"{json_state}","isDraft":{is_draft}}}"#
+            );
+            let info = parse_gh_output(stdout.as_bytes()).unwrap();
+            assert_eq!(info.state, expected, "state={json_state} draft={is_draft}");
+        }
+    }
+
+    #[test]
+    fn missing_state_fields_default_to_open() {
+        // Old gh versions may omit fields we didn't ask for; degrade, don't drop.
+        let stdout =
+            br#"{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}"#;
+        assert_eq!(parse_gh_output(stdout).unwrap().state, PrState::Open);
     }
 }


### PR DESCRIPTION
Four opt-in appearance features; an unmodified config keeps today's behavior bit-for-bit.

- `[ui.font]` — independent chrome font family/size. The family (or file path) resolves through the existing face machinery and is spliced, with its own height-normalized fallback chain, ahead of the terminal font in egui's Proportional family; the grid's Monospace is untouched. `size` drives normal/heading text and `ui_scale`. Restart required (fonts install once), same caveat as window transparency.
- `[ui.icons]` — every sidebar status glyph is overridable (worktree/session/home markers, project arrows, PR badges, and the search glyph, unified with the existing `search` entry). Overrides are trimmed; blank falls back to the default.
- PR status badges — worktree rows whose branch has a PR paint a state-colored glyph (open green, draft muted, merged magenta, closed red) with a `PR #n — state` tooltip. Reuses PrCache's throttled background `gh` lookups, polls only expanded projects, and both pollers share the live branch source on the active workspace so they can never invalidate each other's lookups. Off by default (`[ui] pr_status = true` to enable) so unmodified configs spawn no `gh` processes.
- `[ui.focus_outline]` — per-panel outline (projects sidebar / terminal) while it owns keyboard focus; shared color (default: accent) and thickness; hidden while a modal is open. Both toggles default off.

Tests: 347 passed / 0 failed / 1 ignored at tip; rustfmt clean. Rebased onto a9dc31c1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)