### PR TITLE
fix: garbled (CRLF) CLI output when launched from WSL

### DIFF
--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -74,6 +74,7 @@ fontconfig = "0.8"
 # borrows the launching shell's console so the CLI can print
 # (`attach_parent_console`).
 windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
     "Win32_System_Console",
     "Win32_System_LibraryLoader",
 ] }

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -110,19 +110,34 @@ fn main() -> eframe::Result<()> {
     )
 }
 
-/// Borrow the console of whatever shell launched us, if there is one.
+/// Borrow the console of whatever shell launched us, but only when we have no
+/// output destination of our own.
 ///
 /// A `windows_subsystem = "windows"` binary starts with no console attached, so
 /// in a release build `println!` writes to a handle that goes nowhere and the
 /// CLI is silent at a prompt.  (A debug build has a console and looks fine,
-/// which is how this hides.)  Redirected output is unaffected either way —
-/// `GetStdHandle` returns the pipe — so only the interactive case needs this.
+/// which is how this hides.)  Attaching the parent's console fixes that.
+///
+/// But a caller that already gave us a stdout — a redirect, a pipe, or WSL,
+/// which relays the Windows binary's output through a pipe of its own — needs
+/// no console, and grabbing one actively breaks WSL: output is repointed at a
+/// Windows console whose contents WSL relays line by line as CRLF, so `--help`
+/// and every other command come out littered with `^M`.  So attach only when
+/// `GetStdHandle` reports no stdout at all.
 ///
 /// Must run before anything touches `std::io::stdout()`, which caches the
 /// handle it first sees.
 #[cfg(windows)]
 fn attach_parent_console() {
-    use windows_sys::Win32::System::Console::{ATTACH_PARENT_PROCESS, AttachConsole};
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{
+        ATTACH_PARENT_PROCESS, AttachConsole, GetStdHandle, STD_OUTPUT_HANDLE,
+    };
+
+    let stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+    if !stdout.is_null() && stdout != INVALID_HANDLE_VALUE {
+        return;
+    }
 
     // Fails when the parent has no console (launched from a GUI shell), which
     // is exactly when there is nothing to attach to and nothing to report.


### PR DESCRIPTION
Running `alacritree.exe --help` — or any CLI subcommand — from a WSL shell produced output with a stray `\r` on every line, making it unreadable. Ordinary console-subsystem Rust binaries don't hit this.

**Cause:** alacritree is a `windows_subsystem = "windows"` (GUI) binary, so it calls `AttachConsole(ATTACH_PARENT_PROCESS)` at startup to reclaim a console when launched from a Windows shell (otherwise the CLI is silent at a prompt). Under WSL that attach repoints stdout into a Windows console, whose contents WSL then relays line by line as CRLF.

**Fix:** attach the parent console only when `GetStdHandle(STD_OUTPUT_HANDLE)` reports no stdout — the GUI-launched-from-a-Windows-shell case the attach exists for. WSL, like a redirect or a pipe, already hands the process a valid stdout, so it is left untouched and output stays LF-clean. The Windows interactive case (null stdout → attach) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)