### PR TITLE
feat(wsl): resident per-distro helper for probes and batched git [7]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ version = "0.1.2"
 dependencies = [
  "alacritty_terminal",
  "arboard",
+ "base64",
  "clap",
  "clap_complete",
  "eframe",

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 alacritty_terminal = { path = "../alacritty_terminal" }
+base64 = "0.22"
 eframe = { version = "0.31", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }
 egui = "0.31"
 log = "0.4"

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -28,6 +28,7 @@ use crate::state::{self, PersistedProject};
 use crate::terminal_view;
 use crate::worktree::{self as wt, CreateRequest, Progress};
 use crate::wsl::{self, ShellChoice};
+use crate::wsl_helper::{self, WslProbe};
 
 /// `None` is the home workspace (sessions inherit `$PWD`); `Some` is a worktree path.
 pub type WorkspaceKey = Option<PathBuf>;
@@ -738,8 +739,8 @@ impl AlacritreeApp {
         if let Some(dir) = &working_directory {
             self.sync_doppler_scopes(dir.clone());
         }
-        let shell = self.resolve_shell(&working_directory);
-        self.spawn_session_with_shell(ctx, working_directory, shell)
+        let (shell, wsl_probe) = self.resolve_shell(&working_directory);
+        self.spawn_session_with_shell(ctx, working_directory, shell, wsl_probe)
     }
 
     fn spawn_session_with_shell(
@@ -747,6 +748,7 @@ impl AlacritreeApp {
         ctx: &Context,
         working_directory: WorkspaceKey,
         shell: Option<Shell>,
+        wsl_probe: Option<WslProbe>,
     ) -> std::io::Result<SessionId> {
         let session = Session::spawn(
             ctx.clone(),
@@ -755,6 +757,7 @@ impl AlacritreeApp {
             TermSize::new(80, 24),
             (8.0, 16.0),
             shell,
+            wsl_probe,
         )?;
         let id = session.id;
         self.sessions.push(session);
@@ -795,9 +798,9 @@ impl AlacritreeApp {
             self.last_error = Some(format!("no shell profile named `{name}`"));
             return;
         };
-        let shell = Some(profile_shell(profile));
+        let (shell, wsl_probe) = profile_session_shell(profile);
         let ws = self.current_workspace.clone();
-        if let Err(e) = self.spawn_session_with_shell(ctx, ws, shell) {
+        if let Err(e) = self.spawn_session_with_shell(ctx, ws, shell, wsl_probe) {
             self.last_error = Some(format!("failed to spawn profile `{name}`: {e}"));
         }
     }
@@ -806,7 +809,7 @@ impl AlacritreeApp {
     /// falls through to alacritty's config-driven shell with its
     /// OS-guaranteed fallback.  The home tab (`None` workspace) has no
     /// project or location, so only the default profile can apply there.
-    fn resolve_shell(&self, workspace: &WorkspaceKey) -> Option<Shell> {
+    fn resolve_shell(&self, workspace: &WorkspaceKey) -> (Option<Shell>, Option<WslProbe>) {
         let path = workspace.as_deref();
         let choice = path.and_then(|p| {
             self.projects
@@ -826,11 +829,17 @@ impl AlacritreeApp {
             &self.config.profiles,
             self.config.default_profile.as_deref(),
         ) {
-            ShellDecision::ConfigShell => None,
+            ShellDecision::ConfigShell => config_session_shell(&self.config),
             // A WSL decision only arises from a workspace path (override or
             // location), never from the home tab.
-            ShellDecision::WslDistro(distro) => path.map(|p| wsl_shell(&distro, p)),
-            ShellDecision::Profile(name) => self.config.profile(&name).map(profile_shell),
+            ShellDecision::WslDistro(distro) => match path {
+                Some(p) => wsl_session_shell(&distro, p),
+                None => (None, None),
+            },
+            ShellDecision::Profile(name) => match self.config.profile(&name) {
+                Some(profile) => profile_session_shell(profile),
+                None => (None, None),
+            },
         }
     }
 
@@ -3156,6 +3165,53 @@ fn build_wsl_diff_command_login(
 fn wsl_shell(distro: &str, workdir: &Path) -> Shell {
     let (program, args) = wsl::shell_invocation(distro, workdir);
     Shell::new(program, args)
+}
+
+/// Shimmed when the resident helper is on; the plain wsl.exe login-shell
+/// launch (and an unknown probe) otherwise.
+fn wsl_session_shell(distro: &str, workdir: &Path) -> (Option<Shell>, Option<WslProbe>) {
+    if !wsl_helper::enabled() {
+        return (Some(wsl_shell(distro, workdir)), None);
+    }
+    let key = wsl_helper::new_probe_key();
+    let (program, args) = wsl_helper::shim_invocation(distro, workdir, &key);
+    (Some(Shell::new(program, args)), Some(WslProbe { distro: distro.to_string(), key }))
+}
+
+/// The probe shim for any user-supplied wsl.exe argv (profile or
+/// `[terminal.shell]`): `Some` only when the argv is fully understood and
+/// a distro name is known — the probe registry needs one, so a wrapped
+/// default-distro launch resolves it via enumeration.  Anything exotic
+/// runs unmodified and probes as unknown.
+fn shimmed_wsl_argv(program: &str, args: &[String]) -> Option<(Shell, WslProbe)> {
+    if !wsl_helper::enabled() {
+        return None;
+    }
+    let key = wsl_helper::new_probe_key();
+    let (args, distro) = wsl_helper::wrap_profile_argv(program, args, &key)?;
+    let distro =
+        distro.or_else(|| wsl::distros().into_iter().find(|d| d.is_default).map(|d| d.name))?;
+    Some((Shell::new(program.to_string(), args), WslProbe { distro, key }))
+}
+
+fn profile_session_shell(profile: &crate::config::Profile) -> (Option<Shell>, Option<WslProbe>) {
+    match shimmed_wsl_argv(&profile.program, &profile.args) {
+        Some((shell, probe)) => (Some(shell), Some(probe)),
+        None => (Some(profile_shell(profile)), None),
+    }
+}
+
+/// `[terminal.shell] program = "wsl.exe"` gets the same shim as a wsl.exe
+/// profile; any other config shell (or none) spawns unchanged through
+/// `Session::spawn`'s own config-shell default.
+fn config_session_shell(config: &crate::config::Config) -> (Option<Shell>, Option<WslProbe>) {
+    match &config.shell {
+        Some(s) => match shimmed_wsl_argv(&s.program, &s.args) {
+            Some((shell, probe)) => (Some(shell), Some(probe)),
+            None => (None, None),
+        },
+        None => (None, None),
+    }
 }
 
 /// What shell a new session should run, decided from plain data so the

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -40,6 +40,7 @@ pub struct Config {
     /// alacritty's `[general] ipc_socket` (default on).
     pub ipc_socket: bool,
     pub wsl_automount_root: String,
+    pub wsl_resident_helper: bool,
     /// Explicit `delta` program for the diff pane, from `[ui] delta_path`.
     /// When set it is used verbatim in git's `core.pager` on every platform
     /// and skips WSL delta autodiscovery; when unset, native diffs run bare
@@ -451,6 +452,7 @@ impl Default for Config {
             bindings: Vec::new(),
             ipc_socket: true,
             wsl_automount_root: "/mnt".to_string(),
+            wsl_resident_helper: true,
             delta_path: None,
             profiles: Vec::new(),
             default_profile: None,
@@ -737,6 +739,7 @@ struct RawConfig {
     selection: RawSelection,
     keyboard: RawKeyboard,
     general: RawGeneral,
+    wsl: RawWsl,
 }
 
 /// Subset of alacritty's `[general]` section that alacritree honors.  It
@@ -915,9 +918,17 @@ struct RawIndexed {
     color: RgbStr,
 }
 
+/// Top-level `[wsl]`: platform-integration options.  Lives outside `[ui]`
+/// because nothing here is presentation — it governs how the app talks to
+/// distros.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
-struct RawUiWsl {
+struct RawWsl {
+    /// Keep a resident helper process per distro for foreground probes,
+    /// batched git queries, and tool discovery.  `false` restores one-shot
+    /// wsl.exe spawns everywhere; WSL sessions then always report "no
+    /// TUI", so FocusLeft/FocusRight always move panel focus.
+    resident_helper: Option<bool>,
     /// Distro-side mount point for Windows drives, mirroring wsl.conf's
     /// `[automount] root`.  Only used for paths *we* translate (git output
     /// from inside a distro); `wsl.exe --cd` translates with the distro's
@@ -965,6 +976,14 @@ fn build_icons(raw: RawIcons) -> Icons {
         pr_merged: icon_or(raw.pr_merged, &d.pr_merged),
         pr_closed: icon_or(raw.pr_closed, &d.pr_closed),
     }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RawUiWsl {
+    /// Deprecated location: `[wsl] automount_root` supersedes this and wins
+    /// when both are set; kept so existing configs keep working.
+    automount_root: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1267,13 +1286,15 @@ impl RawConfig {
         };
 
         // ---- WSL ----
+        // `[wsl]` supersedes the deprecated `[ui.wsl]` location.
         let wsl_automount_root = self
-            .ui
             .wsl
             .automount_root
+            .or(self.ui.wsl.automount_root)
             .map(|r| r.trim_end_matches('/').to_string())
             .filter(|r| r.starts_with('/') && r.len() > 1)
             .unwrap_or_else(|| "/mnt".to_string());
+        let wsl_resident_helper = self.wsl.resident_helper.unwrap_or(true);
 
         // ---- UI Font ----
         let ui_font = UiFont {
@@ -1306,6 +1327,7 @@ impl RawConfig {
             bindings,
             ipc_socket: self.general.ipc_socket.unwrap_or(true),
             wsl_automount_root,
+            wsl_resident_helper,
             delta_path: self.ui.delta_path.filter(|s| !s.trim().is_empty()),
             profiles,
             default_profile,
@@ -1398,6 +1420,29 @@ mod tests {
         // Nonsense values fall back rather than corrupting every translation.
         let raw: RawConfig = toml::from_str("[ui.wsl]\nautomount_root = \"mnt\"").unwrap();
         assert_eq!(raw.into_config().wsl_automount_root, "/mnt");
+    }
+
+    #[test]
+    fn wsl_section_wins_over_deprecated_ui_location() {
+        let raw: RawConfig = toml::from_str("[wsl]\nautomount_root = \"/drives\"").unwrap();
+        assert_eq!(raw.into_config().wsl_automount_root, "/drives");
+
+        let both = "[wsl]\nautomount_root = \"/new\"\n[ui.wsl]\nautomount_root = \"/old\"";
+        let raw: RawConfig = toml::from_str(both).unwrap();
+        assert_eq!(raw.into_config().wsl_automount_root, "/new");
+
+        // Existing configs keep working through the deprecated location.
+        let raw: RawConfig = toml::from_str("[ui.wsl]\nautomount_root = \"/old\"").unwrap();
+        assert_eq!(raw.into_config().wsl_automount_root, "/old");
+    }
+
+    #[test]
+    fn resident_helper_defaults_on() {
+        let raw: RawConfig = toml::from_str("").unwrap();
+        assert!(raw.into_config().wsl_resident_helper);
+
+        let raw: RawConfig = toml::from_str("[wsl]\nresident_helper = false").unwrap();
+        assert!(!raw.into_config().wsl_resident_helper);
     }
 
     #[test]

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -34,6 +34,7 @@ mod terminal_view;
 mod test_util;
 mod worktree;
 mod wsl;
+mod wsl_helper;
 
 use app::AlacritreeApp;
 use clap::Parser;

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -87,6 +87,7 @@ fn main() -> eframe::Result<()> {
 
     let config = config::load();
     wsl::set_automount_root(config.wsl_automount_root.clone());
+    wsl_helper::set_enabled(config.wsl_resident_helper);
     let translucent = config.window.opacity < 1.0;
 
     let mut viewport = egui::ViewportBuilder::default()

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -156,32 +156,38 @@ fn pr_state(state: &str, is_draft: bool) -> PrState {
 /// answer is tied to that specific branch rather than whatever ref happens
 /// to be checked out in the worktree.
 fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
-    let mut cmd = match wsl::classify(path) {
+    const PR_JSON_FIELDS: &str = "number,baseRefName,url,state,isDraft";
+    match wsl::classify(path) {
         wsl::Location::Windows(p) => {
-            let mut c = Command::new("gh");
-            c.hide_console().current_dir(p);
-            c
+            let output = Command::new("gh")
+                .hide_console()
+                .current_dir(p)
+                .args(["pr", "view", branch, "--json", PR_JSON_FIELDS])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .stdin(Stdio::null())
+                .output()
+                .ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            parse_gh_output(&output.stdout)
         },
         // `gh` must be installed and authenticated *inside* the distro; any
         // failure falls back to the default branch, same as a missing
-        // Windows gh.  `--cd` accepts the UNC path natively.
-        wsl::Location::Wsl { distro, .. } => {
-            let mut c = wsl::command(&distro, Some(path));
-            c.arg("gh");
-            c
+        // Windows gh.  The batch script rides the resident helper when it
+        // is up (a one-shot spawn otherwise); the capability path from the
+        // helper's hello honors per-user install dirs that the default
+        // `--exec` PATH lacks.
+        wsl::Location::Wsl { distro, linux_path } => {
+            let gh = crate::wsl_helper::capability_gh(&distro).unwrap_or_else(|| "gh".to_string());
+            let script = r#"cd "$1" && exec "$2" pr view "$3" --json "$4""#;
+            let stdout =
+                wsl::run_batch(&distro, script, &[&linux_path, &gh, branch, PR_JSON_FIELDS])
+                    .ok()?;
+            parse_gh_output(&stdout)
         },
-    };
-    let output = cmd
-        .args(["pr", "view", branch, "--json", "number,baseRefName,url,state,isDraft"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
     }
-    parse_gh_output(&output.stdout)
 }
 
 fn parse_gh_output(stdout: &[u8]) -> Option<PrInfo> {

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -648,10 +648,11 @@ impl Session {
             env,
             // Windows has no argv: alacritty_terminal joins these args into a
             // single CreateProcess command line, quoting them only when this
-            // is set.  True for argv built in code (diff panes, WSL shells),
-            // where an arg with a space (delta's pager spec, UNC paths) must
-            // survive as one argument; shell args from alacritty.toml stay
-            // raw to match upstream alacritty.
+            // is set.  True for argv built in code (diff panes, WSL shells,
+            // and a config shell shimmed by the resident helper), where an
+            // arg with a space (delta's pager spec, UNC paths) must survive
+            // as one argument; a config shell that isn't shimmed stays raw,
+            // matching upstream alacritty.
             #[cfg(windows)]
             escape_args,
         };

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -17,6 +17,7 @@ use alacritty_terminal::vte::ansi::Rgb;
 use crate::clipboard::Target;
 use crate::colors;
 use crate::config::{Config, Palette};
+use crate::wsl_helper::{self, WslProbe};
 
 #[derive(Clone)]
 pub struct EventProxy {
@@ -105,6 +106,10 @@ pub struct Session {
     /// timer instead of polling the process table every frame.  `Cell` is
     /// enough since `Session` isn't `Sync` and the values are `Copy`.
     agent_cache: Cell<AgentCache>,
+    /// Set for shimmed WSL sessions: the distro plus the probe key its
+    /// shim published, unregistered again on drop.  The Windows process
+    /// table ends at wsl.exe, so this is the only live view inside.
+    wsl_probe: Option<WslProbe>,
     notifier: Notifier,
     sender: EventLoopSender,
     exited: bool,
@@ -194,14 +199,21 @@ fn is_nav_tui_name(name: &str) -> bool {
     n.starts_with("nvim") || n.starts_with("vim") || n.starts_with("tmux")
 }
 
-/// `wsl.exe` (and its `wslhost`/`wslrelay` helpers) mark a session whose
-/// real process tree lives on the Linux side, where this probe cannot see.
-/// Assume the inside cooperates like a nav TUI: the key is forwarded, and
-/// programs in the distro hand focus back by exec'ing the Windows CLI
-/// (`alacritree.exe action Focus…`) through WSL interop.
-#[cfg(any(test, windows))]
-fn is_wsl_boundary_name(name: &str) -> bool {
-    name.to_ascii_lowercase().starts_with("wsl")
+/// FocusLeft/FocusRight passthrough decision for a shimmed WSL session: the
+/// helper's cached foreground `comm`, matched like the native Linux probe.
+/// Unknown means no TUI — the keys move panel focus.  Gated the same as
+/// `is_nav_tui_name` (plus its `not(...)` fallback below) since `Session`
+/// always carries a `wsl_probe` field, so `process_probe`'s match on it must
+/// compile everywhere, even though a shimmed session only exists on Windows.
+#[cfg(any(test, target_os = "linux", windows))]
+fn wsl_nav_tui(comm: Option<&str>) -> bool {
+    comm.is_some_and(is_nav_tui_name)
+}
+
+#[cfg(not(any(test, target_os = "linux", windows)))]
+fn wsl_nav_tui(_comm: Option<&str>) -> bool {
+    // Same gap as the glyph probe: macOS isn't wired up yet.
+    false
 }
 
 /// Match full command lines against the agent map — picks up
@@ -474,10 +486,7 @@ mod windows_process_probe {
 
     use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
-    use super::{
-        agent_glyph_by_cmdline, agent_glyph_by_name, is_nav_tui_name, is_wsl_boundary_name,
-        process_tree_pids,
-    };
+    use super::{agent_glyph_by_cmdline, agent_glyph_by_name, is_nav_tui_name, process_tree_pids};
 
     /// Slightly under `AGENT_CACHE_TTL` so the first session to tick
     /// refreshes and the rest reuse the same table.
@@ -514,7 +523,7 @@ mod windows_process_probe {
             .filter_map(|pid| sys.process(*pid))
             .map(|p| p.name().to_string_lossy().into_owned())
             .collect();
-        let nav_tui = names.iter().any(|n| is_nav_tui_name(n) || is_wsl_boundary_name(n));
+        let nav_tui = names.iter().any(|n| is_nav_tui_name(n));
         if let Some(glyph) = agent_glyph_by_name(&names) {
             return (Some(glyph), has_children, nav_tui);
         }
@@ -542,6 +551,7 @@ impl Session {
         size: TermSize,
         cell_size: (f32, f32),
         shell_override: Option<Shell>,
+        wsl_probe: Option<WslProbe>,
     ) -> std::io::Result<Self> {
         // Overrides are argv built in code (`wsl.exe -d <distro> --cd <dir>`),
         // so their args need Windows quoting like diff-pane argv; config
@@ -564,6 +574,7 @@ impl Session {
             title,
             SessionKind::Shell,
             escape_args,
+            wsl_probe,
         )
     }
 
@@ -591,6 +602,7 @@ impl Session {
             title,
             kind,
             true,
+            None,
         )
     }
 
@@ -604,6 +616,7 @@ impl Session {
         title: String,
         kind: SessionKind,
         escape_args: bool,
+        wsl_probe: Option<WslProbe>,
     ) -> std::io::Result<Self> {
         ensure_working_directory(working_directory.as_deref())?;
         let window_size = window_size(size, cell_size);
@@ -652,6 +665,9 @@ impl Session {
         let sender = event_loop.channel();
         event_loop.spawn();
 
+        if let Some(probe) = &wsl_probe {
+            wsl_helper::register_probe(&probe.distro, &probe.key);
+        }
         Ok(Self {
             id: next_session_id(),
             title,
@@ -666,6 +682,7 @@ impl Session {
             last_report_cell: None,
             shell_pid,
             agent_cache: Cell::new(AgentCache::default()),
+            wsl_probe,
             notifier: Notifier(sender.clone()),
             sender,
             exited: false,
@@ -783,7 +800,12 @@ impl Session {
         }
         let glyph = self.shell_pid.and_then(foreground_process_glyph);
         let foreground_job = self.shell_pid.is_some_and(shell_has_foreground_job);
-        let nav_tui = self.shell_pid.is_some_and(foreground_nav_tui);
+        let nav_tui = match &self.wsl_probe {
+            Some(probe) => {
+                wsl_nav_tui(wsl_helper::foreground_comm(&probe.distro, &probe.key).as_deref())
+            },
+            None => self.shell_pid.is_some_and(foreground_nav_tui),
+        };
         self.agent_cache.set(AgentCache {
             polled_at: Some(Instant::now()),
             process_glyph: glyph,
@@ -847,6 +869,9 @@ impl Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
+        if let Some(probe) = &self.wsl_probe {
+            wsl_helper::unregister_probe(&probe.distro, &probe.key);
+        }
         self.shutdown();
     }
 }
@@ -1208,6 +1233,18 @@ mod tests {
     }
 
     #[test]
+    fn wsl_nav_tui_needs_a_known_cooperating_comm() {
+        assert!(wsl_nav_tui(Some("nvim")));
+        assert!(wsl_nav_tui(Some("vim")));
+        assert!(wsl_nav_tui(Some("tmux: client")));
+        // A shell, an agent, or an unknown probe must move panel focus —
+        // losing passthrough beats losing the keys.
+        assert!(!wsl_nav_tui(Some("bash")));
+        assert!(!wsl_nav_tui(Some("claude")));
+        assert!(!wsl_nav_tui(None));
+    }
+
+    #[test]
     fn nav_tui_name_match_covers_both_platforms_naming() {
         // Windows image names.
         assert!(is_nav_tui_name("nvim.exe"));
@@ -1220,14 +1257,12 @@ mod tests {
         assert!(!is_nav_tui_name("gvim.exe"));
         assert!(!is_nav_tui_name("chezmoi.exe"));
         assert!(!is_nav_tui_name("pwsh.exe"));
-    }
-
-    #[test]
-    fn wsl_boundary_match_covers_the_helper_processes() {
-        assert!(is_wsl_boundary_name("wsl.exe"));
-        assert!(is_wsl_boundary_name("wslhost.exe"));
-        assert!(is_wsl_boundary_name("WSLRELAY.EXE"));
-        assert!(!is_wsl_boundary_name("pwsh.exe"));
+        // A wsl.exe in the descendant tree no longer implies a cooperating
+        // TUI — the Windows process table can't see the distro side, so the
+        // resident helper's foreground probe is the only signal now.
+        assert!(!is_nav_tui_name("wsl.exe"));
+        assert!(!is_nav_tui_name("wslhost.exe"));
+        assert!(!is_nav_tui_name("WSLRELAY.EXE"));
     }
 
     #[test]

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -216,6 +216,15 @@ fn wsl_nav_tui(_comm: Option<&str>) -> bool {
     false
 }
 
+/// `(foreground_job, nav_tui)` for a shimmed WSL session, from the helper's
+/// cached foreground `comm`.  Any comm at all means a job owns the tty — the
+/// helper reports nothing for an idle shell.  The Windows descendant probe
+/// can't stand in here: wsl.exe keeps plumbing children alive for the life
+/// of the session, so it reads every idle WSL shell as busy.
+fn wsl_probe_signals(comm: Option<&str>) -> (bool, bool) {
+    (comm.is_some(), wsl_nav_tui(comm))
+}
+
 /// Match full command lines against the agent map — picks up
 /// `node ...\claude-code\cli.js`-style wrappers that hide behind their
 /// runtime's name, same as the Linux cmdline pass.
@@ -771,8 +780,9 @@ impl Session {
     }
 
     /// A session "looks busy" when a process is running in the terminal
-    /// (a foreground job on Linux, any descendant of the shell on Windows),
-    /// its foreground process is a recognized agent, or its title is in a
+    /// (a foreground job on Linux, any descendant of the shell on Windows,
+    /// the helper's foreground probe for shimmed WSL sessions), its
+    /// foreground process is a recognized agent, or its title is in a
     /// spinner state — the signal the close-confirmation policy keys on.
     pub fn is_busy(&self) -> bool {
         self.process_probe().1 || looks_busy(self.agent_glyph(), &self.title)
@@ -800,12 +810,14 @@ impl Session {
             return (cached.process_glyph, cached.foreground_job, cached.nav_tui);
         }
         let glyph = self.shell_pid.and_then(foreground_process_glyph);
-        let foreground_job = self.shell_pid.is_some_and(shell_has_foreground_job);
-        let nav_tui = match &self.wsl_probe {
+        let (foreground_job, nav_tui) = match &self.wsl_probe {
             Some(probe) => {
-                wsl_nav_tui(wsl_helper::foreground_comm(&probe.distro, &probe.key).as_deref())
+                wsl_probe_signals(wsl_helper::foreground_comm(&probe.distro, &probe.key).as_deref())
             },
-            None => self.shell_pid.is_some_and(foreground_nav_tui),
+            None => (
+                self.shell_pid.is_some_and(shell_has_foreground_job),
+                self.shell_pid.is_some_and(foreground_nav_tui),
+            ),
         };
         self.agent_cache.set(AgentCache {
             polled_at: Some(Instant::now()),
@@ -1231,6 +1243,16 @@ mod tests {
         assert_eq!(agent_glyph_by_name(["pwsh.exe", "git.exe"]), None);
         assert_eq!(agent_glyph_by_name(["not-claude.exe"]), None);
         assert_eq!(agent_glyph_by_name(std::iter::empty::<&str>()), None);
+    }
+
+    #[test]
+    fn wsl_busy_needs_a_foreground_comm() {
+        // Idle shell: the helper reports no foreground comm at all.
+        assert_eq!(wsl_probe_signals(None), (false, false));
+        // Any foreground job counts as busy, cooperating TUI or not.
+        assert_eq!(wsl_probe_signals(Some("sleep")), (true, false));
+        assert_eq!(wsl_probe_signals(Some("claude")), (true, false));
+        assert_eq!(wsl_probe_signals(Some("nvim")), (true, true));
     }
 
     #[test]

--- a/alacritree/src/wsl.rs
+++ b/alacritree/src/wsl.rs
@@ -299,10 +299,17 @@ pub fn shell_invocation(distro: &str, workdir: &Path) -> (String, Vec<String>) {
 pub const SECTION_SEP: &[u8] = b"\n@@ALACRITREE@@\n";
 
 /// Run `script` through `sh -c` inside `distro`, with `args` bound to
-/// `$1..`.  One wsl.exe round trip (~400 ms warm on a dev machine, seconds
-/// while the VM cold-boots) — callers batch every query for a repo into a
-/// single script and must never call this on the UI thread.
+/// `$1..`.  Rides the resident helper's pipe when it is up; otherwise one
+/// wsl.exe round trip (~400 ms warm on a dev machine, seconds while the VM
+/// cold-boots) — callers batch every query for a repo into a single script
+/// and must never call this on the UI thread.
 pub fn run_batch(distro: &str, script: &str, args: &[&str]) -> Result<Vec<u8>, String> {
+    // A request the helper may have executed is never re-run as a one-shot
+    // (batch scripts have side effects); only a transport that failed
+    // before the write falls through to the spawn below.
+    if let Some(result) = crate::wsl_helper::try_run(distro, script, args) {
+        return result;
+    }
     let output = command(distro, None)
         .arg("sh")
         .arg("-c")
@@ -332,6 +339,12 @@ pub fn run_batch(distro: &str, script: &str, args: &[&str]) -> Result<Vec<u8>, S
 /// Returns `None` when delta isn't found; callers must not cache that, so an
 /// install mid-session is picked up on the next attempt.
 pub fn discover_delta(distro: &str) -> Option<String> {
+    // The helper's hello already resolved delta through the login shell; a
+    // missing capability is not a cached miss — fall through and re-check
+    // live so a mid-session install is still picked up.
+    if let Some(path) = crate::wsl_helper::capability_delta(distro) {
+        return Some(path);
+    }
     let script = r#"s=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7); [ -x "$s" ] || s=${SHELL:-/bin/sh}; exec "$s" -lc 'command -v delta'"#;
     let output = command(distro, None)
         .arg("sh")

--- a/alacritree/src/wsl.rs
+++ b/alacritree/src/wsl.rs
@@ -48,7 +48,7 @@ pub enum Location {
 }
 
 /// The distro-side directory Windows drives are mounted under.  Set once at
-/// startup from `[ui.wsl] automount_root`; `/mnt` is WSL's default.
+/// startup from `[wsl] automount_root`; `/mnt` is WSL's default.
 static AUTOMOUNT_ROOT: OnceLock<String> = OnceLock::new();
 
 pub fn set_automount_root(root: String) {

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -539,6 +539,80 @@ pub fn capability_gh(distro: &str) -> Option<String> {
     client(distro)?.capabilities()?.gh.clone()
 }
 
+/// Identity of a shimmed WSL session for the foreground probe.
+#[derive(Debug, Clone)]
+pub struct WslProbe {
+    pub distro: String,
+    pub key: String,
+}
+
+const PROBE_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Last-known foreground `comm` per registered `(distro, probe key)`.
+/// Written only by the poller thread (and tests); read from the UI thread.
+fn probe_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {
+    static CACHE: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// A probe key unique across alacritree instances: the pidfile dir inside
+/// each distro is shared, so the Windows pid namespaces the per-instance
+/// counter.
+pub fn new_probe_key() -> String {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    format!("{}-{}", std::process::id(), NEXT.fetch_add(1, Ordering::Relaxed))
+}
+
+pub fn register_probe(distro: &str, key: &str) {
+    lock(probe_cache()).insert((distro.to_string(), key.to_string()), None);
+    ensure_poller();
+}
+
+pub fn unregister_probe(distro: &str, key: &str) {
+    lock(probe_cache()).remove(&(distro.to_string(), key.to_string()));
+}
+
+/// Cached foreground `comm` for a shimmed WSL session — never blocks and
+/// never touches the pipe, so it is safe on the UI thread.  `None` means
+/// unknown (helper down, key unregistered, or an idle shell at the last
+/// poll); callers must treat unknown as "no TUI".
+pub fn foreground_comm(distro: &str, key: &str) -> Option<String> {
+    lock(probe_cache()).get(&(distro.to_string(), key.to_string()))?.clone()
+}
+
+#[cfg(test)]
+fn set_cached_comm(distro: &str, key: &str, comm: Option<String>) {
+    lock(probe_cache()).insert((distro.to_string(), key.to_string()), comm);
+}
+
+/// One process-wide poller refreshes every registered key at the agent
+/// cadence.  Requests leave this thread, so a slow helper delays freshness,
+/// never the UI.  Polling a distro also (re)spawns its helper through
+/// `client()`, so an open WSL session keeps nudging a cooled-down helper
+/// back up.  The key list is snapshotted before any pipe I/O so the cache
+/// lock is never held across a request.
+fn ensure_poller() {
+    static STARTED: std::sync::Once = std::sync::Once::new();
+    STARTED.call_once(|| {
+        let spawned =
+            std::thread::Builder::new().name("wsl-helper-probe".to_string()).spawn(|| {
+                loop {
+                    std::thread::sleep(PROBE_POLL_INTERVAL);
+                    let keys: Vec<(String, String)> = lock(probe_cache()).keys().cloned().collect();
+                    for entry in keys {
+                        let comm = client(&entry.0).and_then(|c| c.probe(&entry.1).ok()).flatten();
+                        if let Some(slot) = lock(probe_cache()).get_mut(&entry) {
+                            *slot = comm;
+                        }
+                    }
+                }
+            });
+        if let Err(e) = spawned {
+            log::warn!("wsl probe poller failed to start: {e}");
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -691,6 +765,31 @@ mod tests {
         assert!(wrap_profile_argv("wslhost.exe", &[], "k").is_none());
     }
 
+    #[test]
+    fn probe_cache_lifecycle() {
+        // An inert distro name: even if the poller ticks mid-test, `client()`
+        // cools down on the failed spawn instead of touching a real distro.
+        const D: &str = "no-such-distro";
+        // Unknown key: unknown comm — the caller treats that as "no TUI".
+        assert_eq!(foreground_comm(D, "test-77-1"), None);
+        register_probe(D, "test-77-1");
+        // Registered but not yet polled: still unknown, not a panic or a block.
+        assert_eq!(foreground_comm(D, "test-77-1"), None);
+        set_cached_comm(D, "test-77-1", Some("nvim".to_string()));
+        assert_eq!(foreground_comm(D, "test-77-1").as_deref(), Some("nvim"));
+        unregister_probe(D, "test-77-1");
+        assert_eq!(foreground_comm(D, "test-77-1"), None);
+    }
+
+    #[test]
+    fn probe_keys_are_pid_namespaced_and_unique() {
+        let a = new_probe_key();
+        let b = new_probe_key();
+        assert_ne!(a, b);
+        let prefix = format!("{}-", std::process::id());
+        assert!(a.starts_with(&prefix), "{a} should start with {prefix}");
+    }
+
     /// Live round trip against the default distro.  Requires WSL; run
     /// manually: `cargo test -p alacritree wsl_helper:: -- --ignored`
     #[test]
@@ -736,5 +835,41 @@ mod tests {
 
         // An unregistered probe key resolves to "no foreground comm".
         assert_eq!(client.probe("999999-999999").expect("probe"), None);
+
+        use std::process::{Command, Stdio};
+
+        // The shim publishes its pid, then execs the login shell; piped stdin
+        // (held open) keeps that shell alive for the duration of the test.
+        let key = new_probe_key();
+        let (program, args) = shim_invocation(&distro.name, Path::new(r"C:\"), &key);
+        let mut child = Command::new(program)
+            .args(&args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn shimmed session");
+        std::thread::sleep(Duration::from_secs(3));
+
+        // The pidfile names a live, numeric pid...
+        let (exit, out) = client
+            .run(r#"cat "${XDG_RUNTIME_DIR:-/tmp}/alacritree/session-$1.pid" 2>/dev/null"#, &[&key])
+            .expect("read pidfile");
+        assert_eq!(exit, 0, "pidfile should exist for a shimmed session");
+        let pid = String::from_utf8_lossy(&out);
+        assert!(!pid.is_empty() && pid.chars().all(|c| c.is_ascii_digit()), "pid: {pid:?}");
+
+        // ...and probing it completes without a transport error.  WSL2
+        // allocates a controlling pty for every `--exec` session regardless
+        // of the Windows-side stdio redirection (confirmed via `/proc/self/stat`
+        // on this distro), so the shell is its own foreground process rather
+        // than tpgid -1; either a bare shell or "unknown" both read as "no
+        // TUI" to callers, so accept both rather than asserting the tty state
+        // this harness does not control.
+        let comm = client.probe(&key).expect("probe shimmed session");
+        assert!(comm.is_none() || comm.as_deref() == Some("bash"), "comm: {comm:?}");
+
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -255,7 +255,11 @@ pub fn wrap_profile_argv(
     args: &[String],
     probe_key: &str,
 ) -> Option<(Vec<String>, Option<String>)> {
-    let stem = Path::new(program).file_stem()?.to_str()?;
+    // The argv comes from a Windows host, so the program path uses Windows
+    // separators — split on them explicitly rather than via `Path`, whose
+    // separator set depends on the compilation target.
+    let file_name = program.rsplit(['\\', '/']).next().unwrap_or(program);
+    let stem = Path::new(file_name).file_stem()?.to_str()?;
     if !stem.eq_ignore_ascii_case("wsl") {
         return None;
     }

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -203,9 +203,12 @@ while IFS=$TAB read -r id kind rest; do
       stat=$(cat "/proc/$p/stat" 2>/dev/null)
       after=${stat##*')'}
       set -- $after
+      pgrp=${3:-}
       tpgid=${6:-}
       case $tpgid in ''|*[!0-9]*) tpgid= ;; esac
-      [ -n "$tpgid" ] && comm=$(cat "/proc/$tpgid/comm" 2>/dev/null)
+      if [ -n "$tpgid" ] && [ "$tpgid" != "$pgrp" ]; then
+        comm=$(cat "/proc/$tpgid/comm" 2>/dev/null)
+      fi
     fi
     printf %s "$comm" > "$t/$id.out"
     printf '%s 0\n' "$id" >> "$t/done"
@@ -888,15 +891,13 @@ mod tests {
         let pid = String::from_utf8_lossy(&out);
         assert!(!pid.is_empty() && pid.chars().all(|c| c.is_ascii_digit()), "pid: {pid:?}");
 
-        // ...and probing it completes without a transport error.  WSL2
-        // allocates a controlling pty for every `--exec` session regardless
-        // of the Windows-side stdio redirection (confirmed via `/proc/self/stat`
-        // on this distro), so the shell is its own foreground process rather
-        // than tpgid -1; either a bare shell or "unknown" both read as "no
-        // TUI" to callers, so accept both rather than asserting the tty state
-        // this harness does not control.
+        // ...and probing the idle shell resolves to "no foreground comm".
+        // WSL2 allocates a controlling pty for every `--exec` session
+        // regardless of the Windows-side stdio redirection, so the shell owns
+        // the tty itself — the probe must read that as idle, not as a running
+        // job, or every idle WSL session trips the close confirmation.
         let comm = client.probe(&key).expect("probe shimmed session");
-        assert!(comm.is_none() || comm.as_deref() == Some("bash"), "comm: {comm:?}");
+        assert_eq!(comm, None, "idle shell should probe as no foreground job");
 
         let _ = child.kill();
         let _ = child.wait();

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -526,7 +526,10 @@ pub fn try_run(distro: &str, script: &str, args: &[&str]) -> Option<Result<Vec<u
                 Some(Ok(stdout))
             }
         },
-        Err(TransportError::NotWritten(_)) => None,
+        Err(TransportError::NotWritten(e)) => {
+            log::debug!("wsl helper ({distro}): {e}; falling back to one-shot spawns");
+            None
+        },
         Err(TransportError::NoReply(e)) => Some(Err(e)),
     }
 }

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -96,11 +96,22 @@ impl FrameReader {
                     String::from_utf8_lossy(&self.buf[..newline])
                 ));
             };
-            let frame_end = newline + 1 + len;
+            let Some(payload_start) = newline.checked_add(1) else {
+                return Err(format!(
+                    "malformed helper frame header: {:?}",
+                    String::from_utf8_lossy(&self.buf[..newline])
+                ));
+            };
+            let Some(frame_end) = payload_start.checked_add(len) else {
+                return Err(format!(
+                    "malformed helper frame header: {:?}",
+                    String::from_utf8_lossy(&self.buf[..newline])
+                ));
+            };
             if self.buf.len() < frame_end {
                 return Ok(frames);
             }
-            frames.push(Frame { id, exit, payload: self.buf[newline + 1..frame_end].to_vec() });
+            frames.push(Frame { id, exit, payload: self.buf[payload_start..frame_end].to_vec() });
             self.buf.drain(..frame_end);
         }
     }
@@ -699,6 +710,12 @@ mod tests {
     fn malformed_header_is_a_protocol_error() {
         assert!(FrameReader::default().push(b"not a header\n").is_err());
         assert!(FrameReader::default().push(b"1\t0\n").is_err());
+    }
+
+    #[test]
+    fn oversized_length_field_is_a_protocol_error_not_a_panic() {
+        let header = format!("1\t0\t{}\n", usize::MAX);
+        assert!(FrameReader::default().push(header.as_bytes()).is_err());
     }
 
     use std::path::Path;

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -278,6 +278,267 @@ pub fn wrap_profile_argv(
     Some((wrapped, distro))
 }
 
+use std::collections::HashMap;
+use std::io::{BufRead, Read, Write};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError, mpsc};
+use std::time::{Duration, Instant};
+
+use crate::wsl;
+
+/// Batch scripts can legitimately run long (worktree add on a cold cache);
+/// probes are two `/proc` reads and only ever gate a keypress decision.
+const RUN_TIMEOUT: Duration = Duration::from_secs(60);
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+/// A broken distro must not cause a spawn storm.
+const RESPAWN_COOLDOWN: Duration = Duration::from_secs(30);
+
+static ENABLED: AtomicBool = AtomicBool::new(true);
+
+pub fn set_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Release);
+}
+
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Acquire)
+}
+
+/// Why a request produced no result — the distinction the fallback rule
+/// keys on.  `NotWritten` never reached the helper and is safe to re-run
+/// as a one-shot; `NoReply` was written and may have executed (batch
+/// scripts have side effects), so it must surface as an error, never a
+/// silent retry.
+#[derive(Debug)]
+pub enum TransportError {
+    NotWritten(String),
+    NoReply(String),
+}
+
+pub struct HelperClient {
+    distro: String,
+    stdin: Mutex<Option<std::process::ChildStdin>>,
+    pending: Mutex<HashMap<u64, mpsc::Sender<Frame>>>,
+    next_id: AtomicU64,
+    capabilities: OnceLock<Capabilities>,
+    down: AtomicBool,
+}
+
+fn lock<'a, T>(mutex: &'a Mutex<T>) -> std::sync::MutexGuard<'a, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+impl HelperClient {
+    /// Spawn the helper for `distro`.  Returns once the process launch is
+    /// attempted; readiness (the hello line) arrives asynchronously on the
+    /// reader thread.  Failures leave the client marked down so the
+    /// registry's cooldown sees them like any other death.
+    fn spawn(distro: &str) -> Arc<Self> {
+        let client = Arc::new(Self {
+            distro: distro.to_string(),
+            stdin: Mutex::new(None),
+            pending: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+            capabilities: OnceLock::new(),
+            down: AtomicBool::new(false),
+        });
+        let mut child = match wsl::command(distro, None)
+            .arg("sh")
+            .arg("-c")
+            .arg(HELPER_SCRIPT)
+            .arg("sh")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) => {
+                client.mark_down(&format!("failed to spawn: {e}"));
+                return client;
+            },
+        };
+        *lock(&client.stdin) = child.stdin.take();
+        let stdout = child.stdout.take().expect("stdout piped above");
+        let reader = client.clone();
+        let spawned =
+            std::thread::Builder::new().name(format!("wsl-helper-{distro}")).spawn(move || {
+                reader.read_loop(stdout);
+                // Stdin is closed by mark_down; reap so a dead helper never
+                // lingers as a zombie in the process table.
+                let _ = child.wait();
+            });
+        if let Err(e) = spawned {
+            client.mark_down(&format!("failed to start reader thread: {e}"));
+        }
+        client
+    }
+
+    fn read_loop(&self, stdout: std::process::ChildStdout) {
+        let mut reader = std::io::BufReader::new(stdout);
+        let mut hello = String::new();
+        match reader.read_line(&mut hello) {
+            Ok(n) if n > 0 => {},
+            _ => return self.mark_down("exited before hello"),
+        }
+        let Some(caps) = parse_hello(&hello) else {
+            return self.mark_down("unusable hello (unknown protocol version?)");
+        };
+        let _ = self.capabilities.set(caps);
+        let mut frames = FrameReader::default();
+        let mut chunk = [0u8; 8192];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => return self.mark_down("closed its pipe"),
+                Err(e) => return self.mark_down(&format!("read failed: {e}")),
+                Ok(n) => match frames.push(&chunk[..n]) {
+                    Ok(done) => {
+                        for frame in done {
+                            if let Some(tx) = lock(&self.pending).remove(&frame.id) {
+                                let _ = tx.send(frame);
+                            }
+                        }
+                    },
+                    Err(e) => return self.mark_down(&e),
+                },
+            }
+        }
+    }
+
+    fn mark_down(&self, why: &str) {
+        if !self.down.swap(true, Ordering::AcqRel) {
+            log::warn!("wsl helper for {}: {why}; falling back to one-shot spawns", self.distro);
+        }
+        // Closing stdin EOFs the helper, which cleans up and exits.
+        *lock(&self.stdin) = None;
+        // Waiters whose request was already written see the hangup as a
+        // dropped sender — NoReply, never a retry.
+        lock(&self.pending).clear();
+    }
+
+    fn is_down(&self) -> bool {
+        self.down.load(Ordering::Acquire)
+    }
+
+    fn is_ready(&self) -> bool {
+        !self.is_down() && self.capabilities.get().is_some()
+    }
+
+    pub fn capabilities(&self) -> Option<&Capabilities> {
+        self.capabilities.get()
+    }
+
+    fn request(&self, id: u64, line: String, timeout: Duration) -> Result<Frame, TransportError> {
+        if !self.is_ready() {
+            return Err(TransportError::NotWritten("helper not ready".to_string()));
+        }
+        let (tx, rx) = mpsc::channel();
+        lock(&self.pending).insert(id, tx);
+        let write = {
+            let mut guard = lock(&self.stdin);
+            match guard.as_mut() {
+                None => Err("helper stdin closed".to_string()),
+                Some(stdin) => stdin
+                    .write_all(line.as_bytes())
+                    .and_then(|()| stdin.flush())
+                    .map_err(|e| e.to_string()),
+            }
+        };
+        if let Err(e) = write {
+            lock(&self.pending).remove(&id);
+            // A partial line has no terminating newline, so the dispatcher
+            // can never have run it — NotWritten is safe.
+            self.mark_down(&format!("write failed: {e}"));
+            return Err(TransportError::NotWritten(e));
+        }
+        match rx.recv_timeout(timeout) {
+            Ok(frame) => Ok(frame),
+            Err(_) => {
+                lock(&self.pending).remove(&id);
+                Err(TransportError::NoReply(format!("no reply from the {} helper", self.distro)))
+            },
+        }
+    }
+
+    pub fn run(&self, script: &str, args: &[&str]) -> Result<(i32, Vec<u8>), TransportError> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let frame = self.request(id, encode_run(id, script, args), RUN_TIMEOUT)?;
+        Ok((frame.exit, frame.payload))
+    }
+
+    pub fn probe(&self, key: &str) -> Result<Option<String>, TransportError> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let frame = self.request(id, encode_probe(id, key), PROBE_TIMEOUT)?;
+        let comm = String::from_utf8_lossy(&frame.payload).trim().to_string();
+        Ok((!comm.is_empty()).then_some(comm))
+    }
+}
+
+enum Slot {
+    Live(Arc<HelperClient>),
+    Cooldown(Instant),
+}
+
+fn registry() -> &'static Mutex<HashMap<String, Slot>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, Slot>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The ready client for `distro`, spawning one when none exists.  `None`
+/// while disabled, still starting, or cooling down after a death — callers
+/// fall back to one-shot spawns, which pay the same cold-boot cost the
+/// helper would.  Spawning happens under the registry lock but is only a
+/// process launch; the slow part (the hello) lands on the reader thread.
+/// Never call on the UI thread — same rule as `wsl::run_batch`.
+pub fn client(distro: &str) -> Option<Arc<HelperClient>> {
+    if !enabled() || !cfg!(windows) {
+        return None;
+    }
+    let mut reg = lock(registry());
+    match reg.get(distro) {
+        Some(Slot::Live(c)) if c.is_ready() => return Some(c.clone()),
+        Some(Slot::Live(c)) if !c.is_down() => return None,
+        Some(Slot::Live(_)) => {
+            reg.insert(distro.to_string(), Slot::Cooldown(Instant::now()));
+            return None;
+        },
+        Some(Slot::Cooldown(since)) if since.elapsed() < RESPAWN_COOLDOWN => return None,
+        _ => {},
+    }
+    reg.insert(distro.to_string(), Slot::Live(HelperClient::spawn(distro)));
+    None
+}
+
+/// Resident-first transport for `wsl::run_batch`.  `None` = helper
+/// unavailable before anything was sent (fall back to a one-shot spawn);
+/// `Some(Err)` = sent but unanswered, which must not be retried;
+/// `Some(Ok)` = script stdout, one-shot-compatible.
+pub fn try_run(distro: &str, script: &str, args: &[&str]) -> Option<Result<Vec<u8>, String>> {
+    let client = client(distro)?;
+    match client.run(script, args) {
+        Ok((exit, stdout)) => {
+            // Mirror one-shot semantics: guarded scripts always emit their
+            // sections, so hard failure with silence means the script
+            // itself refused.
+            if exit != 0 && stdout.is_empty() {
+                Some(Err(format!("wsl helper script exited {exit}")))
+            } else {
+                Some(Ok(stdout))
+            }
+        },
+        Err(TransportError::NotWritten(_)) => None,
+        Err(TransportError::NoReply(e)) => Some(Err(e)),
+    }
+}
+
+pub fn capability_delta(distro: &str) -> Option<String> {
+    client(distro)?.capabilities()?.delta.clone()
+}
+
+pub fn capability_gh(distro: &str) -> Option<String> {
+    client(distro)?.capabilities()?.gh.clone()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -428,5 +689,52 @@ mod tests {
         assert!(wrap_profile_argv("wsl.exe", &to_vec(&["-d"]), "k").is_none());
         assert!(wrap_profile_argv("pwsh.exe", &[], "k").is_none());
         assert!(wrap_profile_argv("wslhost.exe", &[], "k").is_none());
+    }
+
+    /// Live round trip against the default distro.  Requires WSL; run
+    /// manually: `cargo test -p alacritree wsl_helper:: -- --ignored`
+    #[test]
+    #[ignore]
+    fn helper_round_trips() {
+        use std::time::{Duration, Instant};
+
+        let distro =
+            crate::wsl::distros().into_iter().find(|d| d.is_default).expect("a default distro");
+        // Cold VM boot can take a while; the client comes up asynchronously.
+        let deadline = Instant::now() + Duration::from_secs(120);
+        let client = loop {
+            if let Some(c) = client(&distro.name) {
+                break c;
+            }
+            assert!(Instant::now() < deadline, "helper never became ready");
+            std::thread::sleep(Duration::from_millis(200));
+        };
+
+        let caps = client.capabilities().expect("capabilities after ready");
+        assert!(caps.git.is_some(), "test distros are expected to have git");
+        assert!(caps.runtime_dir.ends_with("/alacritree"));
+
+        let (exit, out) = client.run(r#"printf '%s' "$1""#, &["hello"]).expect("run");
+        assert_eq!((exit, out.as_slice()), (0, &b"hello"[..]));
+
+        // Empty args survive the `-` field encoding.
+        let (_, out) = client.run(r#"printf '[%s][%s]' "$1" "$2""#, &["", "x"]).expect("run");
+        assert_eq!(out, b"[][x]");
+
+        // Payloads are binary-safe end to end.
+        let (_, out) = client.run(r#"printf 'a\0b'"#, &[]).expect("run");
+        assert_eq!(out, b"a\0b");
+
+        // Concurrent jobs multiplex on one pipe without cross-talk.
+        let slow = std::thread::spawn({
+            let client = client.clone();
+            move || client.run("sleep 1; printf slow", &[]).expect("slow run")
+        });
+        let (_, fast) = client.run("printf fast", &[]).expect("fast run");
+        assert_eq!(fast, b"fast");
+        assert_eq!(slow.join().unwrap().1, b"slow");
+
+        // An unregistered probe key resolves to "no foreground comm".
+        assert_eq!(client.probe("999999-999999").expect("probe"), None);
     }
 }

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -116,6 +116,168 @@ fn parse_header(line: &[u8]) -> Option<(u64, i32, usize)> {
     fields.next().is_none().then_some((id, exit, len))
 }
 
+use std::path::Path;
+
+/// The distro-side helper, passed verbatim as the single argument of
+/// `wsl.exe --exec sh -c`.  POSIX sh only — dash and busybox ash both run
+/// it.  Shape: capability hello, dead-pidfile GC, a background writer that
+/// owns stdout, then the request dispatcher on stdin.  Responses all leave
+/// through the writer, whose FIFO completion lines are far under PIPE_BUF,
+/// so concurrent jobs never interleave frames.  Commentary lives here, not
+/// in the script, so every byte shipped into the distro earns its keep.
+///
+/// Empty request fields arrive as `-` (see `encode_field`); decoded args
+/// lose trailing newlines to command substitution, which no current caller
+/// passes.  Stdin EOF ends the dispatcher; the EXIT trap removes the temp
+/// dir and `kill 0` takes the writer and any in-flight jobs down with the
+/// process group, so a job can never deadlock on the deleted FIFO.
+pub(crate) const HELPER_SCRIPT: &str = r##"
+set -u
+b64() { printf %s "$1" | base64 | tr -d '\n'; }
+s=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)
+[ -x "$s" ] || s=${SHELL:-/bin/sh}
+caps=$("$s" -lc 'command -v git || echo; command -v delta || echo; command -v gh || echo' 2>/dev/null)
+rt=${XDG_RUNTIME_DIR:-/tmp}/alacritree
+printf 'hello\t1\t%s\t%s\t%s\t%s\n' \
+  "$(b64 "$(printf %s "$caps" | sed -n 1p)")" \
+  "$(b64 "$(printf %s "$caps" | sed -n 2p)")" \
+  "$(b64 "$(printf %s "$caps" | sed -n 3p)")" \
+  "$(b64 "$rt")"
+mkdir -p "$rt" 2>/dev/null
+for f in "$rt"/session-*.pid; do
+  [ -e "$f" ] || continue
+  p=$(cat "$f" 2>/dev/null)
+  case $p in ''|*[!0-9]*) rm -f "$f"; continue;; esac
+  [ -d "/proc/$p" ] || rm -f "$f"
+done
+t=$(mktemp -d) || exit 1
+mkfifo "$t/done" || exit 1
+trap 'rm -rf "$t"; kill 0 2>/dev/null' EXIT
+(
+  exec 3<>"$t/done"
+  while read -r id code <&3; do
+    out="$t/$id.out"
+    n=$(wc -c < "$out" 2>/dev/null) || n=0
+    printf '%s\t%s\t%s\n' "$id" "$code" "${n:-0}"
+    cat "$out" 2>/dev/null
+    rm -f "$out"
+  done
+) &
+TAB=$(printf '\t')
+while IFS=$TAB read -r id kind rest; do
+  case $kind in
+  RUN)
+    (
+      script=
+      set --
+      first=1
+      line=$rest
+      while [ -n "$line" ]; do
+        case $line in
+        *"$TAB"*) field=${line%%"$TAB"*}; line=${line#*"$TAB"} ;;
+        *) field=$line; line= ;;
+        esac
+        if [ "$field" = - ]; then dec=; else dec=$(printf %s "$field" | base64 -d 2>/dev/null); fi
+        if [ "$first" = 1 ]; then script=$dec; first=0; else set -- "$@" "$dec"; fi
+      done
+      sh -c "$script" sh "$@" > "$t/$id.out" 2>/dev/null
+      printf '%s %s\n' "$id" "$?" >> "$t/done"
+    ) &
+    ;;
+  PROBE)
+    comm=
+    p=$(cat "$rt/session-$rest.pid" 2>/dev/null)
+    case $p in ''|*[!0-9]*) p= ;; esac
+    if [ -n "$p" ] && [ -d "/proc/$p" ]; then
+      stat=$(cat "/proc/$p/stat" 2>/dev/null)
+      after=${stat##*')'}
+      set -- $after
+      tpgid=${6:-}
+      case $tpgid in ''|*[!0-9]*) tpgid= ;; esac
+      [ -n "$tpgid" ] && comm=$(cat "/proc/$tpgid/comm" 2>/dev/null)
+    fi
+    printf %s "$comm" > "$t/$id.out"
+    printf '%s 0\n' "$id" >> "$t/done"
+    ;;
+  esac
+done
+"##;
+
+/// Login-shell shim for shimmed WSL sessions: publish the shell's PID under
+/// the probe key, then become the user's login shell.  `exec` makes the
+/// pidfile PID *be* the shell, so the helper's tpgid walk starts from the
+/// right place.  wsl.exe's own no-`--exec` launch would start the login
+/// shell too but gives no way to learn its PID; re-resolving through
+/// `getent` is the documented divergence, with `/bin/sh` only as a last
+/// resort.  Single line: it travels through ConPTY command-line quoting.
+pub(crate) const SHIM_SCRIPT: &str = r##"d=${XDG_RUNTIME_DIR:-/tmp}/alacritree; mkdir -p "$d" 2>/dev/null && printf %s $$ > "$d/session-$1.pid"; s=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7); [ -x "$s" ] || s=/bin/sh; exec "$s" -l"##;
+
+/// argv for a session alacritree constructs itself (`ShellChoice::Wsl`,
+/// auto-by-location): the shim with the probe key as `$1`.
+pub fn shim_invocation(distro: &str, workdir: &Path, probe_key: &str) -> (String, Vec<String>) {
+    (
+        "wsl.exe".to_string(),
+        vec![
+            "-d".to_string(),
+            distro.to_string(),
+            "--cd".to_string(),
+            workdir.to_string_lossy().into_owned(),
+            "--exec".to_string(),
+            "sh".to_string(),
+            "-c".to_string(),
+            SHIM_SCRIPT.to_string(),
+            "sh".to_string(),
+            probe_key.to_string(),
+        ],
+    )
+}
+
+/// Probe-key shim for a `[[ui.profiles]]` entry that launches wsl.exe.
+/// Only argv this parser fully understands is wrapped: any mix of
+/// `-d`/`--distribution <distro>` and `--cd <dir>`, nothing else.  An
+/// unknown flag or a positional command may not be a plain login shell —
+/// it runs unmodified and simply probes as unknown.  Returns the rewritten
+/// argv plus the explicit distro (`None` = the default distro; the caller
+/// resolves it, since only `wsl::distros` knows which that is).
+pub fn wrap_profile_argv(
+    program: &str,
+    args: &[String],
+    probe_key: &str,
+) -> Option<(Vec<String>, Option<String>)> {
+    let stem = Path::new(program).file_stem()?.to_str()?;
+    if !stem.eq_ignore_ascii_case("wsl") {
+        return None;
+    }
+    let mut distro = None;
+    let mut wrapped = Vec::new();
+    let mut it = args.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "-d" | "--distribution" => {
+                let name = it.next()?;
+                distro = Some(name.clone());
+                wrapped.push(arg.clone());
+                wrapped.push(name.clone());
+            },
+            "--cd" => {
+                let dir = it.next()?;
+                wrapped.push(arg.clone());
+                wrapped.push(dir.clone());
+            },
+            _ => return None,
+        }
+    }
+    wrapped.extend([
+        "--exec".to_string(),
+        "sh".to_string(),
+        "-c".to_string(),
+        SHIM_SCRIPT.to_string(),
+        "sh".to_string(),
+        probe_key.to_string(),
+    ]);
+    Some((wrapped, distro))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,5 +361,72 @@ mod tests {
     fn malformed_header_is_a_protocol_error() {
         assert!(FrameReader::default().push(b"not a header\n").is_err());
         assert!(FrameReader::default().push(b"1\t0\n").is_err());
+    }
+
+    use std::path::Path;
+
+    #[test]
+    fn shim_invocation_builds_expected_argv() {
+        let (program, args) = shim_invocation("kali-linux", Path::new(r"C:\proj"), "1234-1");
+        assert_eq!(program, "wsl.exe");
+        assert_eq!(
+            args,
+            vec![
+                "-d",
+                "kali-linux",
+                "--cd",
+                r"C:\proj",
+                "--exec",
+                "sh",
+                "-c",
+                SHIM_SCRIPT,
+                "sh",
+                "1234-1",
+            ]
+        );
+    }
+
+    #[test]
+    fn wraps_bare_wsl_profile_for_default_distro() {
+        let (args, distro) = wrap_profile_argv("wsl.exe", &[], "1234-2").unwrap();
+        assert_eq!(distro, None);
+        assert_eq!(args, vec!["--exec", "sh", "-c", SHIM_SCRIPT, "sh", "1234-2"]);
+    }
+
+    #[test]
+    fn wraps_distro_and_cd_flags() {
+        let profile_args: Vec<String> =
+            ["-d", "kali-linux", "--cd", "/home"].iter().map(|s| s.to_string()).collect();
+        let (args, distro) =
+            wrap_profile_argv(r"C:\Windows\System32\wsl.exe", &profile_args, "9-9").unwrap();
+        assert_eq!(distro.as_deref(), Some("kali-linux"));
+        assert_eq!(
+            args,
+            vec![
+                "-d",
+                "kali-linux",
+                "--cd",
+                "/home",
+                "--exec",
+                "sh",
+                "-c",
+                SHIM_SCRIPT,
+                "sh",
+                "9-9"
+            ]
+        );
+    }
+
+    #[test]
+    fn refuses_unparseable_profiles() {
+        let to_vec = |a: &[&str]| a.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        // A positional command, an unknown flag, or a dangling value-flag may
+        // not be a plain login shell — leave it alone (probes as unknown).
+        assert!(wrap_profile_argv("wsl.exe", &to_vec(&["bash"]), "k").is_none());
+        assert!(wrap_profile_argv("wsl.exe", &to_vec(&["-d", "kali", "htop"]), "k").is_none());
+        assert!(wrap_profile_argv("wsl.exe", &to_vec(&["--exec", "sh"]), "k").is_none());
+        assert!(wrap_profile_argv("wsl.exe", &to_vec(&["-d"]), "k").is_none());
+        assert!(wrap_profile_argv("pwsh.exe", &[], "k").is_none());
+        assert!(wrap_profile_argv("wslhost.exe", &[], "k").is_none());
     }
 }

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -46,7 +46,9 @@ pub fn encode_probe(id: u64, key: &str) -> String {
 }
 
 pub fn parse_hello(line: &str) -> Option<Capabilities> {
-    let mut fields = line.trim_end().split('\t');
+    // Strip only line terminators — trim_end() would also eat the tab
+    // before a legitimately empty trailing field.
+    let mut fields = line.trim_end_matches(['\r', '\n']).split('\t');
     if fields.next()? != "hello" || fields.next()? != PROTOCOL_VERSION {
         return None;
     }
@@ -153,6 +155,13 @@ mod tests {
         assert!(parse_hello("hello\t2\t\t\t\t\n").is_none());
         assert!(parse_hello("goodbye\t1\t\t\t\t\n").is_none());
         assert!(parse_hello("hello\t1\t\t\n").is_none());
+    }
+
+    #[test]
+    fn hello_with_empty_trailing_field_still_parses() {
+        let caps = parse_hello("hello\t1\t\t\t\t\n").expect("empty fields are valid");
+        assert_eq!(caps.git, None);
+        assert_eq!(caps.runtime_dir, "");
     }
 
     #[test]

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -1,0 +1,194 @@
+//! Resident WSL helper: one long-lived `sh` per distro, spoken to over its
+//! stdio pipe, serving the batch scripts (`RUN`), the foreground-process
+//! probe (`PROBE`), and tool paths (the hello line) without a per-call
+//! `wsl.exe` spawn.  The wire protocol is the seam a future compiled helper
+//! would slot behind; nothing outside this module knows it exists.
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+
+/// Bumped only when the request/response framing changes incompatibly; a
+/// client seeing any other version treats the helper as unusable and stays
+/// on one-shot spawns.
+pub const PROTOCOL_VERSION: &str = "1";
+
+/// Login-shell-resolved tool paths and the distro-side runtime dir, from
+/// the helper's hello line.  `None` means the tool wasn't on the login
+/// shell's PATH at helper start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Capabilities {
+    pub git: Option<String>,
+    pub delta: Option<String>,
+    pub gh: Option<String>,
+    pub runtime_dir: String,
+}
+
+/// A request-side payload field: base64, or `-` for the empty payload.
+/// Tab is IFS whitespace in sh, so an empty field would be collapsed away
+/// by the dispatcher's field splitting; base64 can never produce a bare
+/// `-`, so the encodings stay disjoint.
+fn encode_field(payload: &str) -> String {
+    if payload.is_empty() { "-".to_string() } else { B64.encode(payload) }
+}
+
+pub fn encode_run(id: u64, script: &str, args: &[&str]) -> String {
+    let mut line = format!("{id}\tRUN\t{}", encode_field(script));
+    for arg in args {
+        line.push('\t');
+        line.push_str(&encode_field(arg));
+    }
+    line.push('\n');
+    line
+}
+
+pub fn encode_probe(id: u64, key: &str) -> String {
+    format!("{id}\tPROBE\t{key}\n")
+}
+
+pub fn parse_hello(line: &str) -> Option<Capabilities> {
+    let mut fields = line.trim_end().split('\t');
+    if fields.next()? != "hello" || fields.next()? != PROTOCOL_VERSION {
+        return None;
+    }
+    let mut decode = || -> Option<String> {
+        let raw = B64.decode(fields.next()?).ok()?;
+        Some(String::from_utf8_lossy(&raw).trim().to_string())
+    };
+    let git = decode()?;
+    let delta = decode()?;
+    let gh = decode()?;
+    let runtime_dir = decode()?;
+    let some = |s: String| (!s.is_empty()).then_some(s);
+    Some(Capabilities { git: some(git), delta: some(delta), gh: some(gh), runtime_dir })
+}
+
+/// One response off the helper's stdout: `<id>\t<exit>\t<len>\n` followed
+/// by exactly `len` raw payload bytes.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Frame {
+    pub id: u64,
+    pub exit: i32,
+    pub payload: Vec<u8>,
+}
+
+/// Incremental response parser fed arbitrary read chunks; complete frames
+/// come out as they close.  A malformed header is unrecoverable (the byte
+/// count is the only framing, so there is no resync point) and surfaces as
+/// an error for the caller to tear the client down on.
+#[derive(Default)]
+pub struct FrameReader {
+    buf: Vec<u8>,
+}
+
+impl FrameReader {
+    pub fn push(&mut self, bytes: &[u8]) -> Result<Vec<Frame>, String> {
+        self.buf.extend_from_slice(bytes);
+        let mut frames = Vec::new();
+        loop {
+            let Some(newline) = self.buf.iter().position(|&b| b == b'\n') else {
+                return Ok(frames);
+            };
+            let Some((id, exit, len)) = parse_header(&self.buf[..newline]) else {
+                return Err(format!(
+                    "malformed helper frame header: {:?}",
+                    String::from_utf8_lossy(&self.buf[..newline])
+                ));
+            };
+            let frame_end = newline + 1 + len;
+            if self.buf.len() < frame_end {
+                return Ok(frames);
+            }
+            frames.push(Frame { id, exit, payload: self.buf[newline + 1..frame_end].to_vec() });
+            self.buf.drain(..frame_end);
+        }
+    }
+}
+
+fn parse_header(line: &[u8]) -> Option<(u64, i32, usize)> {
+    let text = std::str::from_utf8(line).ok()?;
+    let mut fields = text.trim_end_matches('\r').split('\t');
+    // `wc -c` output may carry leading blanks on some implementations.
+    let id = fields.next()?.trim().parse().ok()?;
+    let exit = fields.next()?.trim().parse().ok()?;
+    let len = fields.next()?.trim().parse().ok()?;
+    fields.next().is_none().then_some((id, exit, len))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_request_encodes_base64_fields() {
+        let line = encode_run(7, r#"printf %s "$1""#, &["hello"]);
+        assert_eq!(line, "7\tRUN\tcHJpbnRmICVzICIkMSI=\taGVsbG8=\n");
+    }
+
+    #[test]
+    fn empty_arg_encodes_as_dash() {
+        // Tab is IFS whitespace in sh, so an empty field would be collapsed
+        // away by the dispatcher's field splitting.
+        let line = encode_run(1, "s", &["", "x"]);
+        assert_eq!(line, "1\tRUN\tcw==\t-\teA==\n");
+    }
+
+    #[test]
+    fn probe_request_is_plain() {
+        assert_eq!(encode_probe(3, "1234-7"), "3\tPROBE\t1234-7\n");
+    }
+
+    #[test]
+    fn parses_hello_with_missing_tools() {
+        // git and runtime dir present, delta and gh absent (empty fields).
+        let line = "hello\t1\tL3Vzci9iaW4vZ2l0\t\t\tL3J1bi91c2VyLzEwMDAvYWxhY3JpdHJlZQ==\n";
+        let caps = parse_hello(line).unwrap();
+        assert_eq!(caps.git.as_deref(), Some("/usr/bin/git"));
+        assert_eq!(caps.delta, None);
+        assert_eq!(caps.gh, None);
+        assert_eq!(caps.runtime_dir, "/run/user/1000/alacritree");
+    }
+
+    #[test]
+    fn rejects_unknown_hello_version() {
+        assert!(parse_hello("hello\t2\t\t\t\t\n").is_none());
+        assert!(parse_hello("goodbye\t1\t\t\t\t\n").is_none());
+        assert!(parse_hello("hello\t1\t\t\n").is_none());
+    }
+
+    #[test]
+    fn reassembles_frames_across_split_reads() {
+        let mut stream = Vec::new();
+        stream.extend_from_slice(b"4\t0\t5\nhello");
+        stream.extend_from_slice(b"9\t1\t0\n");
+        let mut reader = FrameReader::default();
+        let mut frames = Vec::new();
+        // Byte-at-a-time is the worst case a pipe can deliver.
+        for byte in stream {
+            frames.extend(reader.push(&[byte]).unwrap());
+        }
+        assert_eq!(
+            frames,
+            vec![
+                Frame { id: 4, exit: 0, payload: b"hello".to_vec() },
+                Frame { id: 9, exit: 1, payload: Vec::new() },
+            ]
+        );
+    }
+
+    #[test]
+    fn payload_bytes_are_binary_safe() {
+        // NUL-delimited git porcelain, tabs, and newlines all pass through:
+        // the header's byte count is the only framing.
+        let payload = b"a\0b\tc\nd";
+        let mut stream = format!("1\t0\t{}\n", payload.len()).into_bytes();
+        stream.extend_from_slice(payload);
+        let frames = FrameReader::default().push(&stream).unwrap();
+        assert_eq!(frames, vec![Frame { id: 1, exit: 0, payload: payload.to_vec() }]);
+    }
+
+    #[test]
+    fn malformed_header_is_a_protocol_error() {
+        assert!(FrameReader::default().push(b"not a header\n").is_err());
+        assert!(FrameReader::default().push(b"1\t0\n").is_err());
+    }
+}

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -838,12 +838,17 @@ mod tests {
 
         use std::process::{Command, Stdio};
 
+        use crate::command_ext::CommandExt;
+
         // The shim publishes its pid, then execs the login shell; piped stdin
         // (held open) keeps that shell alive for the duration of the test.
+        // Without hide_console the spawn pops a visible terminal window when
+        // the test runs from a hidden console.
         let key = new_probe_key();
         let (program, args) = shim_invocation(&distro.name, Path::new(r"C:\"), &key);
         let mut child = Command::new(program)
             .args(&args)
+            .hide_console()
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())


### PR DESCRIPTION
One resident POSIX-sh process per WSL distro, spawned lazily by alacritree and spoken to over its stdio pipe. Nothing is installed inside the distro — the helper script is a string constant compiled into the binary. It serves three things:

- **RUN** — the existing `run_batch` scripts (git status, dirty counts, discovery, worktree ops) run over the pipe instead of paying a `wsl.exe` spawn per query (~400 ms warm, seconds while the VM cold-boots).
- **PROBE** — the real foreground process of a WSL session, via the same tpgid-from-`/proc` check the native Linux build uses. FocusLeft/FocusRight now forward into the distro only when a cooperating TUI is actually in the foreground.
- **hello capabilities** — login-shell-resolved `git`/`delta`/`gh` paths, so delta discovery and `gh pr view` for WSL repos honor per-user install dirs without a spawn.

Sessions alacritree constructs itself (and profile/config shells whose argv is a safely parseable `wsl.exe` invocation) spawn through a tiny shim that records the shell PID for probing; anything exotic runs unmodified and probes as unknown.

**Safety rules:** falling back to a one-shot spawn is only allowed when the request was never written to the pipe; a request that was sent but got no reply returns an error and is never silently re-run (batch scripts can have side effects). Helper death falls back to one-shot spawns with a 30 s respawn cooldown.

**Config:** new top-level `[wsl]` section — `resident_helper` (default `true`) and `automount_root` (moved from `[ui.wsl]`; the old location still works and is documented as deprecated). `resident_helper = false` restores one-shot spawns and unmodified session invocations everywhere.

**One deliberate behavior change (not config-gateable):** the old rule that assumed every WSL session has a cooperating nav TUI is deleted — it was the reported bug (focus keys completely dead in bare shells and Claude Code sessions). With the helper disabled or down, WSL sessions never forward focus keys; they always move panel focus. No config combination reproduces the old always-forward behavior.

**Tests:** 391 passing (protocol codec, probe decisions, profile-argv parser, config precedence), plus `#[ignore]`d live round-trip tests against a real distro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
