### PR TITLE
[17] feat(ui): focus sidebars on click

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -170,6 +170,20 @@ fn paint_focus_outline(ctx: &Context, rect: egui::Rect, theme: &Theme) {
     );
 }
 
+/// A primary press landed on the panel itself: inside its rect with no
+/// floating layer (modal, window, context menu) above the press position.
+/// `layer_id_at` resolves only floating `Area` layers — `None` means the
+/// press reached the background panels — and while a modal is open egui
+/// resolves *every* position to the modal's layer, so presses never register
+/// here until the modal closes.
+fn pressed_on_panel(ctx: &Context, resp: &egui::Response) -> bool {
+    let (pressed, origin) = ctx.input(|i| (i.pointer.primary_pressed(), i.pointer.press_origin()));
+    pressed
+        && origin.is_some_and(|pos| {
+            resp.rect.contains(pos) && ctx.layer_id_at(pos).is_none_or(|l| l == resp.layer_id)
+        })
+}
+
 fn blend_toward(c: Color32, target: Color32, amount: f32) -> Color32 {
     let amount = amount.clamp(0.0, 1.0);
     let mix = |a: u8, b: u8| -> u8 {
@@ -2640,6 +2654,12 @@ impl AlacritreeApp {
                 self.last_error = Some(format!("failed to spawn shell: {e}"));
             }
         }
+        if self.config.ui.sidebar_click_focus
+            && self.focus != PaneFocus::ProjectsSidebar
+            && pressed_on_panel(ctx, &panel_resp.response)
+        {
+            self.focus_sidebar();
+        }
         panel_resp.response.rect
     }
 
@@ -2950,6 +2970,12 @@ impl AlacritreeApp {
             });
         if let Some(req) = diff_request.take() {
             self.open_diff(ctx, req);
+        }
+        if self.config.ui.sidebar_click_focus
+            && self.focus != PaneFocus::GitSidebar
+            && pressed_on_panel(ctx, &panel_resp.response)
+        {
+            self.focus_git_sidebar();
         }
         panel_resp.response.rect
     }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -371,6 +371,10 @@ pub struct UiTheme {
     pub pr_status: bool,
     pub icons: Icons,
     pub focus_outline: FocusOutline,
+    /// `[ui] sidebar_click_focus`: clicking a sidebar moves keyboard focus to
+    /// it (so filter typing works without the focus shortcut).  Off by default
+    /// so unmodified configs keep click-through-to-terminal behavior.
+    pub sidebar_click_focus: bool,
     /// `[ui] worktree_name`: template for worktree row labels (subst syntax:
     /// `$name`, `$branch`, `$path`, `${var:fallback}`; `$pr` is the branch's
     /// PR number as `#123`, absent when none is known — it needs
@@ -397,6 +401,7 @@ impl Default for UiTheme {
             pr_status: false,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
+            sidebar_click_focus: false,
             worktree_name: None,
             project_name: None,
         }
@@ -1044,6 +1049,8 @@ struct RawUi {
     profiles: Vec<RawProfile>,
     default_profile: Option<String>,
     focus_outline: RawFocusOutline,
+    /// Clicking a sidebar moves keyboard focus to it.  Default false.
+    sidebar_click_focus: Option<bool>,
 }
 
 /// One `[[ui.profiles]]` entry.  Fields are optional so a malformed entry
@@ -1183,6 +1190,7 @@ impl RawConfig {
                 color: self.ui.focus_outline.color.map(|v| rgb_to_color32(v.0)),
                 thickness: self.ui.focus_outline.thickness.map_or(1.0, |t| t.max(0.5)),
             },
+            sidebar_click_focus: self.ui.sidebar_click_focus.unwrap_or(false),
             worktree_name: self.ui.worktree_name.clone().filter(|t| !t.trim().is_empty()),
             project_name: self.ui.project_name.clone().filter(|t| !t.trim().is_empty()),
         };
@@ -1817,6 +1825,16 @@ program = "second"
     fn focus_outline_thickness_clamps() {
         let fo = ui_from_toml("[ui.focus_outline]\nthickness = 0.1").focus_outline;
         assert_eq!(fo.thickness, 0.5);
+    }
+
+    #[test]
+    fn sidebar_click_focus_defaults_off() {
+        assert!(!ui_from_toml("").sidebar_click_focus);
+    }
+
+    #[test]
+    fn sidebar_click_focus_parses() {
+        assert!(ui_from_toml("[ui]\nsidebar_click_focus = true").sidebar_click_focus);
     }
 
     #[test]

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -215,6 +215,7 @@ notifications      = true   # desktop notification when a hidden session bells
 attention_grace_ms = 0      # hold pings this long and drop them if the session
                             # resumes work (agents that continue between tasks);
                             # 0 pings immediately
+sidebar_click_focus = true  # clicking a sidebar moves keyboard focus to it (default false)
 
 [ui.icons]                  # sidebar glyph overrides (e.g. Nerd Font icons)
 search = "⌕"                # glyph prefixing the sidebar search prompt


### PR DESCRIPTION
Clicking a sidebar moves keyboard focus to it, so filter typing works without reaching for the focus shortcut. Opt-in via `[ui] sidebar_click_focus = true` (default off — stock behavior unchanged). Presses under a modal, floating window, or context menu are ignored via egui's layer hit-test, and the cursor seeds exactly like the focus-move binding.

- `config.rs`: new `[ui] sidebar_click_focus` bool, default false, with parse/default tests
- `app.rs`: `pressed_on_panel` helper (primary press inside the panel rect with no floating layer above it) wired into both sidebars
- `docs/alacritree.md`: config example line

Tests: 392 passed, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)