### PR TITLE
[9] fix(bindings): parse modern and legacy alacritty key names

### DIFF
--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -406,12 +406,13 @@ fn parse_key(name: &str) -> Option<Key> {
         let c = n.chars().next().unwrap().to_ascii_uppercase();
         return char_to_key(c);
     }
-    if n == "NumpadEnter" {
-        // egui-winit maps both `KeyCode::Enter` and `KeyCode::NumpadEnter` to
-        // `egui::Key::Enter`, so we can't tell them apart.  Aliasing NumpadEnter
-        // to Enter would silently fire NumpadEnter bindings on the regular
-        // Return key — drop the binding instead.
-        log::warn!("ignoring NumpadEnter binding: egui cannot distinguish it from Return");
+    if n.starts_with("Numpad") {
+        // egui-winit collapses numpad keys into their standard counterparts
+        // (`KeyCode::NumpadEnter` → `egui::Key::Enter`, NumpadAdd → the plus
+        // key, ...), so a numpad binding can't be told apart from the main
+        // key.  Aliasing would silently fire it on the standard key — drop
+        // the binding instead.
+        log::warn!("ignoring {n} binding: egui cannot distinguish numpad keys");
         return None;
     }
     Some(match n {
@@ -444,6 +445,11 @@ fn parse_key(name: &str) -> Option<Key> {
         "LBracket" | "LeftBracket" => Key::OpenBracket,
         "RBracket" | "RightBracket" => Key::CloseBracket,
         "Grave" | "Backtick" => Key::Backtick,
+        "Colon" => Key::Colon,
+        // Legacy alacritty digit names: "Key1" is the top-row 1.
+        n if n.len() == 4 && n.starts_with("Key") => {
+            return char_to_key(n.chars().nth(3).unwrap());
+        },
         // F1..F35.
         n if n.starts_with('F') => {
             let num: u8 = n[1..].parse().ok()?;
@@ -491,6 +497,19 @@ fn char_to_key(c: char) -> Option<Key> {
         '7' => Key::Num7,
         '8' => Key::Num8,
         '9' => Key::Num9,
+        '-' => Key::Minus,
+        '=' => Key::Equals,
+        '+' => Key::Plus,
+        ',' => Key::Comma,
+        '.' => Key::Period,
+        '/' => Key::Slash,
+        '\\' => Key::Backslash,
+        ';' => Key::Semicolon,
+        ':' => Key::Colon,
+        '\'' => Key::Quote,
+        '`' => Key::Backtick,
+        '[' => Key::OpenBracket,
+        ']' => Key::CloseBracket,
         _ => return None,
     })
 }
@@ -498,32 +517,33 @@ fn char_to_key(c: char) -> Option<Key> {
 /// Winit key names that egui doesn't model.  Default alacritty configs include
 /// a handful of these, so swallow them silently rather than logging noise.
 fn is_silent_unsupported_key(name: &str) -> bool {
-    matches!(
-        name.trim(),
-        "Paste"
-            | "Copy"
-            | "Cut"
-            | "Find"
-            | "Help"
-            | "Undo"
-            | "BrowserBack"
-            | "BrowserForward"
-            | "BrowserRefresh"
-            | "BrowserStop"
-            | "BrowserHome"
-            | "BrowserSearch"
-            | "BrowserFavorites"
-            | "MediaPlayPause"
-            | "MediaStop"
-            | "MediaTrackNext"
-            | "MediaTrackPrevious"
-            | "VolumeUp"
-            | "VolumeDown"
-            | "VolumeMute"
-            // `parse_key` already logs a dedicated message explaining why
-            // NumpadEnter is dropped; suppress the generic "unknown key" follow-up.
-            | "NumpadEnter"
-    )
+    let n = name.trim();
+    // `parse_key` already logs a dedicated message explaining why numpad
+    // bindings are dropped; suppress the generic "unknown key" follow-up.
+    n.starts_with("Numpad")
+        || matches!(
+            n,
+            "Paste"
+                | "Copy"
+                | "Cut"
+                | "Find"
+                | "Help"
+                | "Undo"
+                | "BrowserBack"
+                | "BrowserForward"
+                | "BrowserRefresh"
+                | "BrowserStop"
+                | "BrowserHome"
+                | "BrowserSearch"
+                | "BrowserFavorites"
+                | "MediaPlayPause"
+                | "MediaStop"
+                | "MediaTrackNext"
+                | "MediaTrackPrevious"
+                | "VolumeUp"
+                | "VolumeDown"
+                | "VolumeMute"
+        )
 }
 
 fn f_key(n: u8) -> Option<Key> {
@@ -799,6 +819,68 @@ mod tests {
             assert!(
                 matched.iter().any(|a| matches!(a, BindingAction::Chars(c) if c == b"x")),
                 "{name} binding was dropped: {matched:?}"
+            );
+        }
+    }
+
+    /// Alacritty accepts any single character as a key name; the punctuation
+    /// egui models must round-trip instead of being dropped as unknown.
+    #[test]
+    fn single_char_punctuation_parses() {
+        for (name, key) in [
+            ("-", Key::Minus),
+            ("=", Key::Equals),
+            ("+", Key::Plus),
+            ("[", Key::OpenBracket),
+            ("]", Key::CloseBracket),
+            (";", Key::Semicolon),
+            (":", Key::Colon),
+            ("'", Key::Quote),
+            ("`", Key::Backtick),
+            (",", Key::Comma),
+            (".", Key::Period),
+            ("/", Key::Slash),
+            ("\\", Key::Backslash),
+        ] {
+            let bindings = parse_bindings(vec![raw_chars(name, None, "x")]);
+            let matched = all_matches(&bindings, key, Modifiers::NONE);
+            assert!(
+                matched.iter().any(|a| matches!(a, BindingAction::Chars(c) if c == b"x")),
+                "{name:?} binding was dropped: {matched:?}"
+            );
+        }
+    }
+
+    /// Alacritty's legacy digit names ("Key1") and the "Colon" alias must keep
+    /// their bindings like they do upstream.
+    #[test]
+    fn legacy_key_names_parse() {
+        for (name, key) in
+            [("Key0", Key::Num0), ("Key1", Key::Num1), ("Key9", Key::Num9), ("Colon", Key::Colon)]
+        {
+            let bindings = parse_bindings(vec![raw_chars(name, None, "x")]);
+            let matched = all_matches(&bindings, key, Modifiers::NONE);
+            assert!(
+                matched.iter().any(|a| matches!(a, BindingAction::Chars(c) if c == b"x")),
+                "{name} binding was dropped: {matched:?}"
+            );
+        }
+    }
+
+    /// egui collapses numpad keys into their standard counterparts, so numpad
+    /// bindings are dropped — with the dedicated log message, not the generic
+    /// unknown-key warning.
+    #[test]
+    fn numpad_bindings_drop_without_unknown_key_noise() {
+        for name in ["NumpadEnter", "NumpadAdd", "Numpad1"] {
+            let bindings = parse_bindings(vec![raw_chars(name, None, "x")]);
+            assert!(
+                !bindings.iter().any(|b| matches!(&b.action, BindingAction::Chars(c) if c == b"x")),
+                "{name} must not produce a binding"
+            );
+            assert!(
+                is_silent_unsupported_key(name),
+                "{name} must be exempt from the generic unknown-key warning"
             );
         }
     }

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -426,10 +426,12 @@ fn parse_key(name: &str) -> Option<Key> {
         "End" => Key::End,
         "PageUp" => Key::PageUp,
         "PageDown" => Key::PageDown,
-        "Up" => Key::ArrowUp,
-        "Down" => Key::ArrowDown,
-        "Left" => Key::ArrowLeft,
-        "Right" => Key::ArrowRight,
+        // Alacritty names keys after winit's `NamedKey` ("ArrowUp") and keeps
+        // the pre-0.13 names ("Up") as legacy aliases — accept both.
+        "ArrowUp" | "Up" => Key::ArrowUp,
+        "ArrowDown" | "Down" => Key::ArrowDown,
+        "ArrowLeft" | "Left" => Key::ArrowLeft,
+        "ArrowRight" | "Right" => Key::ArrowRight,
         "Minus" => Key::Minus,
         "Equals" | "Equal" => Key::Equals,
         "Plus" => Key::Plus,
@@ -778,6 +780,27 @@ mod tests {
             matched.iter().any(|a| matches!(a, BindingAction::Named(NamedAction::Paste))),
             "Ctrl+Shift+V no longer pastes: {matched:?}"
         );
+    }
+
+    /// Modern alacritty configs name keys after winit's `NamedKey`
+    /// ("ArrowUp"); the legacy alacritty names ("Up") are aliases.  Both
+    /// spellings must keep their bindings.
+    #[test]
+    fn winit_named_arrow_keys_parse() {
+        for (name, key) in [
+            ("ArrowUp", Key::ArrowUp),
+            ("ArrowDown", Key::ArrowDown),
+            ("ArrowLeft", Key::ArrowLeft),
+            ("ArrowRight", Key::ArrowRight),
+            ("Up", Key::ArrowUp),
+        ] {
+            let bindings = parse_bindings(vec![raw_chars(name, None, "x")]);
+            let matched = all_matches(&bindings, key, Modifiers::NONE);
+            assert!(
+                matched.iter().any(|a| matches!(a, BindingAction::Chars(c) if c == b"x")),
+                "{name} binding was dropped: {matched:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Alacritree's `parse_key` translates alacritty's `[[keyboard.bindings]]` key names into egui keys, but only knew a subset of what alacritty accepts — such bindings were silently dropped with an "ignoring binding for unknown key" warning.

Verified against alacritty master's `BindingKey` deserializer (`alacritty/src/config/bindings.rs`), which accepts winit `NamedKey` spellings natively plus a legacy translation table:

- **Winit arrow names** (`ArrowUp`, `ArrowDown`, ...): the canonical spellings in alacritty 0.13+ and its docs; only the pre-0.13 aliases (`Up`, `Down`, ...) parsed. Both spellings now map to the same key, like upstream.
- **Single-character names** (`key = "+"`, `"["`, `"-"`): alacritty accepts any single character; only alphanumerics parsed. Added the punctuation egui models.
- **Legacy digit names** (`Key1`) **and `Colon`**: from upstream's legacy table.
- **Numpad family**: egui collapses numpad keys into their standard counterparts, so these can't be supported — but only `NumpadEnter` got the dedicated explanation; the rest fell through to the generic unknown-key warning. The whole `Numpad*` family is now dropped with the dedicated message.

Deliberately out of scope: `At`/`Asterisk` (no egui key exists, the warning is honest), numeric scancodes and `Dead*` keys (not representable in egui), media/browser keys (already silently dropped).

TDD: each gap covered by a table-driven test written first and confirmed failing, then green. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)