### PR TITLE
feat: add cross-workspace session cycling actions

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1100,6 +1100,32 @@ impl AlacritreeApp {
         }
     }
 
+    fn cycle_sessions(&mut self, ctx: &Context, delta: i32) {
+        let ring: Vec<(WorkspaceKey, SessionId)> = self
+            .workspace_order()
+            .into_iter()
+            .flat_map(|ws| {
+                let entries: Vec<_> = self
+                    .workspace_session_indices(&ws)
+                    .into_iter()
+                    .map(|i| (ws.clone(), self.sessions[i].id))
+                    .collect();
+                entries
+            })
+            .collect();
+        let current = self.active_session_index().map(|i| self.sessions[i].id);
+        let Some((target_ws, id)) = session_ring_target(&ring, current, delta) else {
+            return;
+        };
+        // Record the target before switching: ensure_active_session would
+        // otherwise re-adopt the workspace's previously active session.
+        self.active_session.insert(target_ws.clone(), id);
+        match target_ws {
+            None => self.activate_home(ctx),
+            Some(path) => self.activate_worktree(ctx, &path),
+        }
+    }
+
     fn workspace_order(&self) -> Vec<WorkspaceKey> {
         let mut order: Vec<WorkspaceKey> = vec![None];
         for project in &self.projects {
@@ -1820,6 +1846,10 @@ impl AlacritreeApp {
             },
             BindingAction::Named(NamedAction::SelectNextTab) => self.cycle_tabs(1),
             BindingAction::Named(NamedAction::SelectPreviousTab) => self.cycle_tabs(-1),
+            BindingAction::Named(NamedAction::SelectNextSession) => self.cycle_sessions(ctx, 1),
+            BindingAction::Named(NamedAction::SelectPreviousSession) => {
+                self.cycle_sessions(ctx, -1);
+            },
             BindingAction::Named(NamedAction::SelectTab(n)) => self.select_tab(n),
             BindingAction::Named(NamedAction::SelectLastTab) => self.select_last_tab(),
             BindingAction::Named(NamedAction::SpawnProfile(n)) => {
@@ -4215,6 +4245,28 @@ fn base_branch_target(
     current.clone()
 }
 
+/// The session a SelectNextSession/SelectPreviousSession press lands on:
+/// one flat ring over every open session, workspaces in sidebar order and
+/// each workspace's sessions in spawn order.  `None` means stay put — a
+/// ring too small to cycle, or an active session missing from the ring
+/// (its worktree turned prunable).  With no active session (an emptied
+/// workspace on screen) the first entry re-anchors the cycle.
+fn session_ring_target(
+    ring: &[(WorkspaceKey, SessionId)],
+    current: Option<SessionId>,
+    delta: i32,
+) -> Option<(WorkspaceKey, SessionId)> {
+    if ring.len() < 2 {
+        return None;
+    }
+    let Some(current) = current else {
+        return Some(ring[0].clone());
+    };
+    let pos = ring.iter().position(|(_, id)| *id == current)?;
+    let next = (pos as i32 + delta).rem_euclid(ring.len() as i32) as usize;
+    Some(ring[next].clone())
+}
+
 /// Branches whose name contains `query`, case-insensitively.
 fn filter_branches(branches: &[String], query: &str) -> Vec<String> {
     let query = query.to_lowercase();
@@ -4992,7 +5044,9 @@ impl AlacritreeApp {
             .collapsible(false)
             .resizable(false)
             .show(ctx, |ui| {
-                ui.set_width(480.0 * s);
+                // Three columns (key, action name, description) need more
+                // room than the old stacked two-column layout.
+                ui.set_width(600.0 * s);
                 ui.spacing_mut().item_spacing.y = 4.0 * s;
 
                 let search = ui.add(
@@ -5013,6 +5067,10 @@ impl AlacritreeApp {
                     .into_iter()
                     .filter(|r| shortcuts_window::row_matches(&query, r))
                     .collect();
+                let unbound_rows: Vec<_> = shortcuts_window::unbound_rows(&self.config.bindings)
+                    .into_iter()
+                    .filter(|r| shortcuts_window::row_matches(&query, r))
+                    .collect();
 
                 // auto_shrink would size the scroll area to the grids'
                 // content, leaving a dead margin between the rows and the
@@ -5023,18 +5081,21 @@ impl AlacritreeApp {
                     if scroll_delta != 0.0 {
                         ui.scroll_with_delta(egui::vec2(0.0, scroll_delta));
                     }
-                    if app_rows.is_empty() && nav_rows.is_empty() {
+                    if app_rows.is_empty() && nav_rows.is_empty() && unbound_rows.is_empty() {
                         ui.label(RichText::new("no matches").color(theme.text_dim));
                         return;
                     }
                     if !app_rows.is_empty() {
                         ui.label(RichText::new("App shortcuts").color(theme.text_muted).small());
-                        egui::Grid::new("shortcuts_app_grid").num_columns(2).striped(true).show(
+                        egui::Grid::new("shortcuts_app_grid").num_columns(3).striped(true).show(
                             ui,
                             |ui| {
                                 for row in &app_rows {
                                     ui.label(
                                         RichText::new(&row.keys).color(theme.accent).monospace(),
+                                    );
+                                    ui.label(
+                                        RichText::new(&row.name).color(theme.text_dim).monospace(),
                                     );
                                     ui.vertical(|ui| {
                                         // Stretch the last column to the
@@ -5042,9 +5103,6 @@ impl AlacritreeApp {
                                         // whole row, not just the text.
                                         ui.set_min_width(ui.available_width());
                                         ui.label(RichText::new(&row.description).color(theme.text));
-                                        ui.label(
-                                            RichText::new(&row.name).color(theme.text_dim).small(),
-                                        );
                                     });
                                     ui.end_row();
                                 }
@@ -5073,6 +5131,29 @@ impl AlacritreeApp {
                                 }
                             },
                         );
+                    }
+                    if !unbound_rows.is_empty() {
+                        ui.add_space(6.0 * s);
+                        ui.label(
+                            RichText::new("Unbound actions (name them in [[keyboard.bindings]])")
+                                .color(theme.text_muted)
+                                .small(),
+                        );
+                        egui::Grid::new("shortcuts_unbound_grid")
+                            .num_columns(2)
+                            .striped(true)
+                            .show(ui, |ui| {
+                                for row in &unbound_rows {
+                                    ui.label(
+                                        RichText::new(&row.name).color(theme.accent).monospace(),
+                                    );
+                                    ui.vertical(|ui| {
+                                        ui.set_min_width(ui.available_width());
+                                        ui.label(RichText::new(&row.description).color(theme.text));
+                                    });
+                                    ui.end_row();
+                                }
+                            });
                     }
                 });
             });
@@ -6114,6 +6195,32 @@ mod tests {
         assert_eq!(latest_notification_click(&rx), Some(5));
         // The drain consumed everything, not just the returned click.
         assert_eq!(latest_notification_click(&rx), None);
+    }
+
+    #[test]
+    fn session_ring_crosses_workspace_boundaries_and_wraps() {
+        let ring = [(None, 1), (None, 2), (ws("a"), 3), (ws("b"), 4)];
+        // Within a workspace it moves like tab cycling…
+        assert_eq!(session_ring_target(&ring, Some(1), 1), Some((None, 2)));
+        // …and crossing a boundary switches workspaces.
+        assert_eq!(session_ring_target(&ring, Some(2), 1), Some((ws("a"), 3)));
+        assert_eq!(session_ring_target(&ring, Some(3), -1), Some((None, 2)));
+        // The ring wraps at both ends.
+        assert_eq!(session_ring_target(&ring, Some(4), 1), Some((None, 1)));
+        assert_eq!(session_ring_target(&ring, Some(1), -1), Some((ws("b"), 4)));
+    }
+
+    #[test]
+    fn session_ring_stays_put_on_degenerate_input() {
+        // Fewer than two sessions: nowhere to go.
+        assert_eq!(session_ring_target(&[], Some(1), 1), None);
+        assert_eq!(session_ring_target(&[(None, 1)], Some(1), 1), None);
+        let ring = [(None, 1), (ws("a"), 2)];
+        // No active session (emptied workspace on screen) re-anchors on the
+        // first entry.
+        assert_eq!(session_ring_target(&ring, None, 1), Some((None, 1)));
+        // An active session missing from the ring does nothing.
+        assert_eq!(session_ring_target(&ring, Some(9), 1), None);
     }
 
     #[test]

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -45,6 +45,10 @@ pub enum NamedAction {
     /// 1-indexed.
     SelectTab(u8),
     SelectLastTab,
+    /// Like SelectNextTab/SelectPreviousTab, but one flat ring over every
+    /// open session: crossing a workspace boundary switches workspaces.
+    SelectNextSession,
+    SelectPreviousSession,
     ToggleLeftSidebar,
     ToggleRightSidebar,
     SelectNextWorkspace,
@@ -133,6 +137,12 @@ impl NamedAction {
             Self::SelectPreviousTab => "Cycle to the previous session in the workspace".into(),
             Self::SelectTab(n) => format!("Select session {n} in the current workspace"),
             Self::SelectLastTab => "Select the last session in the current workspace".into(),
+            Self::SelectNextSession => {
+                "Cycle to the next session, continuing across workspaces".into()
+            },
+            Self::SelectPreviousSession => {
+                "Cycle to the previous session, continuing across workspaces".into()
+            },
             Self::ToggleLeftSidebar => "Toggle the projects sidebar".into(),
             Self::ToggleRightSidebar => "Toggle the git sidebar".into(),
             Self::SelectNextWorkspace => "Switch to the next workspace".into(),
@@ -638,6 +648,8 @@ pub fn parse_action(name: &str) -> BindingAction {
         "SelectTab8" => BindingAction::Named(SelectTab(8)),
         "SelectTab9" => BindingAction::Named(SelectTab(9)),
         "SelectLastTab" => BindingAction::Named(SelectLastTab),
+        "SelectNextSession" => BindingAction::Named(SelectNextSession),
+        "SelectPreviousSession" => BindingAction::Named(SelectPreviousSession),
         "ToggleLeftSidebar" => BindingAction::Named(ToggleLeftSidebar),
         "ToggleRightSidebar" => BindingAction::Named(ToggleRightSidebar),
         "SelectNextWorkspace" => BindingAction::Named(SelectNextWorkspace),
@@ -1046,6 +1058,19 @@ mod tests {
             parse_action("CloseSession"),
             BindingAction::Named(NamedAction::CloseSession)
         ));
+    }
+
+    #[test]
+    fn select_session_actions_parse_from_config_names() {
+        for (name, expected) in [
+            ("SelectNextSession", NamedAction::SelectNextSession),
+            ("SelectPreviousSession", NamedAction::SelectPreviousSession),
+        ] {
+            assert!(
+                matches!(parse_action(name), BindingAction::Named(a) if a == expected),
+                "{name} does not parse"
+            );
+        }
     }
 
     #[test]

--- a/alacritree/src/shortcuts_window.rs
+++ b/alacritree/src/shortcuts_window.rs
@@ -1,6 +1,7 @@
 //! Data model for the searchable shortcuts window: the effective binding
-//! rows, the static sidebar-navigation entries, and the fuzzy matcher the
-//! search box filters them with.  Pure — painting lives in `app.rs`.
+//! rows, the static sidebar-navigation entries, the actions no binding
+//! currently triggers, and the fuzzy matcher the search box filters them
+//! with.  Pure — painting lives in `app.rs`.
 
 use crate::bindings::{BindingAction, KeyBinding, NamedAction};
 
@@ -50,6 +51,104 @@ pub fn named_rows(bindings: &[KeyBinding]) -> Vec<ShortcutRow> {
             })
         })
         .collect()
+}
+
+/// Actions no current binding triggers — the discoverable remainder the
+/// shortcuts window lists so users learn what `[[keyboard.bindings]]` can
+/// name without reading the docs.
+pub fn unbound_rows(bindings: &[KeyBinding]) -> Vec<ShortcutRow> {
+    let bound: std::collections::HashSet<String> = bindings
+        .iter()
+        .filter_map(|b| match &b.action {
+            BindingAction::Named(a) => Some(a.config_name()),
+            _ => None,
+        })
+        .collect();
+    bindable_rows()
+        .into_iter()
+        .filter(|(names, _)| names.iter().all(|n| !bound.contains(n)))
+        .map(|(_, row)| row)
+        .collect()
+}
+
+fn simple(a: NamedAction) -> (Vec<String>, ShortcutRow) {
+    (
+        vec![a.config_name()],
+        ShortcutRow { keys: String::new(), name: a.config_name(), description: a.description() },
+    )
+}
+
+fn family(prefix: &str, description: &str) -> (Vec<String>, ShortcutRow) {
+    (
+        (1..=9).map(|n| format!("{prefix}{n}")).collect(),
+        ShortcutRow {
+            keys: String::new(),
+            name: format!("{prefix}1 … {prefix}9"),
+            description: description.into(),
+        },
+    )
+}
+
+/// Every action a `[[keyboard.bindings]]` entry can name, paired with the
+/// config names that hide its row once any of them is bound.  Parametrized
+/// families collapse to one row each.  Kept in sync with `NamedAction` by
+/// hand (`NoOp`/`ReceiveChar` unbind rather than bind — no rows).
+fn bindable_rows() -> Vec<(Vec<String>, ShortcutRow)> {
+    use NamedAction::*;
+    let mut rows: Vec<_> = [
+        Paste,
+        PasteSelection,
+        Copy,
+        CopySelection,
+        ScrollPageUp,
+        ScrollPageDown,
+        ScrollHalfPageUp,
+        ScrollHalfPageDown,
+        ScrollLineUp,
+        ScrollLineDown,
+        ScrollToTop,
+        ScrollToBottom,
+        ClearHistory,
+        SpawnNewInstance,
+        IncreaseFontSize,
+        DecreaseFontSize,
+        ResetFontSize,
+        ToggleFullscreen,
+        ToggleMaximized,
+        Minimize,
+        SelectNextTab,
+        SelectPreviousTab,
+        SelectLastTab,
+        SelectNextSession,
+        SelectPreviousSession,
+        SelectNextWorkspace,
+        SelectPreviousWorkspace,
+        ToggleLeftSidebar,
+        ToggleRightSidebar,
+        AddProject,
+        ToggleSidebarFocus,
+        CloseSession,
+        SidebarTop,
+        SidebarBottom,
+        SidebarNextProject,
+        SidebarPreviousProject,
+        ShowShortcuts,
+        FocusProjectsSidebar,
+        FocusGitSidebar,
+        FocusTerminal,
+        FocusLeft,
+        FocusRight,
+        ToggleSessionRows,
+        ToggleSessionTabs,
+        SetBaseBranch,
+        Quit,
+    ]
+    .into_iter()
+    .map(simple)
+    .collect();
+    rows.push(family("SelectTab", "Select the Nth session in the current workspace"));
+    rows.push(family("SpawnProfile", "Open a session with the Nth [[ui.profiles]] entry"));
+    rows
 }
 
 fn format_shortcut(key: egui::Key, mods: egui::Modifiers) -> String {
@@ -141,6 +240,45 @@ mod tests {
         assert!(!NamedAction::SelectTab(3).description().is_empty());
         assert!(!NamedAction::SpawnProfile(2).description().is_empty());
         assert_eq!(NamedAction::SelectTab(3).config_name(), "SelectTab3");
+    }
+
+    #[test]
+    fn unbound_rows_lists_only_actions_without_bindings() {
+        let rows = unbound_rows(&parse_bindings(vec![]));
+        // Actions no default binds show up…
+        assert!(rows.iter().any(|r| r.name == "SelectNextSession"));
+        assert!(rows.iter().any(|r| r.name == "FocusTerminal"));
+        // …while bound defaults stay out.
+        assert!(!rows.iter().any(|r| r.name == "CloseSession"));
+        // Every row is discoverable by name and description; keys stay empty.
+        for r in &rows {
+            assert!(r.keys.is_empty(), "{} has keys", r.name);
+            assert!(!r.name.is_empty() && !r.description.is_empty());
+        }
+    }
+
+    #[test]
+    fn binding_an_action_removes_its_unbound_row() {
+        let rows = unbound_rows(&parse_bindings(vec![raw_action(
+            "N",
+            Some("Control|Shift"),
+            "SelectNextSession",
+        )]));
+        assert!(!rows.iter().any(|r| r.name == "SelectNextSession"));
+    }
+
+    #[test]
+    fn a_family_row_covers_all_members_and_hides_once_one_is_bound() {
+        let rows = unbound_rows(&parse_bindings(vec![]));
+        // SpawnProfile has no default binding on any platform: one collapsed
+        // row for the whole family, not nine.
+        assert_eq!(rows.iter().filter(|r| r.name.contains("SpawnProfile")).count(), 1);
+        let rows = unbound_rows(&parse_bindings(vec![raw_action(
+            "2",
+            Some("Control|Shift"),
+            "SpawnProfile2",
+        )]));
+        assert!(!rows.iter().any(|r| r.name.contains("SpawnProfile")));
     }
 
     #[test]

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -120,6 +120,16 @@ entry. Names match alacritty's own action names, so existing configs port over.
   workspace, so they collapse to the same action.)
 - `SelectNextTab` / `SelectPreviousTab` — cycle through sessions in the
   current workspace.
+- `SelectNextSession` / `SelectPreviousSession` — cycle through every open
+  session across all workspaces: one flat ring with workspaces in sidebar
+  order, switching workspace when the cycle crosses a boundary. Unbound by
+  default; example binding:
+  ```toml
+  [[keyboard.bindings]]
+  key = "PageDown"
+  mods = "Control|Shift"
+  action = "SelectNextSession"
+  ```
 - `SelectTab1` … `SelectTab9` — select the Nth session in the current
   workspace. Out-of-range indices are ignored.
 - `SelectLastTab` — select the last session in the current workspace.
@@ -139,7 +149,9 @@ All four sidebar actions act only while the projects sidebar has keyboard
 focus; anywhere else their keys pass through to the terminal untouched, so
 the unmodified defaults don't shadow Home/End/PageUp/PageDown in TUIs.
 - `ShowShortcuts` — toggle a searchable window listing every effective
-  binding. Type to fuzzy-filter, `/` refocuses the search box, `Escape`
+  binding, plus the actions nothing currently binds (so the full action
+  vocabulary is discoverable without the docs). Type to fuzzy-filter, `/`
+  refocuses the search box, `Escape`
   clears the query and then closes, and `Up`/`Down`/`PageUp`/`PageDown`
   scroll the list without leaving the search box. Clicking outside the
   window closes it. The default `F1` shadows `F1` for terminal apps;


### PR DESCRIPTION
Adds `SelectNextSession` / `SelectPreviousSession`: one flat session ring across all workspaces (sidebar order, home first), switching workspace when the cycle crosses a boundary. Unbound by default — existing bindings and behavior are untouched.

Also improves the F1 shortcuts window: a new **Unbound actions** section lists every action nothing currently binds (parametrized families like `SelectTab1…9` collapse to one row, and a row disappears once you bind it), and the app-shortcut rows split into key | action | description columns instead of stacking the name under the description.

Tests cover the ring math (boundary crossing, wrap, degenerate cases), action-name parsing, and unbound-row filtering. Full suite green; the conpty handshake timing test is flaky under load on my machine, pre-existing on clean master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)