### PR TITLE
[12] feat(ui): debounce session attention pings

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
 
 use alacritty_terminal::tty::Shell;
 use eframe::CreationContext;
@@ -21,7 +22,9 @@ use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
 use crate::pr_status::{PrCache, PrInfo, PrState};
 use crate::projects::{Project, Worktree, project_json};
-use crate::session::{Session, SessionId, SessionKind, TermSize};
+use crate::session::{
+    AttentionVerdict, Session, SessionId, SessionKind, TermSize, poll_attention_debounce,
+};
 use crate::shortcuts_window;
 use crate::sidebar_nav::{self, SidebarRow};
 use crate::state::{self, PersistedProject};
@@ -4194,6 +4197,7 @@ impl AlacritreeApp {
         // treat unknown as "focused" so we don't pile up stale attention dots.
         let focused = ctx.input(|i| i.viewport().focused).unwrap_or(true);
 
+        let grace = self.config.ui.attention_grace;
         for idx in 0..self.sessions.len() {
             let outcome = self.sessions[idx].drain_events(&self.config.palette);
             // Ahead of the attention early-out: a background session copying
@@ -4201,20 +4205,34 @@ impl AlacritreeApp {
             for (target, text) in &outcome.clipboard {
                 clipboard::write(*target, text);
             }
-            if !outcome.attention {
-                continue;
-            }
             let is_visible_to_user = Some(idx) == visible_idx && focused;
             if is_visible_to_user {
+                // Nothing pending survives the user already looking at it.
+                self.sessions[idx].pending_attention = None;
                 continue;
             }
-            // Only toast on the *transition* into needs_attention — otherwise
-            // BEL + title-transition firing in the same idle cycle would
-            // produce two toasts for the same "Claude is done" event.
-            let was_attending = self.sessions[idx].needs_attention;
-            self.sessions[idx].needs_attention = true;
-            if !was_attending && self.config.ui.notifications {
-                notify_attention(&self.sessions[idx], ctx);
+            if outcome.attention && self.sessions[idx].pending_attention.is_none() {
+                self.sessions[idx].pending_attention = Some(Instant::now());
+            }
+            let Some(since) = self.sessions[idx].pending_attention else {
+                continue;
+            };
+            match poll_attention_debounce(since, Instant::now(), &self.sessions[idx].title, grace) {
+                AttentionVerdict::Cancel => self.sessions[idx].pending_attention = None,
+                // A quiet PTY repaints nothing on its own, so the wake-up
+                // that decides the ping has to be scheduled here.
+                AttentionVerdict::Wait(remaining) => ctx.request_repaint_after(remaining),
+                AttentionVerdict::Fire => {
+                    self.sessions[idx].pending_attention = None;
+                    // Only toast on the *transition* into needs_attention — otherwise
+                    // BEL + title-transition firing in the same idle cycle would
+                    // produce two toasts for the same "Claude is done" event.
+                    let was_attending = self.sessions[idx].needs_attention;
+                    self.sessions[idx].needs_attention = true;
+                    if !was_attending && self.config.ui.notifications {
+                        notify_attention(&self.sessions[idx], ctx);
+                    }
+                },
             }
         }
 

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -15,6 +15,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use alacritty_terminal::vte::ansi::{CursorShape, CursorStyle, Rgb};
 use egui::Color32;
@@ -353,6 +354,9 @@ pub struct UiTheme {
     pub sidebar_accent: Option<Color32>,
     /// Fire a desktop notification when a non-visible session needs attention.
     pub notifications: bool,
+    /// How long an attention trigger must survive without the session going
+    /// back to work before it pings.  Zero pings on the trigger itself.
+    pub attention_grace: Duration,
     /// Ask before the sidebar's per-session `×` kills the PTY.
     pub confirm_session_close: ConfirmSessionClose,
     /// What closing the last session in the on-screen workspace does.
@@ -385,6 +389,7 @@ impl Default for UiTheme {
             sidebar_border: None,
             sidebar_accent: None,
             notifications: true,
+            attention_grace: Duration::ZERO,
             confirm_session_close: ConfirmSessionClose::Never,
             last_session_close: LastSessionClose::Respawn,
             session_display: SessionDisplay::default(),
@@ -1000,6 +1005,9 @@ struct RawUi {
     sidebar_border: Option<RgbStr>,
     sidebar_accent: Option<RgbStr>,
     notifications: Option<bool>,
+    /// Grace window in milliseconds before an attention trigger pings; a
+    /// session that resumes work inside it swallows the ping.  Default 0.
+    attention_grace_ms: Option<u64>,
     /// When the sidebar × on a session row asks before killing the PTY:
     /// "never" (default) | "busy" | "always".
     confirm_session_close: Option<String>,
@@ -1139,6 +1147,7 @@ impl RawConfig {
             sidebar_border: self.ui.sidebar_border.map(|v| rgb_to_color32(v.0)),
             sidebar_accent: self.ui.sidebar_accent.map(|v| rgb_to_color32(v.0)),
             notifications: self.ui.notifications.unwrap_or(true),
+            attention_grace: Duration::from_millis(self.ui.attention_grace_ms.unwrap_or(0)),
             confirm_session_close: parse_confirm_session_close(
                 self.ui.confirm_session_close.as_deref(),
             ),

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -90,6 +90,9 @@ pub struct Session {
     pub events: mpsc::Receiver<TermEvent>,
     /// Latched attention flag, cleared when the user views this session.
     pub needs_attention: bool,
+    /// When a not-yet-surfaced attention trigger arrived.  `None` once it
+    /// fires, cancels, or the user views the session.
+    pub pending_attention: Option<Instant>,
     /// Sub-cell wheel residue (logical points), retained across frames so that
     /// trackpad pixel-deltas accumulate into whole-line scrolls instead of
     /// being dropped when each frame's delta is smaller than a cell.
@@ -260,6 +263,39 @@ fn is_spinner_title(title: &str) -> bool {
         let n = c as u32;
         (0x2800..=0x28FF).contains(&n)
     })
+}
+
+/// Outcome of polling a pending attention trigger.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AttentionVerdict {
+    /// Latch the flag and notify now.
+    Fire,
+    /// Still inside the grace window; poll again after the returned delay.
+    Wait(Duration),
+    /// The session went back to work — drop the trigger without notifying.
+    Cancel,
+}
+
+/// Debounce for attention triggers.  Agent CLIs driven by an orchestrator
+/// (e.g. Claude Code running a multi-task workflow) ring BEL and drop their
+/// spinner title at every task boundary, then resume on their own — an
+/// immediate ping per boundary is noise.  A trigger only fires if the title
+/// stays out of its spinner state for the whole grace window.  Zero grace
+/// disables the debounce and fires on the trigger frame, spinner or not.
+pub fn poll_attention_debounce(
+    since: Instant,
+    now: Instant,
+    title: &str,
+    grace: Duration,
+) -> AttentionVerdict {
+    if grace.is_zero() {
+        return AttentionVerdict::Fire;
+    }
+    if is_spinner_title(title) {
+        return AttentionVerdict::Cancel;
+    }
+    let elapsed = now.saturating_duration_since(since);
+    if elapsed >= grace { AttentionVerdict::Fire } else { AttentionVerdict::Wait(grace - elapsed) }
 }
 
 /// A session "looks busy" when its foreground process is a recognized
@@ -662,6 +698,7 @@ impl Session {
             term,
             events,
             needs_attention: false,
+            pending_attention: None,
             accumulated_scroll: (0.0, 0.0),
             last_report_cell: None,
             shell_pid,
@@ -938,6 +975,47 @@ mod tests {
         apply_term_event(event, &mut title, &mut exited, &mut outcome);
 
         assert_eq!(outcome.clipboard, vec![(Target::Clipboard, "hello".to_owned())]);
+    }
+
+    /// Zero grace is the config default and must keep the pre-debounce
+    /// behavior: the trigger frame latches, even mid-spinner (a BEL from a
+    /// still-working agent latched before the debounce existed too).
+    #[test]
+    fn zero_grace_fires_on_the_trigger_frame() {
+        let now = Instant::now();
+        assert_eq!(
+            poll_attention_debounce(now, now, "⠋ working", Duration::ZERO),
+            AttentionVerdict::Fire
+        );
+    }
+
+    /// An orchestrated agent that resumes after a task boundary brings its
+    /// spinner title back — that resumption is what must eat the ping.
+    #[test]
+    fn a_returning_spinner_cancels_a_pending_trigger() {
+        let since = Instant::now();
+        let grace = Duration::from_secs(2);
+        assert_eq!(
+            poll_attention_debounce(since, since + grace, "⠋ working", grace),
+            AttentionVerdict::Cancel
+        );
+    }
+
+    /// A genuinely idle session pings, but only after waiting out the grace
+    /// window — the wait carries the remaining delay so the app can schedule
+    /// the deciding repaint.
+    #[test]
+    fn an_idle_session_waits_out_the_grace_window_then_fires() {
+        let since = Instant::now();
+        let grace = Duration::from_secs(2);
+        assert_eq!(
+            poll_attention_debounce(since, since + Duration::from_secs(1), "~/repo", grace),
+            AttentionVerdict::Wait(Duration::from_secs(1))
+        );
+        assert_eq!(
+            poll_attention_debounce(since, since + grace, "~/repo", grace),
+            AttentionVerdict::Fire
+        );
     }
 
     /// The wheel scrolls a diff pane only because its pager sits on the alternate

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -212,6 +212,9 @@ sidebar_foreground = "#d8d8d8"
 sidebar_border     = "#2a2a2a"
 sidebar_accent     = "#6a9fb5"
 notifications      = true   # desktop notification when a hidden session bells
+attention_grace_ms = 0      # hold pings this long and drop them if the session
+                            # resumes work (agents that continue between tasks);
+                            # 0 pings immediately
 
 [ui.icons]                  # sidebar glyph overrides (e.g. Nerd Font icons)
 search = "⌕"                # glyph prefixing the sidebar search prompt


### PR DESCRIPTION
## What

Adds `[ui] attention_grace_ms` to `alacritree.toml`: when > 0, an attention trigger (BEL or spinner-title stop) on a background session is held for that window and dropped if the session goes back to work within it. Only a session that stays idle for the whole window latches the dot and fires the desktop toast. Default `0` keeps today's instant behavior exactly — nothing changes for existing configs.

## Why

Agent CLIs driven by an orchestrator (e.g. Claude Code running a multi-task workflow) ring BEL and drop their spinner title at *every* task boundary, then resume on their own. Both signals latch `needs_attention`, so the user gets pinged once per task even though the agent never actually stopped. With a grace window of ~2000 ms, the resuming spinner title cancels the pending ping; a genuine "your turn" still pings, just a couple of seconds later.

## How

- `session.rs`: `poll_attention_debounce(since, now, title, grace)` → `Fire | Wait(remaining) | Cancel`, plus a `pending_attention: Option<Instant>` timestamp on `Session`. Unit-tested (zero-grace parity, spinner cancel, wait-then-fire).
- `app.rs`: `process_session_events` runs pending triggers through the poll each frame; `Wait` schedules `request_repaint_after(remaining)` so a quiet PTY still gets the deciding wake-up.
- `config.rs` / `docs/alacritree.md`: the new `[ui]` option.

`cargo test -p alacritree`: 392 passed; the one failure is the pre-existing `fonts::tests::later_variants_reuse_faces_loaded_by_an_earlier_chain` on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)