### PR TITLE
fix(macos): dlopen libfontconfig to unblock the release build

### DIFF
--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -88,6 +88,14 @@ winreg = "0.55"
 tauri-winrt-notification = "0.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# dlopen libfontconfig at runtime instead of linking it at build time. macOS
+# ships no system fontconfig, and the Homebrew bottle on the CI runners is not
+# reliably pkg-config-visible, so the default build-time `pkg_config::find_library`
+# fails. The runtime requirement is unchanged (the linked build already loaded
+# libfontconfig.dylib dynamically); dlopen just defers the lookup to first use.
+# Cargo unions target features, so this enables dlopen only on macOS, leaving the
+# `cfg(unix)` fontconfig dep above to link normally on Linux.
+fontconfig = { version = "0.8", features = ["dlopen"] }
 # Foreground-agent detection: `proc_pidinfo` supplies the process group,
 # foreground group, and command name Linux reads from /proc, and
 # `sysctl(KERN_PROCARGS2)` the command line.


### PR DESCRIPTION
## Problem

The `build-local-artifacts (aarch64-apple-darwin)` and `(x86_64-apple-darwin)` legs of the **Release** workflow fail (seen on the `v0.5.0` tag run), so the v0.5.0 GitHub Release shipped without its macOS binaries.

The build panics in `yeslogic-fontconfig-sys`'s build script:

```
The system library `fontconfig` required by crate `yeslogic-fontconfig-sys` was not found.
The file `fontconfig.pc` needs to be installed and the PKG_CONFIG_PATH ... must contain its parent directory.
thread 'main' panicked at .../yeslogic-fontconfig-sys-5.0.0/build.rs:8: called `Result::unwrap()` on an `Err`
```

`brew bundle` reports `Using fontconfig` (already installed on the runner image) and so never relinks it, leaving `fontconfig.pc` absent from the opt prefix that dist puts on `PKG_CONFIG_PATH`. The build script's `pkg_config::find_library("fontconfig").unwrap()` then blows up.

## Fix

Enable the `fontconfig` crate's `dlopen` feature on macOS. `yeslogic-fontconfig-sys`'s build script skips `pkg_config::find_library` when that feature is set, loading `libfontconfig` at runtime via `dlopen` instead of resolving it through pkg-config at build time.

```toml
[target.'cfg(target_os = "macos")'.dependencies]
fontconfig = { version = "0.8", features = ["dlopen"] }
```

Cargo unions target features, so the feature is scoped to macOS only; the existing `cfg(unix)` fontconfig dep still links normally on Linux (verified with `cargo tree --target ... -e features -i yeslogic-fontconfig-sys`: `dlopen` present on `aarch64-apple-darwin`, absent on `x86_64-unknown-linux-gnu`).

The runtime requirement is unchanged: the linked build already loaded `libfontconfig.dylib` dynamically, so dlopen merely defers the same lookup to first use.

## Verification

- Feature resolution confirmed per target as above.
- Manifest valid (`cargo metadata`), Linux build path untouched.
- The Release build jobs only run for real on a tag push, not on PRs, so full macOS compilation is exercised by the next tagged release.

## Follow-up (not in this PR)

v0.5.0's macOS artifacts are missing from the published release and will need backfilling (re-run the build against a tree containing this fix, or ship them with the next release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)