### PR TITLE
homebrew: bump alacritree to v0.5.1

### DIFF
--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -1,7 +1,7 @@
 class Alacritree < Formula
   desc "Alacritty fork with worktree-aware sidebars"
   homepage "https://github.com/mathix420/alacritree"
-  version "0.4.0"
+  version "0.5.1"
   license "Apache-2.0"
 
   # Linked dynamically through the `fontconfig` Rust crate (alacritty's font
@@ -22,7 +22,7 @@ class Alacritree < Formula
   on_macos do
     on_arm do
       url "https://github.com/mathix420/alacritree/releases/download/v#{version}/alacritree-aarch64-apple-darwin.tar.gz"
-      sha256 "a17f6732f19c660233a20d9e7febd7ab0e45f9b72885729fc7e931b481d6d6c8"
+      sha256 "94dfe4bb198b3a63009f112761119c16226dbe9d50490ddeb6b118734d5472ee"
     end
   end
 


### PR DESCRIPTION
Automated formula bump triggered by the release of `v0.5.1`.