### PR TITLE
[6] feat(sidebar): templated worktree and project names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
+ "subst",
  "swash",
  "sysinfo",
  "tempfile",
@@ -3558,6 +3559,16 @@ dependencies = [
  "quote",
  "rustversion",
  "syn",
+]
+
+[[package]]
+name = "subst"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9a86e5144f63c2d18334698269a8bfae6eece345c70b64821ea5b35054ec99"
+dependencies = [
+ "memchr",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -17,6 +17,10 @@ git2 = { version = "0.20", default-features = false }
 rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "async-std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Shell-style $var / ${var} / ${var:fallback} substitution for the sidebar's
+# templated row names.  Chosen over a template engine: the fallback syntax is
+# the whole feature, and its deps are already in the workspace lockfile.
+subst = { version = "0.3", default-features = false }
 toml = { workspace = true }
 xdg = "3.0.0"
 home = "0.5.5"

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -295,6 +295,8 @@ pub struct AlacritreeApp {
     projects: Vec<Project>,
     git_status: HashMap<PathBuf, StatusCache>,
     pr_cache: PrCache,
+    /// Renders `[ui] worktree_name` / `project_name` templates at paint time.
+    row_labels: crate::row_label::LabelTemplates,
     config: Config,
     theme: Theme,
     last_error: Option<String>,
@@ -554,6 +556,11 @@ impl AlacritreeApp {
         // ever spawn one app per process, ignoring the error is fine.
         let _ = NOTIFY_TX.set(Mutex::new(notify_tx));
 
+        let row_labels = crate::row_label::LabelTemplates::new(
+            config.ui.worktree_name.clone(),
+            config.ui.project_name.clone(),
+        );
+
         let mut app = Self {
             show_left_sidebar: persisted.show_left_sidebar,
             show_right_sidebar: persisted.show_right_sidebar,
@@ -580,6 +587,7 @@ impl AlacritreeApp {
             projects,
             git_status: HashMap::new(),
             pr_cache: PrCache::new(),
+            row_labels,
             config,
             theme,
             last_error: None,
@@ -2114,6 +2122,18 @@ impl AlacritreeApp {
         let icons = self.config.ui.icons.clone();
         let profile_names: Vec<String> =
             self.config.profiles.iter().map(|p| p.name.clone()).collect();
+        // Rendered up front: the panel closure borrows `projects` mutably, and
+        // substitution over short strings is microseconds, so no cache is kept.
+        let mut project_labels: Vec<String> = Vec::with_capacity(self.projects.len());
+        let mut worktree_labels: Vec<Vec<String>> = Vec::with_capacity(self.projects.len());
+        for project in &self.projects {
+            project_labels.push(self.row_labels.project_label(project));
+            let mut rows = Vec::with_capacity(project.worktrees.len());
+            for wt in &project.worktrees {
+                rows.push(self.row_labels.worktree_label(wt));
+            }
+            worktree_labels.push(rows);
+        }
         let mut shell_override_changed: Option<PathBuf> = None;
         let mut label_cleared: Option<PathBuf> = None;
         let mut rename_request: Option<RenameState> = None;
@@ -2277,10 +2297,15 @@ impl AlacritreeApp {
                                 name_resp = Some(
                                     ui.add(
                                         egui::Label::new(
-                                            RichText::new(project.display_name())
-                                                .color(theme.text)
-                                                .strong()
-                                                .small(),
+                                            RichText::new(
+                                                project_labels
+                                                    .get(idx)
+                                                    .map(String::as_str)
+                                                    .unwrap_or(project.display_name()),
+                                            )
+                                            .color(theme.text)
+                                            .strong()
+                                            .small(),
                                         )
                                         .truncate()
                                         .sense(egui::Sense::click()),
@@ -2458,6 +2483,11 @@ impl AlacritreeApp {
                                 let action = worktree_row(
                                     ui,
                                     wt,
+                                    worktree_labels
+                                        .get(idx)
+                                        .and_then(|v| v.get(wt_idx))
+                                        .map(String::as_str)
+                                        .unwrap_or(&wt.name),
                                     pr_infos
                                         .get(idx)
                                         .and_then(|v| v.get(wt_idx))
@@ -3904,6 +3934,7 @@ fn pr_badge<'a>(
 fn worktree_row(
     ui: &mut egui::Ui,
     wt: &Worktree,
+    display_name: &str,
     pr: Option<&PrInfo>,
     is_active: bool,
     is_cursor: bool,
@@ -3947,7 +3978,7 @@ fn worktree_row(
                         is_active,
                     );
                     ui.add(
-                        egui::Label::new(RichText::new(&wt.name).color(name_color).small())
+                        egui::Label::new(RichText::new(display_name).color(name_color).small())
                             .truncate(),
                     );
                 },

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2122,18 +2122,6 @@ impl AlacritreeApp {
         let icons = self.config.ui.icons.clone();
         let profile_names: Vec<String> =
             self.config.profiles.iter().map(|p| p.name.clone()).collect();
-        // Rendered up front: the panel closure borrows `projects` mutably, and
-        // substitution over short strings is microseconds, so no cache is kept.
-        let mut project_labels: Vec<String> = Vec::with_capacity(self.projects.len());
-        let mut worktree_labels: Vec<Vec<String>> = Vec::with_capacity(self.projects.len());
-        for project in &self.projects {
-            project_labels.push(self.row_labels.project_label(project));
-            let mut rows = Vec::with_capacity(project.worktrees.len());
-            for wt in &project.worktrees {
-                rows.push(self.row_labels.worktree_label(wt));
-            }
-            worktree_labels.push(rows);
-        }
         let mut shell_override_changed: Option<PathBuf> = None;
         let mut label_cleared: Option<PathBuf> = None;
         let mut rename_request: Option<RenameState> = None;
@@ -2175,6 +2163,19 @@ impl AlacritreeApp {
                 rows.push(info);
             }
             pr_infos.push(rows);
+        }
+        // Rendered up front: the panel closure borrows `projects` mutably, and
+        // substitution over short strings is microseconds, so no cache is kept.
+        // After `pr_infos` so `$pr` sees this frame's PR numbers.
+        let mut project_labels: Vec<String> = Vec::with_capacity(self.projects.len());
+        let mut worktree_labels: Vec<Vec<String>> = Vec::with_capacity(self.projects.len());
+        for (project, prs) in self.projects.iter().zip(&pr_infos) {
+            project_labels.push(self.row_labels.project_label(project));
+            let mut rows = Vec::with_capacity(project.worktrees.len());
+            for (wt, pr) in project.worktrees.iter().zip(prs) {
+                rows.push(self.row_labels.worktree_label(wt, pr.as_ref()));
+            }
+            worktree_labels.push(rows);
         }
 
         let panel_resp = SidePanel::left("left_sidebar")

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -366,6 +366,13 @@ pub struct UiTheme {
     pub pr_status: bool,
     pub icons: Icons,
     pub focus_outline: FocusOutline,
+    /// `[ui] worktree_name`: template for worktree row labels (subst syntax:
+    /// `$name`, `$branch`, `$path`, `${var:fallback}`).  `None` keeps the plain
+    /// worktree name.
+    pub worktree_name: Option<String>,
+    /// `[ui] project_name`: template for project row labels (`$name`, `$path`).
+    /// A manual rename (`Project.label`) always wins over the template.
+    pub project_name: Option<String>,
 }
 
 impl Default for UiTheme {
@@ -382,6 +389,8 @@ impl Default for UiTheme {
             pr_status: false,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
+            worktree_name: None,
+            project_name: None,
         }
     }
 }
@@ -1000,6 +1009,8 @@ struct RawUi {
     icons: RawIcons,
     pr_status: Option<bool>,
     font: RawUiFont,
+    worktree_name: Option<String>,
+    project_name: Option<String>,
     wsl: RawUiWsl,
     profiles: Vec<RawProfile>,
     default_profile: Option<String>,
@@ -1142,6 +1153,8 @@ impl RawConfig {
                 color: self.ui.focus_outline.color.map(|v| rgb_to_color32(v.0)),
                 thickness: self.ui.focus_outline.thickness.map_or(1.0, |t| t.max(0.5)),
             },
+            worktree_name: self.ui.worktree_name.clone().filter(|t| !t.trim().is_empty()),
+            project_name: self.ui.project_name.clone().filter(|t| !t.trim().is_empty()),
         };
 
         // ---- Font ----
@@ -1748,5 +1761,26 @@ program = "second"
     fn focus_outline_thickness_clamps() {
         let fo = ui_from_toml("[ui.focus_outline]\nthickness = 0.1").focus_outline;
         assert_eq!(fo.thickness, 0.5);
+    }
+
+    #[test]
+    fn name_templates_default_to_none() {
+        let ui = ui_from_toml("");
+        assert_eq!(ui.worktree_name, None);
+        assert_eq!(ui.project_name, None);
+    }
+
+    #[test]
+    fn name_templates_parse() {
+        let ui =
+            ui_from_toml("[ui]\nworktree_name = \"${branch:$name}\"\nproject_name = \"[$name]\"");
+        assert_eq!(ui.worktree_name.as_deref(), Some("${branch:$name}"));
+        assert_eq!(ui.project_name.as_deref(), Some("[$name]"));
+    }
+
+    #[test]
+    fn blank_name_templates_are_dropped() {
+        let ui = ui_from_toml("[ui]\nworktree_name = \"  \"");
+        assert_eq!(ui.worktree_name, None);
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -367,8 +367,10 @@ pub struct UiTheme {
     pub icons: Icons,
     pub focus_outline: FocusOutline,
     /// `[ui] worktree_name`: template for worktree row labels (subst syntax:
-    /// `$name`, `$branch`, `$path`, `${var:fallback}`).  `None` keeps the plain
-    /// worktree name.
+    /// `$name`, `$branch`, `$path`, `${var:fallback}`; `$pr` is the branch's
+    /// PR number as `#123`, absent when none is known — it needs
+    /// `pr_status = true`, which is what polls `gh`).  `None` keeps the
+    /// plain worktree name.
     pub worktree_name: Option<String>,
     /// `[ui] project_name`: template for project row labels (`$name`, `$path`).
     /// A manual rename (`Project.label`) always wins over the template.

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -585,7 +585,7 @@ fn fallback_tweak(primary_ratio: Option<f32>, data: &[u8], index: u32) -> FontTw
 /// definitions unchanged when the family cannot be resolved or read, in which
 /// case the chrome keeps using the terminal font.
 fn install_ui_font(defs: &mut FontDefinitions, family_or_path: &str, fonts: &SystemFonts) -> bool {
-    let Some(resolved) = resolve_face(family_or_path, None, Variant::Normal, fonts) else {
+    let Some(resolved) = resolve_ui_face(family_or_path, fonts) else {
         log::warn!("could not resolve ui font '{family_or_path}'; keeping the terminal font");
         return false;
     };
@@ -988,6 +988,37 @@ fn resolve_face(
     // fontdb fallback for the case where libfontconfig isn't available; it
     // doesn't expand <alias> rules, so it's strictly second-best on Unix.
     resolve_via_fontdb(family_or_path, variant, fonts)
+}
+
+/// Strict resolution for the `[ui.font]` family.  `FcFontMatch` substitutes a
+/// default face for unknown families instead of failing, which would turn a
+/// typo'd family into a silent chrome-font change — so gate on fontdb, which
+/// matches family names literally, and only then let fontconfig pick the face
+/// (its alias and weight substitution beats fontdb's).  CSS generics skip the
+/// gate: they are aliases, not listed families.  Custom `<alias>` names lose
+/// out (fontdb can't see them), a fair trade for keeping typos on the
+/// terminal font.
+#[cfg(unix)]
+fn resolve_ui_face(family_or_path: &str, fonts: &SystemFonts) -> Option<ResolvedFace> {
+    if let Some(face) = resolve_via_path(family_or_path) {
+        return Some(face);
+    }
+    let generic = matches!(
+        family_or_path.to_ascii_lowercase().as_str(),
+        "sans-serif" | "serif" | "monospace" | "cursive" | "fantasy" | "system-ui"
+    );
+    let listed = resolve_via_fontdb(family_or_path, Variant::Normal, fonts);
+    if !generic && listed.is_none() {
+        return None;
+    }
+    fontconfig_resolve::resolve(family_or_path, None, Variant::Normal).or(listed)
+}
+
+/// fontdb already matches family names literally, so the shared path is
+/// exactly as strict as the UI font needs.
+#[cfg(not(unix))]
+fn resolve_ui_face(family_or_path: &str, fonts: &SystemFonts) -> Option<ResolvedFace> {
+    resolve_face(family_or_path, None, Variant::Normal, fonts)
 }
 
 #[cfg(not(unix))]

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -23,6 +23,7 @@ mod panel_filter;
 mod paste;
 mod pr_status;
 mod projects;
+mod row_label;
 mod session;
 mod shortcuts_window;
 mod sidebar_nav;

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -1,0 +1,65 @@
+//! Render templated sidebar row names.
+//!
+//! Templates come from `[ui] worktree_name` / `[ui] project_name` and use
+//! subst's shell-style syntax: `$var`, `${var}`, and `${var:fallback}` (the
+//! fallback may itself contain variables, so `${branch:$name}` reads "the
+//! branch, or the worktree name when detached").  Any error — parse failure,
+//! unknown variable — falls back to the plain name with one warning per
+//! template string, so a typo'd config degrades to today's sidebar rather
+//! than blank rows.
+
+use std::collections::HashMap;
+
+/// Substitute `vars` into `template`.  `None` on any subst error or when the
+/// trimmed result is empty — the caller falls back to the plain name either
+/// way, because a blank row label is as useless as a failed one.
+pub fn render_label(template: &str, vars: &HashMap<String, String>) -> Option<String> {
+    let rendered = subst::substitute(template, vars).ok()?;
+    let trimmed = rendered.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+    }
+
+    #[test]
+    fn plain_variable_substitutes() {
+        assert_eq!(
+            render_label("$name", &vars(&[("name", "feature-x")])).as_deref(),
+            Some("feature-x")
+        );
+    }
+
+    #[test]
+    fn literal_text_passes_through() {
+        assert_eq!(render_label("wt: $name", &vars(&[("name", "a")])).as_deref(), Some("wt: a"));
+    }
+
+    #[test]
+    fn fallback_used_when_variable_missing() {
+        let v = vars(&[("name", "main-wt")]);
+        assert_eq!(render_label("${branch:$name}", &v).as_deref(), Some("main-wt"));
+    }
+
+    #[test]
+    fn fallback_ignored_when_variable_present() {
+        let v = vars(&[("name", "main-wt"), ("branch", "feat/x")]);
+        assert_eq!(render_label("${branch:$name}", &v).as_deref(), Some("feat/x"));
+    }
+
+    #[test]
+    fn unknown_variable_is_an_error() {
+        assert_eq!(render_label("$nope", &vars(&[("name", "a")])), None);
+    }
+
+    #[test]
+    fn empty_render_is_an_error() {
+        assert_eq!(render_label("  ", &vars(&[])), None);
+        assert_eq!(render_label("$name", &vars(&[("name", " ")])), None);
+    }
+}

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -8,7 +8,9 @@
 //! template string, so a typo'd config degrades to today's sidebar rather
 //! than blank rows.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+
+use crate::projects::{Project, Worktree};
 
 /// Substitute `vars` into `template`.  `None` on any subst error or when the
 /// trimmed result is empty — the caller falls back to the plain name either
@@ -19,12 +21,100 @@ pub fn render_label(template: &str, vars: &HashMap<String, String>) -> Option<St
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
+/// The configured templates plus warn-once bookkeeping.  Config strings are
+/// static per run, so one warning per template string covers every row that
+/// hits the same mistake without flooding the log every frame.
+pub struct LabelTemplates {
+    worktree: Option<String>,
+    project: Option<String>,
+    warned: HashSet<String>,
+}
+
+impl LabelTemplates {
+    pub fn new(worktree: Option<String>, project: Option<String>) -> Self {
+        Self { worktree, project, warned: HashSet::new() }
+    }
+
+    /// Display name for a worktree row.  Variables: `$name` (worktree name),
+    /// `$branch` (absent when detached, so `${branch:...}` falls back),
+    /// `$path` (full worktree path).
+    pub fn worktree_label(&mut self, wt: &Worktree) -> String {
+        let Some(template) = self.worktree.clone() else {
+            return wt.name.clone();
+        };
+        let mut vars = HashMap::new();
+        vars.insert("name".to_string(), wt.name.clone());
+        if let Some(branch) = &wt.branch {
+            vars.insert("branch".to_string(), branch.clone());
+        }
+        vars.insert("path".to_string(), wt.path.display().to_string());
+        self.render_or_fallback(&template, &vars, &wt.name)
+    }
+
+    /// Display name for a project row.  A manual rename always wins — the
+    /// template only shapes the *default* name.  Variables: `$name`
+    /// (directory name), `$path` (full project root).
+    pub fn project_label(&mut self, project: &Project) -> String {
+        if let Some(label) = &project.label {
+            return label.clone();
+        }
+        let Some(template) = self.project.clone() else {
+            return project.name.clone();
+        };
+        let mut vars = HashMap::new();
+        vars.insert("name".to_string(), project.name.clone());
+        vars.insert("path".to_string(), project.root.display().to_string());
+        self.render_or_fallback(&template, &vars, &project.name)
+    }
+
+    fn render_or_fallback(
+        &mut self,
+        template: &str,
+        vars: &HashMap<String, String>,
+        fallback: &str,
+    ) -> String {
+        match render_label(template, vars) {
+            Some(rendered) => rendered,
+            None => {
+                if self.warned.insert(template.to_string()) {
+                    log::warn!("label template {template:?} failed to render; using plain name");
+                }
+                fallback.to_string()
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::projects::{Project, Worktree};
+    use std::path::PathBuf;
 
     fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
         pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+    }
+
+    fn wt(name: &str, branch: Option<&str>) -> Worktree {
+        Worktree {
+            name: name.to_string(),
+            path: PathBuf::from("/tmp/wt").join(name),
+            branch: branch.map(str::to_string),
+            is_main: false,
+            prunable: false,
+        }
+    }
+
+    fn project(name: &str, label: Option<&str>) -> Project {
+        Project {
+            root: PathBuf::from("/tmp/projects").join(name),
+            name: name.to_string(),
+            label: label.map(str::to_string),
+            default_branch: None,
+            worktrees: Vec::new(),
+            expanded: false,
+            shell_override: None,
+        }
     }
 
     #[test]
@@ -61,5 +151,42 @@ mod tests {
     fn empty_render_is_an_error() {
         assert_eq!(render_label("  ", &vars(&[])), None);
         assert_eq!(render_label("$name", &vars(&[("name", " ")])), None);
+    }
+
+    #[test]
+    fn no_template_returns_plain_names() {
+        let mut t = LabelTemplates::new(None, None);
+        assert_eq!(t.worktree_label(&wt("alpha", Some("feat/a"))), "alpha");
+        assert_eq!(t.project_label(&project("proj", None)), "proj");
+    }
+
+    #[test]
+    fn worktree_template_renders_branch_with_name_fallback() {
+        let mut t = LabelTemplates::new(Some("${branch:$name}".into()), None);
+        assert_eq!(t.worktree_label(&wt("alpha", Some("feat/a"))), "feat/a");
+        assert_eq!(t.worktree_label(&wt("detached", None)), "detached");
+    }
+
+    #[test]
+    fn project_template_renders_but_manual_label_wins() {
+        let mut t = LabelTemplates::new(None, Some("[$name]".into()));
+        assert_eq!(t.project_label(&project("proj", None)), "[proj]");
+        assert_eq!(t.project_label(&project("proj", Some("Renamed"))), "Renamed");
+    }
+
+    #[test]
+    fn bad_template_falls_back_to_plain_name() {
+        let mut t = LabelTemplates::new(Some("$typo".into()), Some("$typo".into()));
+        assert_eq!(t.worktree_label(&wt("alpha", None)), "alpha");
+        assert_eq!(t.project_label(&project("proj", None)), "proj");
+    }
+
+    #[test]
+    fn path_variable_is_available() {
+        let mut t = LabelTemplates::new(Some("$path".into()), Some("$path".into()));
+        let w = wt("alpha", None);
+        assert_eq!(t.worktree_label(&w), w.path.display().to_string());
+        let p = project("proj", None);
+        assert_eq!(t.project_label(&p), p.root.display().to_string());
     }
 }

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -3,13 +3,17 @@
 //! Templates come from `[ui] worktree_name` / `[ui] project_name` and use
 //! subst's shell-style syntax: `$var`, `${var}`, and `${var:fallback}` (the
 //! fallback may itself contain variables, so `${branch:$name}` reads "the
-//! branch, or the worktree name when detached").  Any error — parse failure,
-//! unknown variable — falls back to the plain name with one warning per
-//! config key, so a typo'd config degrades to today's sidebar rather than
-//! blank rows.
+//! branch, or the worktree name when detached").  Variables that describe
+//! something optional — `$branch` on a detached worktree, `$pr` with no
+//! known PR — are absent rather than empty, so `${pr:}` conditionally shows
+//! the PR number while a bare `$pr` treats its absence as an error.  Any
+//! error — parse failure, unknown variable — falls back to the plain name
+//! with one warning per config key, so a typo'd config degrades to today's
+//! sidebar rather than blank rows.
 
 use std::collections::{HashMap, HashSet};
 
+use crate::pr_status::PrInfo;
 use crate::projects::{Project, Worktree};
 
 /// Substitute `vars` into `template`.  `None` on any subst error or when the
@@ -39,8 +43,10 @@ impl LabelTemplates {
 
     /// Display name for a worktree row.  Variables: `$name` (worktree name),
     /// `$branch` (absent when detached, so `${branch:...}` falls back),
-    /// `$path` (full worktree path).
-    pub fn worktree_label(&mut self, wt: &Worktree) -> String {
+    /// `$path` (full worktree path), `$pr` (the branch's PR number as
+    /// `#123`, absent when none is known — `${pr:}` shows it only when one
+    /// exists).
+    pub fn worktree_label(&mut self, wt: &Worktree, pr: Option<&PrInfo>) -> String {
         let Some(template) = self.worktree.clone() else {
             return wt.name.clone();
         };
@@ -50,6 +56,9 @@ impl LabelTemplates {
             vars.insert("branch".to_string(), branch.clone());
         }
         vars.insert("path".to_string(), wt.path.display().to_string());
+        if let Some(pr) = pr {
+            vars.insert("pr".to_string(), format!("#{}", pr.number));
+        }
         self.render_or_fallback("worktree_name", &template, &vars, &wt.name)
     }
 
@@ -160,15 +169,15 @@ mod tests {
     #[test]
     fn no_template_returns_plain_names() {
         let mut t = LabelTemplates::new(None, None);
-        assert_eq!(t.worktree_label(&wt("alpha", Some("feat/a"))), "alpha");
+        assert_eq!(t.worktree_label(&wt("alpha", Some("feat/a")), None), "alpha");
         assert_eq!(t.project_label(&project("proj", None)), "proj");
     }
 
     #[test]
     fn worktree_template_renders_branch_with_name_fallback() {
         let mut t = LabelTemplates::new(Some("${branch:$name}".into()), None);
-        assert_eq!(t.worktree_label(&wt("alpha", Some("feat/a"))), "feat/a");
-        assert_eq!(t.worktree_label(&wt("detached", None)), "detached");
+        assert_eq!(t.worktree_label(&wt("alpha", Some("feat/a")), None), "feat/a");
+        assert_eq!(t.worktree_label(&wt("detached", None), None), "detached");
     }
 
     #[test]
@@ -181,15 +190,15 @@ mod tests {
     #[test]
     fn bad_template_falls_back_to_plain_name() {
         let mut t = LabelTemplates::new(Some("$typo".into()), Some("$typo".into()));
-        assert_eq!(t.worktree_label(&wt("alpha", None)), "alpha");
+        assert_eq!(t.worktree_label(&wt("alpha", None), None), "alpha");
         assert_eq!(t.project_label(&project("proj", None)), "proj");
     }
 
     #[test]
     fn warn_once_per_config_key_not_per_template() {
         let mut t = LabelTemplates::new(Some("$typo".into()), Some("$typo".into()));
-        assert_eq!(t.worktree_label(&wt("alpha", None)), "alpha");
-        assert_eq!(t.worktree_label(&wt("alpha", None)), "alpha");
+        assert_eq!(t.worktree_label(&wt("alpha", None), None), "alpha");
+        assert_eq!(t.worktree_label(&wt("alpha", None), None), "alpha");
         assert_eq!(t.project_label(&project("proj", None)), "proj");
         assert_eq!(t.project_label(&project("proj", None)), "proj");
         assert_eq!(t.warned.len(), 2);
@@ -199,8 +208,32 @@ mod tests {
     fn path_variable_is_available() {
         let mut t = LabelTemplates::new(Some("$path".into()), Some("$path".into()));
         let w = wt("alpha", None);
-        assert_eq!(t.worktree_label(&w), w.path.display().to_string());
+        assert_eq!(t.worktree_label(&w, None), w.path.display().to_string());
         let p = project("proj", None);
         assert_eq!(t.project_label(&p), p.root.display().to_string());
+    }
+
+    fn pr(number: u64) -> PrInfo {
+        PrInfo {
+            number,
+            base_branch: "master".into(),
+            url: String::new(),
+            state: crate::pr_status::PrState::Open,
+        }
+    }
+
+    #[test]
+    fn pr_variable_shows_conditionally() {
+        let mut t = LabelTemplates::new(Some("${pr:} ${branch:$name}".into()), None);
+        assert_eq!(t.worktree_label(&wt("alpha", Some("feat/a")), Some(&pr(42))), "#42 feat/a");
+        // No PR: ${pr:} renders empty and the trim eats the stray space.
+        assert_eq!(t.worktree_label(&wt("alpha", Some("feat/a")), None), "feat/a");
+    }
+
+    #[test]
+    fn bare_pr_variable_falls_back_without_a_pr() {
+        let mut t = LabelTemplates::new(Some("$pr $name".into()), None);
+        assert_eq!(t.worktree_label(&wt("alpha", None), Some(&pr(7))), "#7 alpha");
+        assert_eq!(t.worktree_label(&wt("alpha", None), None), "alpha");
     }
 }

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -22,12 +22,14 @@ pub fn render_label(template: &str, vars: &HashMap<String, String>) -> Option<St
 }
 
 /// The configured templates plus warn-once bookkeeping.  Config strings are
-/// static per run, so one warning per template string covers every row that
-/// hits the same mistake without flooding the log every frame.
+/// static per run, so one warning per config key + template covers every row
+/// that hits the same mistake without flooding the log every frame — keying
+/// on the template alone would let a second, independently broken config key
+/// hide behind the first one's warning just because the text matched.
 pub struct LabelTemplates {
     worktree: Option<String>,
     project: Option<String>,
-    warned: HashSet<String>,
+    warned: HashSet<(String, String)>,
 }
 
 impl LabelTemplates {
@@ -48,7 +50,7 @@ impl LabelTemplates {
             vars.insert("branch".to_string(), branch.clone());
         }
         vars.insert("path".to_string(), wt.path.display().to_string());
-        self.render_or_fallback(&template, &vars, &wt.name)
+        self.render_or_fallback("worktree_name", &template, &vars, &wt.name)
     }
 
     /// Display name for a project row.  A manual rename always wins — the
@@ -64,11 +66,12 @@ impl LabelTemplates {
         let mut vars = HashMap::new();
         vars.insert("name".to_string(), project.name.clone());
         vars.insert("path".to_string(), project.root.display().to_string());
-        self.render_or_fallback(&template, &vars, &project.name)
+        self.render_or_fallback("project_name", &template, &vars, &project.name)
     }
 
     fn render_or_fallback(
         &mut self,
+        slot: &str,
         template: &str,
         vars: &HashMap<String, String>,
         fallback: &str,
@@ -76,8 +79,10 @@ impl LabelTemplates {
         match render_label(template, vars) {
             Some(rendered) => rendered,
             None => {
-                if self.warned.insert(template.to_string()) {
-                    log::warn!("label template {template:?} failed to render; using plain name");
+                if self.warned.insert((slot.to_string(), template.to_string())) {
+                    log::warn!(
+                        "[ui] {slot} template {template:?} failed to render; using plain name"
+                    );
                 }
                 fallback.to_string()
             },
@@ -88,7 +93,6 @@ impl LabelTemplates {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::projects::{Project, Worktree};
     use std::path::PathBuf;
 
     fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
@@ -179,6 +183,16 @@ mod tests {
         let mut t = LabelTemplates::new(Some("$typo".into()), Some("$typo".into()));
         assert_eq!(t.worktree_label(&wt("alpha", None)), "alpha");
         assert_eq!(t.project_label(&project("proj", None)), "proj");
+    }
+
+    #[test]
+    fn warn_once_per_config_key_not_per_template() {
+        let mut t = LabelTemplates::new(Some("$typo".into()), Some("$typo".into()));
+        assert_eq!(t.worktree_label(&wt("alpha", None)), "alpha");
+        assert_eq!(t.worktree_label(&wt("alpha", None)), "alpha");
+        assert_eq!(t.project_label(&project("proj", None)), "proj");
+        assert_eq!(t.project_label(&project("proj", None)), "proj");
+        assert_eq!(t.warned.len(), 2);
     }
 
     #[test]

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -5,8 +5,8 @@
 //! fallback may itself contain variables, so `${branch:$name}` reads "the
 //! branch, or the worktree name when detached").  Any error — parse failure,
 //! unknown variable — falls back to the plain name with one warning per
-//! template string, so a typo'd config degrades to today's sidebar rather
-//! than blank rows.
+//! config key, so a typo'd config degrades to today's sidebar rather than
+//! blank rows.
 
 use std::collections::{HashMap, HashSet};
 


### PR DESCRIPTION
Template-driven display names for sidebar rows via the `subst` crate (one new dependency; its transitive deps were already in the lockfile). Defaults unchanged: no template configured → plain names, zero substitution work.

- `[ui] worktree_name` / `project_name` — shell-style templates: `$name`, `$branch`, `$path`, with nestable fallbacks (`${branch:$name}` = "the branch, or the worktree name when detached"; `$branch` is simply absent when detached).
- `$pr` — the branch's PR number as `#123`, absent when no PR is known, so `${pr:}` shows it only when one exists: `worktree_name = "${pr:} ${branch:$name}"` renders `#123 my-branch` with a PR and `my-branch` without. Fed by the PR-status cache from #108, so it needs `[ui] pr_status = true` (the badge/poll toggle) to ever populate.
- A manual project rename always wins over the template.
- A broken template degrades to the plain name with one `log::warn!` per config key — never a blank row.
- Cosmetic only: rename seeds, delete/prune prompts, and all modals keep the raw git names, so destructive dialogs always name the real object. The sidebar filter also matches raw names, not rendered labels.

**Stacked on #108** (`$pr` needs its `PrInfo`/`PrCache`): this branch merges `feat/sidebar-appearance`, so the diff shows both until [5] lands. Merge [5] first and the diff collapses to the template work.

Tests: 364 passed / 0 failed / 1 ignored at tip; rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
