### PR TITLE
[15] feat(git): per-worktree base branch override

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -298,6 +298,9 @@ pub struct AlacritreeApp {
     active_session: HashMap<WorkspaceKey, SessionId>,
     projects: Vec<Project>,
     git_status: HashMap<PathBuf, StatusCache>,
+    /// Per-worktree override of the git panel's diff base, keyed by worktree
+    /// path.  Mirrors `state.toml`; written through `state::set_base_branch`.
+    base_branch_overrides: HashMap<PathBuf, String>,
     pr_cache: PrCache,
     /// Renders `[ui] worktree_name` / `project_name` templates at paint time.
     row_labels: crate::row_label::LabelTemplates,
@@ -598,6 +601,11 @@ impl AlacritreeApp {
             active_session: HashMap::new(),
             projects,
             git_status: HashMap::new(),
+            base_branch_overrides: persisted
+                .base_branches
+                .iter()
+                .map(|b| (b.worktree.clone(), b.branch.clone()))
+                .collect(),
             pr_cache: PrCache::new(),
             row_labels,
             config,
@@ -2737,10 +2745,11 @@ impl AlacritreeApp {
                 // be `None`, which `pr_cache.poll` handles by returning early.
                 let cached_branch = cache.current_branch().map(str::to_string);
                 let pr_info = self.pr_cache.poll(&path, cached_branch.as_deref(), ctx);
-                // PR base takes precedence over the repo's default branch so
-                // the sidebar diff matches what GitHub will review.
-                let effective_default =
-                    pr_info.as_ref().map(|p| p.base_branch.clone()).or(project_default);
+                let effective_default = effective_base_branch(
+                    self.base_branch_overrides.get(&path).map(String::as_str),
+                    pr_info.as_ref().map(|p| p.base_branch.as_str()),
+                    project_default.as_deref(),
+                );
                 // Single non-blocking poll: returns the last known status and
                 // kicks off a background refresh if stale or if the hint
                 // changed since the last completed compute.  Cloned so the
@@ -3991,6 +4000,17 @@ fn project_main_for(projects: &[Project], ws: &Path) -> Option<PathBuf> {
     let project = projects.iter().find(|p| p.worktrees.iter().any(|w| w.path == ws))?;
     let main = project.worktrees.iter().find(|w| w.is_main)?;
     if main.path == ws { None } else { Some(main.path.clone()) }
+}
+
+/// The branch the git panel diffs against: the user's explicit override,
+/// else the open PR's base (what GitHub will review), else the project's
+/// detected default branch.
+fn effective_base_branch(
+    override_branch: Option<&str>,
+    pr_base: Option<&str>,
+    project_default: Option<&str>,
+) -> Option<String> {
+    override_branch.or(pr_base).or(project_default).map(str::to_string)
 }
 
 /// Agent glyphs usually come from the title's own leading char
@@ -5743,6 +5763,15 @@ mod tests {
     fn session_ids_empty_for_unknown_workspace() {
         let pairs = vec![(None, 1)];
         assert!(sidebar_session_ids(&pairs, &ws("/missing"), false).is_empty());
+    }
+
+    #[test]
+    fn base_branch_precedence_is_override_then_pr_then_default() {
+        let f = effective_base_branch;
+        assert_eq!(f(Some("develop"), Some("main"), Some("master")), Some("develop".into()));
+        assert_eq!(f(None, Some("main"), Some("master")), Some("main".into()));
+        assert_eq!(f(None, None, Some("master")), Some("master".into()));
+        assert_eq!(f(None, None, None), None);
     }
 
     #[test]

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -4117,6 +4117,25 @@ fn filter_branches(branches: &[String], query: &str) -> Vec<String> {
     branches.iter().filter(|b| b.to_lowercase().contains(&query)).cloned().collect()
 }
 
+/// Where the picker cursor lands after this frame's filter changes.  Row 0 is
+/// always Auto, so reseeding a query edit to 0 would apply Auto on the primary
+/// "type a branch name, press Enter" flow.  A non-empty query instead seeds
+/// the first branch row (1), clamped to 0 when nothing matches; an empty
+/// query seeds Auto.  With no query change, the previous cursor is kept,
+/// clamped to the (possibly shrunk) filtered length.
+fn picker_cursor(
+    query_changed: bool,
+    query_empty: bool,
+    prev: usize,
+    filtered_len: usize,
+) -> usize {
+    if query_changed {
+        if query_empty { 0 } else { 1.min(filtered_len) }
+    } else {
+        prev.min(filtered_len)
+    }
+}
+
 /// Agent glyphs usually come from the title's own leading char
 /// (`Session::agent_glyph`), and the session row paints that glyph as its
 /// status icon right next to the title — showing it in both places doubles
@@ -5178,7 +5197,12 @@ impl AlacritreeApp {
                     Ok(branches) => filter_branches(branches, &picker.query),
                     Err(_) => Vec::new(),
                 };
-                picker.cursor = if query_changed { 0 } else { picker.cursor.min(filtered.len()) };
+                picker.cursor = picker_cursor(
+                    query_changed,
+                    picker.query.is_empty(),
+                    picker.cursor,
+                    filtered.len(),
+                );
 
                 let mark = |selected: bool| if selected { "• " } else { "   " };
                 egui::ScrollArea::vertical().max_height(240.0 * s).show(ui, |ui| {
@@ -5214,7 +5238,11 @@ impl AlacritreeApp {
         if down {
             picker.cursor = (picker.cursor + 1).min(filtered.len());
         }
-        if confirm_via_key {
+        // A failed branch listing leaves `filtered` empty, so cursor 0 would
+        // resolve to Auto — applying it on Enter would clear an existing
+        // override on a reflexive keypress rather than the no-op a listing
+        // failure should be. Clicks can't reach this path (no rows render).
+        if confirm_via_key && picker.branches.is_ok() {
             chosen = Some(if picker.cursor == 0 {
                 None
             } else {
@@ -6006,6 +6034,21 @@ mod tests {
         assert_eq!(filter_branches(&branches, ""), branches);
         assert_eq!(filter_branches(&branches, "DEV"), vec!["develop", "origin/develop"]);
         assert!(filter_branches(&branches, "zz").is_empty());
+    }
+
+    #[test]
+    fn picker_cursor_seeds_the_first_match_on_a_non_empty_query_change() {
+        // Typing a query that matches something jumps past Auto to the first
+        // match, so Enter applies that match instead of Auto.
+        assert_eq!(picker_cursor(true, false, 0, 3), 1);
+        // A query with no matches has nothing to land on but Auto.
+        assert_eq!(picker_cursor(true, false, 0, 0), 0);
+        // Clearing the query back to empty returns the cursor to Auto.
+        assert_eq!(picker_cursor(true, true, 5, 3), 0);
+        // No query change this frame: clamp the previous cursor to the
+        // (possibly shrunk) filtered length instead of reseeding it.
+        assert_eq!(picker_cursor(false, false, 5, 3), 3);
+        assert_eq!(picker_cursor(false, false, 2, 3), 2);
     }
 
     #[test]

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -321,6 +321,8 @@ pub struct AlacritreeApp {
     /// off-thread and are adopted in `poll_pending_creates`.
     pending_creates: Vec<BackgroundCreate>,
     pending_rename: Option<RenameState>,
+    /// The base-branch picker modal.  Transient: never persisted.
+    pending_base_branch: Option<BaseBranchPicker>,
     pending_project_remove: Option<ProjectRemoveState>,
     /// Worktrees already given a Doppler scope pass this app run, so opening
     /// more shells there doesn't re-invoke the doppler CLI.
@@ -403,6 +405,17 @@ struct ProjectRemoveState {
     root: PathBuf,
     /// Display name, kept for the prompt after `projects` may have shifted.
     name: String,
+}
+
+/// Modal state for choosing a worktree's diff base.
+struct BaseBranchPicker {
+    worktree: PathBuf,
+    query: String,
+    /// `Err` is what git said when listing failed (not a repo, WSL down…).
+    branches: Result<Vec<String>, String>,
+    /// Auto-detected base shown on the "Auto" row.
+    detected: Option<String>,
+    cursor: usize,
 }
 
 /// Drag-and-drop payload for reordering the project list.  Carries the dragged
@@ -618,6 +631,7 @@ impl AlacritreeApp {
             pending_create: None,
             pending_creates: Vec::new(),
             pending_rename: None,
+            pending_base_branch: None,
             pending_project_remove: None,
             doppler_synced: HashSet::new(),
             pending_session_close: None,
@@ -1113,6 +1127,7 @@ impl AlacritreeApp {
             || self.pending_create.is_some()
             || self.pending_session_close.is_some()
             || self.pending_rename.is_some()
+            || self.pending_base_branch.is_some()
             || self.pending_project_remove.is_some()
             || self.error_dialog.is_some()
     }
@@ -2685,6 +2700,32 @@ impl AlacritreeApp {
         None
     }
 
+    fn open_base_branch_picker(&mut self, worktree: PathBuf) {
+        let detected = self.project_default_branch_for(&worktree);
+        let branches = crate::worktree::list_branches(&worktree);
+        self.pending_base_branch = Some(BaseBranchPicker {
+            worktree,
+            query: String::new(),
+            branches,
+            detected,
+            cursor: 0,
+        });
+    }
+
+    fn apply_base_branch(&mut self, worktree: PathBuf, branch: Option<String>) {
+        match &branch {
+            Some(b) => {
+                self.base_branch_overrides.insert(worktree.clone(), b.clone());
+            },
+            None => {
+                self.base_branch_overrides.remove(&worktree);
+            },
+        }
+        // The next `StatusCache::poll` sees the changed hint and recomputes;
+        // nothing to invalidate by hand.
+        state::mutate(|s| state::set_base_branch(s, &worktree, branch));
+    }
+
     fn show_git_sidebar(&mut self, ctx: &Context, panel_frame: Frame) -> egui::Rect {
         let theme = self.theme;
         let scrollbar = self.config.ui.scrollbar;
@@ -4013,6 +4054,12 @@ fn effective_base_branch(
     override_branch.or(pr_base).or(project_default).map(str::to_string)
 }
 
+/// Branches whose name contains `query`, case-insensitively.
+fn filter_branches(branches: &[String], query: &str) -> Vec<String> {
+    let query = query.to_lowercase();
+    branches.iter().filter(|b| b.to_lowercase().contains(&query)).cloned().collect()
+}
+
 /// Agent glyphs usually come from the title's own leading char
 /// (`Session::agent_glyph`), and the session row paints that glyph as its
 /// status icon right next to the title — showing it in both places doubles
@@ -5009,6 +5056,112 @@ impl AlacritreeApp {
         self.pending_rename = Some(RenameState { root, label });
     }
 
+    fn show_base_branch_picker(&mut self, ctx: &Context) {
+        let Some(mut picker) = self.pending_base_branch.take() else {
+            return;
+        };
+        let theme = self.theme;
+        let danger = rgb_to_color32(self.config.palette.normal[1]);
+        let (cancel_via_key, confirm_via_key) = consume_modal_keys(ctx);
+        let (up, down) = ctx.input_mut(|i| {
+            (
+                i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp),
+                i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown),
+            )
+        });
+        let frame = modal_frame(&theme);
+        let current = self.base_branch_overrides.get(&picker.worktree).cloned();
+        let s = theme.ui_scale;
+
+        // Row 0 is always "Auto"; branch rows follow, narrowed by the query.
+        let filtered = match &picker.branches {
+            Ok(branches) => filter_branches(branches, &picker.query),
+            Err(_) => Vec::new(),
+        };
+        picker.cursor = picker.cursor.min(filtered.len());
+
+        let mut chosen: Option<Option<String>> = None; // Some(None) = Auto
+        let modal = egui::Modal::new(egui::Id::new("alacritree_base_branch_picker"))
+            .frame(frame)
+            .show(ctx, |ui| {
+                ui.set_width(380.0 * s);
+                ui.spacing_mut().item_spacing.y = 4.0 * s;
+                let name = picker
+                    .worktree
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| picker.worktree.display().to_string());
+                ui.label(
+                    RichText::new(format!("Base branch for `{name}`")).color(theme.text).strong(),
+                );
+                ui.label(
+                    RichText::new("The git panel diffs this worktree against it.")
+                        .color(theme.text_muted)
+                        .small(),
+                );
+                let input_id = egui::Id::new("alacritree_base_branch_query");
+                let edit = egui::TextEdit::singleline(&mut picker.query)
+                    .id(input_id)
+                    .hint_text("filter branches")
+                    .desired_width(f32::INFINITY);
+                ui.add(edit);
+                focus_default(ui.ctx(), input_id);
+
+                if let Err(e) = &picker.branches {
+                    ui.label(RichText::new(e).color(danger).small());
+                }
+
+                let mark = |selected: bool| if selected { "• " } else { "   " };
+                egui::ScrollArea::vertical().max_height(240.0 * s).show(ui, |ui| {
+                    let auto_label = match &picker.detected {
+                        Some(d) => format!("{}Auto ({d})", mark(current.is_none())),
+                        None => format!("{}Auto", mark(current.is_none())),
+                    };
+                    let auto = ui.selectable_label(picker.cursor == 0, auto_label);
+                    if auto.clicked() {
+                        chosen = Some(None);
+                    }
+                    for (i, branch) in filtered.iter().enumerate() {
+                        let selected = current.as_deref() == Some(branch.as_str());
+                        let resp = ui.selectable_label(
+                            picker.cursor == i + 1,
+                            format!("{}{branch}", mark(selected)),
+                        );
+                        if resp.clicked() {
+                            chosen = Some(Some(branch.clone()));
+                        }
+                    }
+                });
+                ui.label(
+                    RichText::new("↑↓ move · Enter apply · Esc cancel")
+                        .color(theme.text_muted)
+                        .small(),
+                );
+            });
+
+        if up {
+            picker.cursor = picker.cursor.saturating_sub(1);
+        }
+        if down {
+            picker.cursor = (picker.cursor + 1).min(filtered.len());
+        }
+        if confirm_via_key {
+            chosen = Some(if picker.cursor == 0 {
+                None
+            } else {
+                filtered.get(picker.cursor - 1).cloned()
+            });
+        }
+        if cancel_via_key || modal.should_close() {
+            return;
+        }
+        if let Some(branch) = chosen {
+            self.apply_base_branch(picker.worktree, branch);
+            return;
+        }
+        self.pending_base_branch = Some(picker);
+    }
+
     fn show_create_dialog(&mut self, ctx: &Context) {
         let Some(state) = self.pending_create.take() else {
             return;
@@ -5588,6 +5741,9 @@ impl eframe::App for AlacritreeApp {
         if self.pending_rename.is_some() {
             self.show_rename_dialog(ctx);
         }
+        if self.pending_base_branch.is_some() {
+            self.show_base_branch_picker(ctx);
+        }
         if self.pending_project_remove.is_some() {
             self.show_remove_project_dialog(ctx);
         }
@@ -5772,6 +5928,15 @@ mod tests {
         assert_eq!(f(None, Some("main"), Some("master")), Some("main".into()));
         assert_eq!(f(None, None, Some("master")), Some("master".into()));
         assert_eq!(f(None, None, None), None);
+    }
+
+    #[test]
+    fn picker_filter_is_a_case_insensitive_contains() {
+        let branches =
+            vec!["main".to_string(), "develop".to_string(), "origin/develop".to_string()];
+        assert_eq!(filter_branches(&branches, ""), branches);
+        assert_eq!(filter_branches(&branches, "DEV"), vec!["develop", "origin/develop"]);
+        assert!(filter_branches(&branches, "zz").is_empty());
     }
 
     #[test]

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1866,6 +1866,22 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::FocusRight) => {
                 self.move_focus(FocusDir::Right, origin);
             },
+            BindingAction::Named(NamedAction::SetBaseBranch) => {
+                let target = base_branch_target(
+                    self.focus == PaneFocus::ProjectsSidebar,
+                    self.sidebar_cursor.as_ref(),
+                    |id| {
+                        self.sessions
+                            .iter()
+                            .find(|s| s.id == id)
+                            .map(|s| s.working_directory.clone())
+                    },
+                    &self.current_workspace,
+                );
+                if let Some(path) = target {
+                    self.open_base_branch_picker(path);
+                }
+            },
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
             },
@@ -2036,6 +2052,7 @@ impl AlacritreeApp {
         let activate_session_request: std::cell::Cell<Option<(WorkspaceKey, SessionId)>> =
             std::cell::Cell::new(None);
         let close_session_request: std::cell::Cell<Option<SessionId>> = std::cell::Cell::new(None);
+        let base_picker_request: std::cell::Cell<Option<PathBuf>> = std::cell::Cell::new(None);
         // Drag-to-reorder: (dragged root, insert-before display index).
         let reorder_request: std::cell::Cell<Option<(PathBuf, usize)>> = std::cell::Cell::new(None);
         let mut add_project_clicked = false;
@@ -2584,6 +2601,9 @@ impl AlacritreeApp {
                                 if action.spawn {
                                     spawn_shell_request.set(Some(Some(wt.path.clone())));
                                 }
+                                if action.set_base {
+                                    base_picker_request.set(Some(wt.path.clone()));
+                                }
                                 let session_rows = worktree_session_rows
                                     .get(idx)
                                     .and_then(|v| v.get(wt_idx))
@@ -2656,6 +2676,9 @@ impl AlacritreeApp {
         }
         if let Some(path) = activate_request.take() {
             self.activate_worktree(ctx, &path);
+        }
+        if let Some(path) = base_picker_request.take() {
+            self.open_base_branch_picker(path);
         }
         if let Some(req) = delete_request.take() {
             self.pending_delete = Some(req);
@@ -2732,6 +2755,7 @@ impl AlacritreeApp {
         let palette = self.config.palette.clone();
         let active_diff_key = self.active_diff_key();
         let diff_request: std::cell::Cell<Option<DiffRequest>> = std::cell::Cell::new(None);
+        let open_picker: std::cell::Cell<Option<PathBuf>> = std::cell::Cell::new(None);
         let panel_resp = SidePanel::right("right_sidebar")
             .resizable(true)
             .default_width(300.0 * theme.ui_scale)
@@ -2889,12 +2913,21 @@ impl AlacritreeApp {
                             |ui| {
                                 if let Some(default) = default {
                                     // right_to_left: default sits rightmost, `vs` to its left.
-                                    ui.add(
-                                        egui::Label::new(
-                                            RichText::new(default).color(theme.text_dim).small(),
+                                    let resp = ui
+                                        .add(
+                                            egui::Label::new(
+                                                RichText::new(default)
+                                                    .color(theme.text_dim)
+                                                    .small(),
+                                            )
+                                            .truncate()
+                                            .sense(egui::Sense::click()),
                                         )
-                                        .truncate(),
-                                    );
+                                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                        .on_hover_text("Set the branch this panel diffs against");
+                                    if resp.clicked() {
+                                        open_picker.set(Some(path.clone()));
+                                    }
                                     ui.label(RichText::new("vs").color(theme.text_muted).small());
                                 }
                             },
@@ -3039,6 +3072,9 @@ impl AlacritreeApp {
             });
         if let Some(req) = diff_request.take() {
             self.open_diff(ctx, req);
+        }
+        if let Some(path) = open_picker.take() {
+            self.open_base_branch_picker(path);
         }
         panel_resp.response.rect
     }
@@ -3970,6 +4006,7 @@ struct WorktreeAction {
     activate: bool,
     delete: bool,
     spawn: bool,
+    set_base: bool,
 }
 
 /// Everything a sidebar session row needs, snapshotted before the panel
@@ -4052,6 +4089,26 @@ fn effective_base_branch(
     project_default: Option<&str>,
 ) -> Option<String> {
     override_branch.or(pr_base).or(project_default).map(str::to_string)
+}
+
+/// The worktree a SetBaseBranch press targets: the sidebar cursor's worktree
+/// while the projects sidebar owns focus (a session row resolves to its
+/// workspace), otherwise the current workspace.  Home and project-header
+/// cursors, and the home workspace, have no base branch to override.
+fn base_branch_target(
+    sidebar_focused: bool,
+    cursor: Option<&SidebarRow>,
+    session_workspace: impl Fn(SessionId) -> Option<WorkspaceKey>,
+    current: &WorkspaceKey,
+) -> Option<PathBuf> {
+    if sidebar_focused {
+        return match cursor {
+            Some(SidebarRow::Worktree(p)) => Some(p.clone()),
+            Some(SidebarRow::Session(id)) => session_workspace(*id).flatten(),
+            _ => None,
+        };
+    }
+    current.clone()
 }
 
 /// Branches whose name contains `query`, case-insensitively.
@@ -4234,6 +4291,14 @@ fn worktree_row(
         }
     }
 
+    let mut set_base_clicked = false;
+    resp.context_menu(|ui| {
+        if ui.button("Set base branch…").clicked() {
+            set_base_clicked = true;
+            ui.close_menu();
+        }
+    });
+
     let bg = if is_active {
         theme.row_active_bg
     } else if resp.hovered() {
@@ -4255,6 +4320,7 @@ fn worktree_row(
         activate: !deleting && resp.clicked() && !delete_clicked && !spawn_clicked && !wt.prunable,
         delete: delete_clicked,
         spawn: spawn_clicked,
+        set_base: set_base_clicked,
     }
 }
 
@@ -6380,5 +6446,43 @@ mod tests {
             16.0 * (crate::config::FontConfig::UI_HEADING_RATIO
                 / crate::config::FontConfig::UI_NORMAL_RATIO)
         );
+    }
+
+    #[test]
+    fn set_base_branch_targets_the_cursored_worktree_when_sidebar_focused() {
+        let wt = PathBuf::from("C:/repo/wt");
+        let none = |_id: SessionId| -> Option<WorkspaceKey> { None };
+        let cursor = SidebarRow::Worktree(wt.clone());
+        assert_eq!(
+            base_branch_target(true, Some(&cursor), none, &Some(PathBuf::from("C:/other"))),
+            Some(wt)
+        );
+    }
+
+    #[test]
+    fn set_base_branch_resolves_a_session_row_to_its_workspace() {
+        let wt = PathBuf::from("C:/repo/wt");
+        let ws = wt.clone();
+        let lookup = move |id: SessionId| (id == 7).then(|| Some(ws.clone()));
+        let cursor = SidebarRow::Session(7);
+        assert_eq!(base_branch_target(true, Some(&cursor), lookup, &None), Some(wt));
+    }
+
+    #[test]
+    fn set_base_branch_ignores_home_and_project_rows() {
+        let none = |_id: SessionId| -> Option<WorkspaceKey> { None };
+        assert_eq!(base_branch_target(true, Some(&SidebarRow::Home), none, &None), None);
+        let cursor = SidebarRow::Project(PathBuf::from("C:/repo"));
+        let none2 = |_id: SessionId| -> Option<WorkspaceKey> { None };
+        assert_eq!(base_branch_target(true, Some(&cursor), none2, &None), None);
+    }
+
+    #[test]
+    fn set_base_branch_falls_back_to_the_current_worktree() {
+        let wt = PathBuf::from("C:/repo/wt");
+        let none = |_id: SessionId| -> Option<WorkspaceKey> { None };
+        assert_eq!(base_branch_target(false, None, none, &Some(wt.clone())), Some(wt));
+        let none2 = |_id: SessionId| -> Option<WorkspaceKey> { None };
+        assert_eq!(base_branch_target(false, None, none2, &None), None, "home has no base branch");
     }
 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -5074,12 +5074,9 @@ impl AlacritreeApp {
         let s = theme.ui_scale;
 
         // Row 0 is always "Auto"; branch rows follow, narrowed by the query.
-        let filtered = match &picker.branches {
-            Ok(branches) => filter_branches(branches, &picker.query),
-            Err(_) => Vec::new(),
-        };
-        picker.cursor = picker.cursor.min(filtered.len());
-
+        // Populated inside the modal closure, after the TextEdit runs, so the
+        // rows reflect this frame's query rather than the previous one.
+        let mut filtered: Vec<String> = Vec::new();
         let mut chosen: Option<Option<String>> = None; // Some(None) = Auto
         let modal = egui::Modal::new(egui::Id::new("alacritree_base_branch_picker"))
             .frame(frame)
@@ -5104,12 +5101,18 @@ impl AlacritreeApp {
                     .id(input_id)
                     .hint_text("filter branches")
                     .desired_width(f32::INFINITY);
-                ui.add(edit);
+                let query_changed = ui.add(edit).changed();
                 focus_default(ui.ctx(), input_id);
 
                 if let Err(e) = &picker.branches {
                     ui.label(RichText::new(e).color(danger).small());
                 }
+
+                filtered = match &picker.branches {
+                    Ok(branches) => filter_branches(branches, &picker.query),
+                    Err(_) => Vec::new(),
+                };
+                picker.cursor = if query_changed { 0 } else { picker.cursor.min(filtered.len()) };
 
                 let mark = |selected: bool| if selected { "• " } else { "   " };
                 egui::ScrollArea::vertical().max_height(240.0 * s).show(ui, |ui| {

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -64,6 +64,8 @@ pub enum NamedAction {
     ToggleSessionRows,
     /// Flip the runtime `session_display.tabs_always` value.
     ToggleSessionTabs,
+    /// Open the base-branch picker for the sidebar-cursored or current worktree.
+    SetBaseBranch,
     /// 1-indexed into the `[[ui.profiles]]` order.
     SpawnProfile(u8),
     Quit,
@@ -152,6 +154,7 @@ impl NamedAction {
             Self::ShowShortcuts => "Show this shortcuts window".into(),
             Self::ToggleSessionRows => "Toggle single-session sidebar rows".into(),
             Self::ToggleSessionTabs => "Toggle single-session tab segments".into(),
+            Self::SetBaseBranch => "Choose the branch the git panel diffs against".into(),
             Self::FocusLeft => "Move panel focus left (TUIs get the key first)".into(),
             Self::FocusRight => "Move panel focus right (TUIs get the key first)".into(),
             Self::NoOp | Self::ReceiveChar => String::new(),
@@ -652,6 +655,7 @@ pub fn parse_action(name: &str) -> BindingAction {
         "FocusTerminal" => BindingAction::Named(FocusTerminal),
         "ToggleSessionRows" => BindingAction::Named(ToggleSessionRows),
         "ToggleSessionTabs" => BindingAction::Named(ToggleSessionTabs),
+        "SetBaseBranch" => BindingAction::Named(SetBaseBranch),
         "SpawnProfile1" => BindingAction::Named(SpawnProfile(1)),
         "SpawnProfile2" => BindingAction::Named(SpawnProfile(2)),
         "SpawnProfile3" => BindingAction::Named(SpawnProfile(3)),
@@ -946,6 +950,7 @@ mod tests {
             ("ToggleSessionTabs", NamedAction::ToggleSessionTabs),
             ("FocusLeft", NamedAction::FocusLeft),
             ("FocusRight", NamedAction::FocusRight),
+            ("SetBaseBranch", NamedAction::SetBaseBranch),
         ] {
             let b = parse_bindings(vec![raw_action("F1", None, name)]);
             assert_eq!(named_matches(&b, Key::F1, Modifiers::NONE), vec![expected], "{name}");

--- a/alacritree/src/state.rs
+++ b/alacritree/src/state.rs
@@ -17,6 +17,9 @@ pub struct PersistedState {
     pub show_left_sidebar: bool,
     #[serde(default = "default_true")]
     pub show_right_sidebar: bool,
+    /// Per-worktree override of the branch the git panel diffs against.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub base_branches: Vec<PersistedBaseBranch>,
 }
 
 /// The `default_true` attributes above only speak for a file that omits the
@@ -24,7 +27,12 @@ pub struct PersistedState {
 /// this would open alacritree with both sidebars hidden.
 impl Default for PersistedState {
     fn default() -> Self {
-        Self { projects: Vec::new(), show_left_sidebar: true, show_right_sidebar: true }
+        Self {
+            projects: Vec::new(),
+            show_left_sidebar: true,
+            show_right_sidebar: true,
+            base_branches: Vec::new(),
+        }
     }
 }
 
@@ -41,6 +49,12 @@ pub struct PersistedProject {
     /// the name from the root, as before the field existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedBaseBranch {
+    pub worktree: PathBuf,
+    pub branch: String,
 }
 
 fn default_true() -> bool {
@@ -76,6 +90,18 @@ fn config_dir() -> Option<PathBuf> {
 /// them.  Stable, so equal keys (all the disk-only roots) hold their order.
 pub fn reorder_projects(state: &mut PersistedState, order: &[PathBuf]) {
     state.projects.sort_by_key(|p| order.iter().position(|r| *r == p.root).unwrap_or(usize::MAX));
+}
+
+/// Set or clear one worktree's base-branch override.  Entries whose worktree
+/// no longer exists on disk are dropped in the same pass — the filesystem is
+/// the truth every window shares, so pruning here can't delete another
+/// window's live entry the way pruning against one window's project list
+/// could.
+pub fn set_base_branch(state: &mut PersistedState, worktree: &Path, branch: Option<String>) {
+    state.base_branches.retain(|b| b.worktree != worktree && b.worktree.is_dir());
+    if let Some(branch) = branch {
+        state.base_branches.push(PersistedBaseBranch { worktree: worktree.to_path_buf(), branch });
+    }
 }
 
 pub fn load() -> PersistedState {
@@ -357,5 +383,62 @@ mod tests {
         let text = toml::to_string_pretty(&state).unwrap();
         let back: PersistedState = toml::from_str(&text).unwrap();
         assert_eq!(back.projects[0].label.as_deref(), Some("Work"));
+    }
+
+    #[test]
+    fn base_branch_field_is_optional_and_round_trips() {
+        // Old state files (no `base_branches`) still parse.
+        let old = "[[projects]]\nroot = 'C:/x'\n";
+        let state: PersistedState = toml::from_str(old).unwrap();
+        assert!(state.base_branches.is_empty());
+
+        let state = PersistedState {
+            base_branches: vec![PersistedBaseBranch {
+                worktree: PathBuf::from("C:/repo/wt"),
+                branch: "develop".to_string(),
+            }],
+            ..Default::default()
+        };
+        let text = toml::to_string_pretty(&state).unwrap();
+        let back: PersistedState = toml::from_str(&text).unwrap();
+        assert_eq!(back.base_branches[0].branch, "develop");
+        assert_eq!(back.base_branches[0].worktree, PathBuf::from("C:/repo/wt"));
+    }
+
+    #[test]
+    fn set_base_branch_replaces_and_clears() {
+        let dir = TempDir::new().unwrap();
+        let wt = dir.path().join("wt");
+        std::fs::create_dir(&wt).unwrap();
+        let mut state = PersistedState::default();
+
+        set_base_branch(&mut state, &wt, Some("develop".to_string()));
+        assert_eq!(state.base_branches.len(), 1);
+        set_base_branch(&mut state, &wt, Some("release".to_string()));
+        assert_eq!(state.base_branches.len(), 1, "a second set must replace, not append");
+        assert_eq!(state.base_branches[0].branch, "release");
+        set_base_branch(&mut state, &wt, None);
+        assert!(state.base_branches.is_empty(), "None clears the override");
+    }
+
+    /// Worktrees deleted on disk take their overrides with them the next time
+    /// any override is written — the filesystem is the truth every window shares.
+    #[test]
+    fn set_base_branch_prunes_entries_for_vanished_worktrees() {
+        let dir = TempDir::new().unwrap();
+        let alive = dir.path().join("alive");
+        std::fs::create_dir(&alive).unwrap();
+        let mut state = PersistedState {
+            base_branches: vec![PersistedBaseBranch {
+                worktree: dir.path().join("gone"),
+                branch: "develop".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        set_base_branch(&mut state, &alive, Some("main".to_string()));
+
+        let worktrees: Vec<_> = state.base_branches.iter().map(|b| b.worktree.clone()).collect();
+        assert_eq!(worktrees, vec![alive]);
     }
 }

--- a/alacritree/src/state.rs
+++ b/alacritree/src/state.rs
@@ -92,15 +92,28 @@ pub fn reorder_projects(state: &mut PersistedState, order: &[PathBuf]) {
     state.projects.sort_by_key(|p| order.iter().position(|r| *r == p.root).unwrap_or(usize::MAX));
 }
 
-/// Set or clear one worktree's base-branch override.  Entries whose worktree
-/// no longer exists on disk are dropped in the same pass — the filesystem is
-/// the truth every window shares, so pruning here can't delete another
-/// window's live entry the way pruning against one window's project list
-/// could.
+/// Set or clear one worktree's base-branch override.  Entries are pruned in
+/// the same pass, but only when the filesystem definitively says the
+/// worktree is gone — the filesystem is the truth every window shares, so
+/// pruning here can't delete another window's live entry the way pruning
+/// against one window's project list could.  A metadata error that isn't
+/// "not found" (permission denied, an unreachable network or WSL mount with
+/// its distro asleep) is not proof the worktree is gone, so those entries
+/// are kept rather than silently dropped.
 pub fn set_base_branch(state: &mut PersistedState, worktree: &Path, branch: Option<String>) {
-    state.base_branches.retain(|b| b.worktree != worktree && b.worktree.is_dir());
+    state.base_branches.retain(|b| b.worktree != worktree && !definitely_gone(&b.worktree));
     if let Some(branch) = branch {
         state.base_branches.push(PersistedBaseBranch { worktree: worktree.to_path_buf(), branch });
+    }
+}
+
+/// True only when the filesystem gives a conclusive answer that `path` is
+/// not a live worktree directory.  Any other metadata error (permission,
+/// an unreachable mount) is inconclusive, not a "gone" verdict.
+fn definitely_gone(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(m) => !m.is_dir(),
+        Err(e) => e.kind() == std::io::ErrorKind::NotFound,
     }
 }
 
@@ -431,6 +444,29 @@ mod tests {
         let mut state = PersistedState {
             base_branches: vec![PersistedBaseBranch {
                 worktree: dir.path().join("gone"),
+                branch: "develop".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        set_base_branch(&mut state, &alive, Some("main".to_string()));
+
+        let worktrees: Vec<_> = state.base_branches.iter().map(|b| b.worktree.clone()).collect();
+        assert_eq!(worktrees, vec![alive]);
+    }
+
+    /// A path that exists but isn't a directory (e.g. clobbered by a file) is
+    /// just as definitively gone as a missing path.
+    #[test]
+    fn set_base_branch_prunes_entries_whose_path_is_a_file_not_a_dir() {
+        let dir = TempDir::new().unwrap();
+        let alive = dir.path().join("alive");
+        std::fs::create_dir(&alive).unwrap();
+        let file_path = dir.path().join("not_a_dir");
+        std::fs::write(&file_path, b"").unwrap();
+        let mut state = PersistedState {
+            base_branches: vec![PersistedBaseBranch {
+                worktree: file_path,
                 branch: "develop".to_string(),
             }],
             ..Default::default()

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -659,7 +659,10 @@ mod tests {
                 .expect("git runs");
             assert!(status.success(), "git {args:?} failed");
         };
-        git_bare(&["init", "--bare"]);
+        // Pin the bare repo's HEAD to main: `set-head -a` below asks the
+        // remote for its HEAD, which otherwise dangles on machines whose
+        // init.defaultBranch is not main (only main is pushed).
+        git_bare(&["init", "--bare", "-b", "main"]);
         let bare_path = bare.path().to_str().unwrap();
         git(&["remote", "add", "origin", bare_path]);
         git(&["push", "origin", "main"]);

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -634,8 +634,11 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let git = |args: &[&str]| {
             let status = std::process::Command::new("git")
+                .hide_console()
                 .current_dir(dir.path())
                 .args(args)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .status()
                 .expect("git runs");
             assert!(status.success(), "git {args:?} failed");
@@ -647,8 +650,11 @@ mod tests {
         let bare = tempfile::TempDir::new().unwrap();
         let git_bare = |args: &[&str]| {
             let status = std::process::Command::new("git")
+                .hide_console()
                 .current_dir(bare.path())
                 .args(args)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .status()
                 .expect("git runs");
             assert!(status.success(), "git {args:?} failed");

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -644,10 +644,35 @@ mod tests {
         git(&["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "x"]);
         git(&["branch", "develop"]);
 
+        let bare = tempfile::TempDir::new().unwrap();
+        let git_bare = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .current_dir(bare.path())
+                .args(args)
+                .status()
+                .expect("git runs");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git_bare(&["init", "--bare"]);
+        let bare_path = bare.path().to_str().unwrap();
+        git(&["remote", "add", "origin", bare_path]);
+        git(&["push", "origin", "main"]);
+        git(&["fetch", "origin"]);
+        git(&["remote", "set-head", "origin", "-a"]);
+
         let branches = list_branches(dir.path()).expect("listing succeeds");
 
         assert!(branches.contains(&"develop".to_string()), "{branches:?}");
         assert!(branches.contains(&"main".to_string()), "{branches:?}");
+        assert!(branches.contains(&"origin/main".to_string()), "{branches:?}");
+        assert!(!branches.contains(&"origin".to_string()), "HEAD alias leaked: {branches:?}");
+
+        let last_local = branches.iter().rposition(|b| !b.starts_with("origin/")).unwrap();
+        let first_remote = branches.iter().position(|b| b.starts_with("origin/")).unwrap();
+        assert!(
+            last_local < first_remote,
+            "local branches must all precede origin/* entries: {branches:?}"
+        );
     }
 
     #[test]

--- a/alacritree/src/worktree.rs
+++ b/alacritree/src/worktree.rs
@@ -197,6 +197,29 @@ fn has_remote(cwd: &Path, name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Branch names for the base-branch picker: locals first, then `origin/*`,
+/// short names, in git's ref order.  Shells out through [`git_command`]
+/// rather than using git2 so WSL worktrees resolve the same way everything
+/// else in this module does.
+pub fn list_branches(cwd: &Path) -> Result<Vec<String>, String> {
+    let output = git_command(cwd)
+        .args(["for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes/origin"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        // `origin/HEAD` shortens to plain `origin` — an alias, not a branch.
+        .filter(|l| !l.is_empty() && *l != "origin")
+        .map(str::to_string)
+        .collect())
+}
+
 /// Resolve the base branch dynamically.  Asks origin first via
 /// `git ls-remote --symref HEAD` — the only source that reflects the
 /// upstream's *current* default branch.  The caller's hint comes from
@@ -604,5 +627,32 @@ mod tests {
         assert!(prune_worktree(&repo_dir, "live", Some("live"), false).is_err());
         assert!(repo.find_worktree("live").is_ok());
         assert!(repo.find_branch("live", git2::BranchType::Local).is_ok());
+    }
+
+    #[test]
+    fn list_branches_returns_locals_then_origin_remotes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .current_dir(dir.path())
+                .args(args)
+                .status()
+                .expect("git runs");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-b", "main"]);
+        git(&["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "x"]);
+        git(&["branch", "develop"]);
+
+        let branches = list_branches(dir.path()).expect("listing succeeds");
+
+        assert!(branches.contains(&"develop".to_string()), "{branches:?}");
+        assert!(branches.contains(&"main".to_string()), "{branches:?}");
+    }
+
+    #[test]
+    fn list_branches_reports_a_non_repo_as_an_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(list_branches(dir.path()).is_err());
     }
 }

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -102,6 +102,27 @@ so the panel stays responsive even on large repos. A faster cheap path
 (`dirty_counts`) is used by the delete modal — it skips the branch-diff work
 and just counts what `git worktree remove` would reject.
 
+### Per-worktree base branch
+
+The git panel diffs each worktree against an automatically picked base: the
+open PR's base branch if there is one, otherwise the project's default branch.
+To override it for a single worktree (e.g. a branch cut from `develop`):
+
+- right-click the worktree in the left sidebar → *Set base branch…*, or
+- click the `vs <branch>` label in the git panel, or
+- bind the `SetBaseBranch` action and press it (targets the sidebar-cursored
+  worktree when the sidebar has focus, the current worktree otherwise):
+
+  ```toml
+  [[keyboard.bindings]]
+  key = "B"
+  mods = "Control|Alt"
+  action = "SetBaseBranch"
+  ```
+
+Picking *Auto* returns to automatic detection. Overrides persist in
+`state.toml` per worktree path.
+
 ## Terminal grid
 
 Alacritree paints its grid cell-by-cell using the egui font system, with the


### PR DESCRIPTION
The right git panel diffs a worktree against an automatically picked base: the open PR's base branch, else the detected default (`init.defaultBranch` → `origin/HEAD` → `main`/`master`). A worktree cut from a non-default branch (e.g. `develop`) still diffs against `main`, showing a pile of changes that won't exist after merge. This adds a per-worktree override.

- One picker, three entry points: right-click a worktree row → *Set base branch…*, click the `vs <branch>` label in the git panel, or bind the new `SetBaseBranch` action (no default binding — nothing changes until the user opts in).
- Precedence: manual override → PR base → detected default. Picking *Auto* deletes the override.
- Branches are listed through `worktree::git_command` (WSL-safe), one-off when the picker opens — not on the throttled status path.
- Overrides persist in `state.toml` as `[[base_branch]]` entries; stale entries are pruned only when the path is definitely gone (`NotFound`), so live WSL worktrees behind a stopped distro keep their override.

Default behavior is unchanged: auto detection stays in effect until a user explicitly sets an override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)