### PR TITLE
[10] feat(config): honor general.working_directory

### DIFF
--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -39,6 +39,12 @@ pub struct Config {
     /// Offer the IPC socket that `alacritree mcp` connects to.  Mirrors
     /// alacritty's `[general] ipc_socket` (default on).
     pub ipc_socket: bool,
+    /// Start dir for sessions with no explicit workspace (the home tab);
+    /// worktree tabs always use their checkout path.  Mirrors alacritty's
+    /// `[general] working_directory`, except a leading `~` expands to the
+    /// home directory (upstream only expands `~` in config imports) so one
+    /// shared config works on every platform.
+    pub working_directory: Option<PathBuf>,
     pub wsl_automount_root: String,
     /// Explicit `delta` program for the diff pane, from `[ui] delta_path`.
     /// When set it is used verbatim in git's `core.pager` on every platform
@@ -450,6 +456,7 @@ impl Default for Config {
             selection: SelectionConfig::default(),
             bindings: Vec::new(),
             ipc_socket: true,
+            working_directory: None,
             wsl_automount_root: "/mnt".to_string(),
             delta_path: None,
             profiles: Vec::new(),
@@ -747,6 +754,7 @@ struct RawConfig {
 #[serde(default)]
 struct RawGeneral {
     ipc_socket: Option<bool>,
+    working_directory: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1305,6 +1313,11 @@ impl RawConfig {
             selection,
             bindings,
             ipc_socket: self.general.ipc_socket.unwrap_or(true),
+            working_directory: self
+                .general
+                .working_directory
+                .as_deref()
+                .and_then(|raw| parse_config_path(raw, "general.working_directory")),
             wsl_automount_root,
             delta_path: self.ui.delta_path.filter(|s| !s.trim().is_empty()),
             profiles,
@@ -1501,6 +1514,45 @@ mod tests {
     fn relative_and_user_tilde_paths_are_rejected() {
         assert_eq!(parse_config_path("relative/dir", "test"), None);
         assert_eq!(parse_config_path("~user/dir", "test"), None);
+    }
+
+    #[test]
+    fn general_working_directory_defaults_to_none() {
+        let raw: RawConfig = toml::from_str("").unwrap();
+        assert_eq!(raw.into_config().working_directory, None);
+    }
+
+    #[test]
+    fn general_working_directory_expands_tilde_and_forward_slashes() {
+        let home = home::home_dir().unwrap();
+        let raw: RawConfig =
+            toml::from_str("[general]\nworking_directory = \"~/projects\"").unwrap();
+        assert_eq!(raw.into_config().working_directory, Some(home.join("projects")));
+    }
+
+    #[test]
+    fn general_working_directory_accepts_absolute_paths() {
+        let toml_src = format!(
+            "[general]\nworking_directory = \"{}\"",
+            abs("somewhere").replace('\\', "\\\\")
+        );
+        let raw: RawConfig = toml::from_str(&toml_src).unwrap();
+        assert_eq!(raw.into_config().working_directory, Some(PathBuf::from(abs("somewhere"))));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn general_working_directory_accepts_forward_slash_windows_paths() {
+        let raw: RawConfig =
+            toml::from_str("[general]\nworking_directory = \"C:/somewhere\"").unwrap();
+        assert_eq!(raw.into_config().working_directory, Some(PathBuf::from("C:/somewhere")));
+    }
+
+    #[test]
+    fn general_working_directory_rejects_relative_paths() {
+        let raw: RawConfig =
+            toml::from_str("[general]\nworking_directory = \"relative/dir\"").unwrap();
+        assert_eq!(raw.into_config().working_directory, None);
     }
 
     #[test]

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -461,6 +461,27 @@ fn ensure_working_directory(dir: Option<&Path>) -> std::io::Result<()> {
     }
 }
 
+/// The directory the PTY starts in: an explicit workspace dir always wins,
+/// then `[general] working_directory` fills in for sessions without one (the
+/// home tab).  A configured dir that does not exist is dropped with a warning
+/// rather than failing the spawn — a stale config value must not stop the
+/// home tab from opening (alacritty ignores an invalid `--working-directory`
+/// the same way).
+fn pty_working_directory(explicit: Option<PathBuf>, config: &Config) -> Option<PathBuf> {
+    explicit.or_else(|| {
+        config.working_directory.clone().filter(|dir| {
+            let ok = dir.is_dir();
+            if !ok {
+                log::warn!(
+                    "general.working_directory {} is not a directory; ignoring",
+                    dir.display()
+                );
+            }
+            ok
+        })
+    })
+}
+
 #[cfg(windows)]
 mod windows_process_probe {
     //! Shared, throttled process-table snapshot.  Every session probes at
@@ -605,7 +626,8 @@ impl Session {
         kind: SessionKind,
         escape_args: bool,
     ) -> std::io::Result<Self> {
-        ensure_working_directory(working_directory.as_deref())?;
+        let pty_cwd = pty_working_directory(working_directory.clone(), config);
+        ensure_working_directory(pty_cwd.as_deref())?;
         let window_size = window_size(size, cell_size);
 
         let (proxy, events) = EventProxy::new(ctx);
@@ -630,7 +652,7 @@ impl Session {
         let _ = escape_args;
         let pty_options = PtyOptions {
             shell,
-            working_directory: working_directory.clone(),
+            working_directory: pty_cwd,
             drain_on_exit: false,
             env,
             // Windows has no argv: alacritty_terminal joins these args into a
@@ -1034,6 +1056,77 @@ mod tests {
             "`cmd /c echo ready` took {exited:?}; the console host is stalling on a \
              handshake (the foreign conpty.dll stall is ~3s)"
         );
+    }
+
+    /// `[general] working_directory` supplies the PTY start dir when a session
+    /// has no explicit one (the home tab), without becoming the session's
+    /// workspace identity — a home-tab session must keep `working_directory:
+    /// None` or it would be filtered into a worktree workspace.
+    #[test]
+    fn a_home_session_starts_in_the_configured_working_directory() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut config = Config::default();
+        config.working_directory = Some(dir.path().to_path_buf());
+
+        // The child writes its cwd into a relative path; the file landing in
+        // `dir` is itself proof the PTY honored the configured directory.
+        #[cfg(windows)]
+        let (program, args) = ("cmd", vec!["/c", "cd", ">", "cwd-probe.txt"]);
+        #[cfg(not(windows))]
+        let (program, args) = ("sh", vec!["-c", "pwd > cwd-probe.txt"]);
+
+        let session = Session::spawn_command(
+            egui::Context::default(),
+            &config,
+            None,
+            TermSize::new(80, 24),
+            (8.0, 16.0),
+            program.to_string(),
+            args.into_iter().map(str::to_string).collect(),
+            "probe".to_string(),
+            SessionKind::Shell,
+        )
+        .unwrap();
+
+        assert!(
+            session.working_directory.is_none(),
+            "the configured cwd must not turn the home tab into a worktree workspace"
+        );
+
+        let start = Instant::now();
+        loop {
+            assert!(start.elapsed() < Duration::from_secs(10), "child never exited");
+            match session.events.try_recv() {
+                Ok(TermEvent::ChildExit(_)) => break,
+                Ok(_) => {},
+                Err(_) => std::thread::sleep(Duration::from_millis(1)),
+            }
+        }
+
+        let content = std::fs::read_to_string(dir.path().join("cwd-probe.txt"))
+            .expect("no probe file: the child did not start in general.working_directory");
+        let reported = PathBuf::from(content.trim()).canonicalize().unwrap();
+        assert_eq!(reported, dir.path().canonicalize().unwrap());
+    }
+
+    /// An explicit workspace dir (worktree/project tab) always wins over the
+    /// configured default, and a configured dir that no longer exists is
+    /// dropped rather than failing the spawn.
+    #[test]
+    fn explicit_dirs_win_and_missing_configured_dirs_are_dropped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.working_directory = Some(tmp.path().join("gone"));
+
+        assert_eq!(
+            pty_working_directory(Some(tmp.path().to_path_buf()), &config),
+            Some(tmp.path().to_path_buf())
+        );
+        assert_eq!(pty_working_directory(None, &config), None);
+
+        config.working_directory = Some(tmp.path().to_path_buf());
+        assert_eq!(pty_working_directory(None, &config), Some(tmp.path().to_path_buf()));
     }
 
     #[derive(Default)]


### PR DESCRIPTION
## What

Honors alacritty's `[general] working_directory` as the start directory for sessions that have no explicit workspace — i.e. the home tab. Worktree/project tabs are untouched: their checkout path always wins.

## Why

When alacritree is launched from a shortcut or launcher, the process cwd is the binary's directory (e.g. `~/.local/bin`), and every home-tab session inherits it. There was no way to configure a sane default.

## Behavior

- Home tab, option set → sessions start in the configured dir.
- Home tab, option unset → inherit process cwd (unchanged default).
- Worktree/project tabs → their checkout path, always (unchanged).
- A configured dir that doesn't exist is dropped with a warning instead of failing the spawn, mirroring how alacritty treats an invalid `--working-directory`.

One deliberate divergence from upstream, noted in a comment: a leading `~` expands to the home directory (upstream only expands `~` in config imports), and forward slashes work on Windows — so a single `working_directory = "~/projects"` line in the shared `alacritty.toml` behaves the same on every platform. Expansion reuses the existing `parse_config_path` helper from `[workspace] worktree_dir`.

## Tests

TDD (RED confirmed before implementing). Config parsing: default `None`, tilde expansion, absolute paths, forward-slash Windows paths, relative rejected. Session level: a real PTY end-to-end test proves the child starts in the configured dir while the session's workspace identity stays `None` (so the home tab doesn't masquerade as a worktree), plus precedence/missing-dir unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)