### PR TITLE
feat(sidebar): add search confirm/cancel actions [3]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -283,6 +283,10 @@ pub struct AlacritreeApp {
     sidebar_auto_shown: bool,
     /// One-shot: scroll the cursor row into view on the next sidebar paint.
     sidebar_cursor_moved: bool,
+    /// One-shot scroll target for the projects sidebar, independent of focus and
+    /// cursor: a search confirm activates a row and focuses the terminal (nulling
+    /// the paint-time cursor), so the row to reveal is carried here instead.
+    pending_sidebar_scroll: Option<SidebarRow>,
     /// Fuzzy-search query and `s`/`a` toggle state for the projects panel.
     /// Transient: never persisted, never touches the `expanded` flag.
     project_filter: PanelFilter,
@@ -611,6 +615,7 @@ impl AlacritreeApp {
             reorder_mode: false,
             sidebar_auto_shown: false,
             sidebar_cursor_moved: false,
+            pending_sidebar_scroll: None,
             project_filter: PanelFilter::new(&['s', 'a']),
             git_filter: PanelFilter::new(&['m', 'd', 'u']),
             git_cursor: None,
@@ -1425,6 +1430,11 @@ impl AlacritreeApp {
                             };
                             valid_for_focus && !(scratchpad_focused && terminal_only)
                         })
+                        // Search actions are owned by the sidebar nav pass; here
+                        // their default Enter/Esc/Shift+Esc must fall through to
+                        // the PTY when the terminal (or a non-searching panel)
+                        // has focus.
+                        .filter(|a| !matches!(a, BindingAction::Named(n) if n.is_search_scoped()))
                         .collect();
                     if !matched.is_empty() {
                         let suppress_chars = matched
@@ -1450,6 +1460,7 @@ impl AlacritreeApp {
     /// app shortcuts still match in `handle_shortcuts` afterwards.
     fn handle_sidebar_nav(&mut self, ctx: &Context) {
         let filter = &mut self.project_filter;
+        let bindings = &self.config.bindings;
         let steps: Vec<SidebarNavStep> = ctx.input_mut(|i| {
             let mut steps = Vec::new();
             i.events.retain(|ev| match ev {
@@ -1460,16 +1471,8 @@ impl AlacritreeApp {
                     },
                     None => true,
                 },
-                egui::Event::Key { key, pressed: true, modifiers, .. } if modifiers.is_none() => {
-                    if let Some(outcome) = filter.on_key(*key) {
-                        steps.push(SidebarNavStep::Filter(outcome));
-                        return false;
-                    }
-                    if is_sidebar_nav_key(*key) {
-                        steps.push(SidebarNavStep::Nav(*key));
-                        return false;
-                    }
-                    true
+                egui::Event::Key { key, pressed: true, modifiers, .. } => {
+                    drain_search_or_nav(&mut steps, filter, bindings, *key, *modifiers)
                 },
                 _ => true,
             });
@@ -1477,27 +1480,21 @@ impl AlacritreeApp {
         });
         for step in steps {
             match step {
-                SidebarNavStep::Filter(outcome) => self.apply_filter_outcome(ctx, outcome),
+                SidebarNavStep::Filter(outcome) => self.apply_filter_outcome(outcome),
                 SidebarNavStep::Nav(key) => self.apply_sidebar_nav(ctx, key),
+                SidebarNavStep::SearchAction(action) => {
+                    self.dispatch_action(ctx, BindingAction::Named(action), ActionOrigin::Keyboard);
+                },
             }
         }
     }
 
-    fn apply_filter_outcome(&mut self, ctx: &Context, outcome: panel_filter::Outcome) {
+    fn apply_filter_outcome(&mut self, outcome: panel_filter::Outcome) {
         use panel_filter::Outcome;
         match outcome {
             Outcome::FilterChanged => self.after_filter_changed(),
             Outcome::Consumed => {},
             Outcome::MoveCursor(delta) => self.move_sidebar_cursor(delta),
-            // Enter clears the query before yielding Activate, so the filtered
-            // row set is already gone; activate the cursor the preceding
-            // MoveCursor/FilterChanged handling maintained against it, rather
-            // than re-deriving rows and rejecting a now-hidden worktree.
-            Outcome::Activate => {
-                if let Some(cursor) = self.sidebar_cursor.clone() {
-                    self.activate_sidebar_row(ctx, &cursor);
-                }
-            },
             Outcome::LeavePanel => self.focus_terminal(),
         }
     }
@@ -1715,6 +1712,7 @@ impl AlacritreeApp {
     /// `handle_shortcuts`.
     fn handle_git_sidebar_nav(&mut self, ctx: &Context) {
         let filter = &mut self.git_filter;
+        let bindings = &self.config.bindings;
         let steps: Vec<SidebarNavStep> = ctx.input_mut(|i| {
             let mut steps = Vec::new();
             i.events.retain(|ev| match ev {
@@ -1725,16 +1723,8 @@ impl AlacritreeApp {
                     },
                     None => true,
                 },
-                egui::Event::Key { key, pressed: true, modifiers, .. } if modifiers.is_none() => {
-                    if let Some(outcome) = filter.on_key(*key) {
-                        steps.push(SidebarNavStep::Filter(outcome));
-                        return false;
-                    }
-                    if is_sidebar_nav_key(*key) {
-                        steps.push(SidebarNavStep::Nav(*key));
-                        return false;
-                    }
-                    true
+                egui::Event::Key { key, pressed: true, modifiers, .. } => {
+                    drain_search_or_nav(&mut steps, filter, bindings, *key, *modifiers)
                 },
                 _ => true,
             });
@@ -1744,29 +1734,19 @@ impl AlacritreeApp {
             match step {
                 SidebarNavStep::Filter(outcome) => self.apply_git_filter_outcome(ctx, outcome),
                 SidebarNavStep::Nav(key) => self.apply_git_sidebar_nav(ctx, key),
+                SidebarNavStep::SearchAction(action) => {
+                    self.dispatch_action(ctx, BindingAction::Named(action), ActionOrigin::Keyboard);
+                },
             }
         }
     }
 
-    fn apply_git_filter_outcome(&mut self, ctx: &Context, outcome: panel_filter::Outcome) {
+    fn apply_git_filter_outcome(&mut self, _ctx: &Context, outcome: panel_filter::Outcome) {
         use panel_filter::Outcome;
         match outcome {
             Outcome::FilterChanged => self.after_git_filter_changed(),
             Outcome::Consumed => {},
             Outcome::MoveCursor(delta) => self.move_git_cursor(delta),
-            // Enter clears the query before yielding Activate, so act on the
-            // cursor the preceding movement maintained against the filtered
-            // rows rather than re-deriving a now-widened set.  Focus stays on
-            // the panel so the next file is one keystroke away.
-            Outcome::Activate => {
-                if let Some(cursor) = self.git_cursor.clone() {
-                    if let Some(req) =
-                        git_row_diff_request(&cursor, self.git_branch_base.as_deref())
-                    {
-                        self.open_diff(ctx, req);
-                    }
-                }
-            },
             Outcome::LeavePanel => self.focus_terminal(),
         }
     }
@@ -2191,12 +2171,120 @@ impl AlacritreeApp {
                     self.open_base_branch_picker(path);
                 }
             },
+            BindingAction::Named(NamedAction::SidebarSearchConfirm) => {
+                self.sidebar_search_confirm(ctx);
+            },
+            BindingAction::Named(NamedAction::SidebarSearchCancel) => {
+                self.sidebar_search_cancel();
+            },
+            BindingAction::Named(NamedAction::SidebarSearchCancelToTerminal) => {
+                self.sidebar_search_cancel_to_terminal();
+            },
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
             },
             BindingAction::Unsupported(name) => {
                 log::debug!("unsupported keyboard binding action: {name}");
             },
+        }
+    }
+
+    /// Confirm the focused sidebar's fuzzy search: activate the highlighted row
+    /// and mark it to scroll into view once search exits (the row may be a child
+    /// force-shown only during search, so a now-hidden one resolves to its
+    /// owning header). No-op unless the focused panel is in search mode.
+    fn sidebar_search_confirm(&mut self, ctx: &Context) {
+        match self.focus {
+            PaneFocus::ProjectsSidebar
+                if self.project_filter.mode() == panel_filter::Mode::Search =>
+            {
+                let acted = self.sidebar_cursor.clone();
+                self.project_filter.exit_search();
+                if let Some(row) = acted {
+                    self.activate_sidebar_row(ctx, &row);
+                    self.pending_sidebar_scroll = self.resolve_confirm_scroll_target(&row);
+                }
+            },
+            PaneFocus::GitSidebar if self.git_filter.mode() == panel_filter::Mode::Search => {
+                let cursor = self.git_cursor.clone();
+                self.git_filter.exit_search();
+                self.recompute_git_rows();
+                if let Some(c) = cursor {
+                    if let Some(req) = git_row_diff_request(&c, self.git_branch_base.as_deref()) {
+                        self.open_diff(ctx, req);
+                    }
+                    // Focus stays in the git panel, so the render pass scrolls the
+                    // cursor row via `git_cursor_moved`.
+                    self.git_cursor = git_nav::ensure_cursor(&self.git_rows, Some(&c));
+                    self.git_cursor_moved = true;
+                }
+            },
+            _ => {},
+        }
+    }
+
+    /// The confirm scroll target: the acted-on row when it still renders after
+    /// search exits, else its owning project header (never Home, which
+    /// `ensure_cursor` would otherwise pick for a vanished child).
+    fn resolve_confirm_scroll_target(&mut self, acted: &SidebarRow) -> Option<SidebarRow> {
+        let rows = self.current_project_rows();
+        if rows.contains(acted) {
+            return sidebar_nav::ensure_cursor(&rows, Some(acted));
+        }
+        let header = {
+            let session_workspace = |id: SessionId| {
+                self.sessions.iter().find(|s| s.id == id).map(|s| s.working_directory.clone())
+            };
+            row_project_root(&self.projects, session_workspace, acted).map(SidebarRow::Project)
+        };
+        sidebar_nav::ensure_cursor(&rows, header.as_ref())
+    }
+
+    /// Cancel the focused sidebar's fuzzy search, staying in the sidebar with the
+    /// cursor on the seed row (active session / workspace, else Home). No-op
+    /// unless the focused panel is in search mode.
+    fn sidebar_search_cancel(&mut self) {
+        match self.focus {
+            PaneFocus::ProjectsSidebar
+                if self.project_filter.mode() == panel_filter::Mode::Search =>
+            {
+                self.project_filter.exit_search();
+                let seed = sidebar_nav::seed(
+                    &self.projects,
+                    self.current_workspace.as_deref(),
+                    &self.listed_session_ids(),
+                    self.active_session.get(&self.current_workspace).copied(),
+                );
+                let rows = self.current_project_rows();
+                let target = sidebar_nav::ensure_cursor(&rows, Some(&seed));
+                self.sidebar_cursor = target.clone();
+                self.sidebar_cursor_moved = true;
+                self.pending_sidebar_scroll = target;
+            },
+            PaneFocus::GitSidebar if self.git_filter.mode() == panel_filter::Mode::Search => {
+                self.git_filter.exit_search();
+                self.after_git_filter_changed();
+            },
+            _ => {},
+        }
+    }
+
+    /// Cancel the focused sidebar's fuzzy search and return focus to the
+    /// terminal. No-op unless the focused panel is in search mode.
+    fn sidebar_search_cancel_to_terminal(&mut self) {
+        match self.focus {
+            PaneFocus::ProjectsSidebar
+                if self.project_filter.mode() == panel_filter::Mode::Search =>
+            {
+                self.project_filter.exit_search();
+                self.focus_terminal();
+            },
+            PaneFocus::GitSidebar if self.git_filter.mode() == panel_filter::Mode::Search => {
+                self.git_filter.exit_search();
+                self.recompute_git_rows();
+                self.focus_terminal();
+            },
+            _ => {},
         }
     }
 
@@ -2380,6 +2468,12 @@ impl AlacritreeApp {
             None
         };
         let cursor_moved = std::mem::take(&mut self.sidebar_cursor_moved);
+        // Focus-independent scroll target from a search confirm/cancel: honored
+        // when its row renders this pass, dropped otherwise (taken either way).
+        let scroll_target = self.pending_sidebar_scroll.take();
+        let scrolls = |row: &SidebarRow, is_cursor: bool| {
+            (is_cursor && cursor_moved) || scroll_target.as_ref() == Some(row)
+        };
 
         // Membership for the active filter, resolved once so paint can skip
         // non-surviving rows.  While filtering, matched projects render their
@@ -2596,11 +2690,12 @@ impl AlacritreeApp {
                     // whenever the list otherwise fits the panel.
                     let mut group_gap = 0.0_f32;
                     if !filtering || home_visible {
+                        let home_is_cursor = matches!(&cursor_row, Some(SidebarRow::Home));
                         let home_action = home_row(
                             ui,
                             self.current_workspace.is_none(),
-                            matches!(&cursor_row, Some(SidebarRow::Home)),
-                            cursor_moved,
+                            home_is_cursor,
+                            scrolls(&SidebarRow::Home, home_is_cursor),
                             home_attention,
                             home_agent_glyph,
                             &icons,
@@ -2617,7 +2712,8 @@ impl AlacritreeApp {
                                 &cursor_row,
                                 Some(SidebarRow::Session(id)) if *id == row.id
                             );
-                            let act = session_row(ui, row, is_cursor, cursor_moved, &icons, &theme);
+                            let scroll = scrolls(&SidebarRow::Session(row.id), is_cursor);
+                            let act = session_row(ui, row, is_cursor, scroll, &icons, &theme);
                             if act.activate {
                                 activate_session_request.set(Some((None, row.id)));
                             }
@@ -2721,14 +2817,18 @@ impl AlacritreeApp {
                                 }
                             },
                         );
-                        if matches!(&cursor_row, Some(SidebarRow::Project(r)) if *r == project.root)
-                        {
+                        let header_is_cursor =
+                            matches!(&cursor_row, Some(SidebarRow::Project(r)) if *r == project.root);
+                        let header_row = SidebarRow::Project(project.root.clone());
+                        if header_is_cursor || scroll_target.as_ref() == Some(&header_row) {
                             let rect = egui::Rect::from_x_y_ranges(
                                 ui.max_rect().x_range(),
                                 row_rect.y_range(),
                             );
-                            paint_cursor_outline(ui, rect, &theme);
-                            if cursor_moved {
+                            if header_is_cursor {
+                                paint_cursor_outline(ui, rect, &theme);
+                            }
+                            if scrolls(&header_row, header_is_cursor) {
                                 ui.scroll_to_rect(rect, None);
                             }
                         }
@@ -2861,6 +2961,8 @@ impl AlacritreeApp {
                                     &cursor_row,
                                     Some(SidebarRow::Worktree(p)) if *p == wt.path
                                 );
+                                let wt_scroll =
+                                    scrolls(&SidebarRow::Worktree(wt.path.clone()), is_cursor);
                                 let is_deleting = deleting_paths.contains(&wt.path);
                                 let action = worktree_row(
                                     ui,
@@ -2876,7 +2978,7 @@ impl AlacritreeApp {
                                         .and_then(Option::as_ref),
                                     is_active,
                                     is_cursor,
-                                    cursor_moved,
+                                    wt_scroll,
                                     wt_attention,
                                     wt_glyph,
                                     is_deleting,
@@ -2905,11 +3007,13 @@ impl AlacritreeApp {
                                         &cursor_row,
                                         Some(SidebarRow::Session(id)) if *id == row.id
                                     );
+                                    let scroll =
+                                        scrolls(&SidebarRow::Session(row.id), is_cursor);
                                     let act = session_row(
                                         ui,
                                         row,
                                         is_cursor,
-                                        cursor_moved,
+                                        scroll,
                                         &icons,
                                         &theme,
                                     );
@@ -4283,6 +4387,7 @@ fn paint_git_row_cursor(
 enum SidebarNavStep {
     Filter(panel_filter::Outcome),
     Nav(egui::Key),
+    SearchAction(NamedAction),
 }
 
 /// Panel title plus its filter chrome, shared by both sidebars: the heading,
@@ -4317,6 +4422,55 @@ fn panel_header_filter_ui(
                 );
             });
     }
+}
+
+/// Decide one key event for a focused sidebar panel and record its step.
+///
+/// In search mode a search-scoped binding match (any modifiers, so `Shift+Esc`
+/// counts) is dispatched through the binding table, keeping `Enter`/`Esc`
+/// rebindable. Otherwise an unmodified key drives the filter or browsing nav; a
+/// modified non-search key is retained for `handle_shortcuts`. Returns whether
+/// the event stays in the queue (`true`) or is consumed here (`false`).
+fn drain_search_or_nav(
+    steps: &mut Vec<SidebarNavStep>,
+    filter: &mut PanelFilter,
+    bindings: &[crate::bindings::KeyBinding],
+    key: egui::Key,
+    modifiers: egui::Modifiers,
+) -> bool {
+    if filter.mode() == panel_filter::Mode::Search {
+        let mut matched = false;
+        for a in crate::bindings::all_matches(bindings, key, modifiers) {
+            if let BindingAction::Named(n) = a {
+                if n.is_search_scoped() {
+                    steps.push(SidebarNavStep::SearchAction(*n));
+                    matched = true;
+                }
+            }
+        }
+        if matched {
+            return false;
+        }
+    }
+    if !modifiers.is_none() {
+        return true;
+    }
+    if let Some(outcome) = filter.on_key(key) {
+        steps.push(SidebarNavStep::Filter(outcome));
+        return false;
+    }
+    // Browsing consumes the whole nav-key set; in search only Space stays
+    // consumed as a no-op, preserving the fake-click guard on the terminal view.
+    let consume = if filter.mode() == panel_filter::Mode::Browsing {
+        is_sidebar_nav_key(key)
+    } else {
+        key == egui::Key::Space
+    };
+    if consume {
+        steps.push(SidebarNavStep::Nav(key));
+        return false;
+    }
+    true
 }
 
 fn is_sidebar_nav_key(key: egui::Key) -> bool {
@@ -4413,12 +4567,12 @@ fn home_row(
         let rect = egui::Rect::from_x_y_ranges(panel_x, resp.rect.y_range());
         ui.painter().set(bg_idx, egui::Shape::rect_filled(rect, 0.0, bg));
     }
+    let full_rect = egui::Rect::from_x_y_ranges(panel_x, resp.rect.y_range());
     if is_cursor {
-        let full_rect = egui::Rect::from_x_y_ranges(panel_x, resp.rect.y_range());
         paint_cursor_outline(ui, full_rect, theme);
-        if scroll_into_view {
-            ui.scroll_to_rect(full_rect, None);
-        }
+    }
+    if scroll_into_view {
+        ui.scroll_to_rect(full_rect, None);
     }
     HomeAction { activate: resp.clicked() && !spawn_clicked, spawn: spawn_clicked }
 }
@@ -4828,9 +4982,9 @@ fn worktree_row(
     }
     if is_cursor {
         paint_cursor_outline(ui, full_rect, theme);
-        if scroll_into_view {
-            ui.scroll_to_rect(full_rect, None);
-        }
+    }
+    if scroll_into_view {
+        ui.scroll_to_rect(full_rect, None);
     }
     WorktreeAction {
         activate: !deleting && resp.clicked() && !delete_clicked && !spawn_clicked && !wt.prunable,
@@ -4919,9 +5073,9 @@ fn session_row(
     }
     if is_cursor {
         paint_cursor_outline(ui, full_rect, theme);
-        if scroll_into_view {
-            ui.scroll_to_rect(full_rect, None);
-        }
+    }
+    if scroll_into_view {
+        ui.scroll_to_rect(full_rect, None);
     }
     SessionRowAction { activate: resp.clicked() && !close_clicked, close: close_clicked }
 }
@@ -6345,6 +6499,10 @@ impl eframe::App for AlacritreeApp {
             {
                 paint_focus_outline(ctx, r, &theme);
             }
+        } else {
+            // A confirm that focuses the terminal can hide an auto-shown sidebar
+            // before it paints; drop its scroll target so it can't fire later.
+            self.pending_sidebar_scroll = None;
         }
 
         if self.show_right_sidebar {
@@ -6570,6 +6728,128 @@ mod tests {
             v.insert(to, it);
         }
         v
+    }
+
+    fn searching_filter() -> PanelFilter {
+        let mut f = PanelFilter::new(&['s', 'a']);
+        f.on_text("/");
+        f
+    }
+
+    #[test]
+    fn search_enter_escape_and_shift_escape_dispatch_distinct_actions() {
+        let binds = crate::bindings::parse_bindings(vec![]);
+        let mut f = searching_filter();
+        f.on_text("foo");
+
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::Enter,
+            egui::Modifiers::NONE,
+        );
+        assert!(!retain, "a matched search action consumes the key");
+        assert!(matches!(steps.as_slice(), [SidebarNavStep::SearchAction(
+            NamedAction::SidebarSearchConfirm
+        )]));
+        // The filter is untouched by the drain — the action does the exit.
+        assert_eq!(f.mode(), panel_filter::Mode::Search);
+        assert_eq!(f.query(), "foo");
+
+        let mut steps = Vec::new();
+        drain_search_or_nav(&mut steps, &mut f, &binds, egui::Key::Escape, egui::Modifiers::NONE);
+        assert!(matches!(steps.as_slice(), [SidebarNavStep::SearchAction(
+            NamedAction::SidebarSearchCancel
+        )]));
+
+        let mut steps = Vec::new();
+        drain_search_or_nav(&mut steps, &mut f, &binds, egui::Key::Escape, egui::Modifiers::SHIFT);
+        assert!(
+            matches!(steps.as_slice(), [SidebarNavStep::SearchAction(
+                NamedAction::SidebarSearchCancelToTerminal
+            )]),
+            "Shift+Esc is a distinct search action from plain Esc"
+        );
+    }
+
+    #[test]
+    fn search_arrows_move_cursor_and_space_is_swallowed() {
+        let binds = crate::bindings::parse_bindings(vec![]);
+        let mut f = searching_filter();
+
+        let mut steps = Vec::new();
+        drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::ArrowDown,
+            egui::Modifiers::NONE,
+        );
+        assert!(matches!(steps.as_slice(), [SidebarNavStep::Filter(
+            panel_filter::Outcome::MoveCursor(1)
+        )]));
+
+        // Space stays consumed as a no-op nav even in search (fake-click guard).
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::Space,
+            egui::Modifiers::NONE,
+        );
+        assert!(!retain);
+        assert!(matches!(steps.as_slice(), [SidebarNavStep::Nav(egui::Key::Space)]));
+    }
+
+    #[test]
+    fn browsing_enter_navigates_and_modified_keys_fall_through() {
+        let binds = crate::bindings::parse_bindings(vec![]);
+        let mut f = PanelFilter::new(&['s', 'a']); // browsing
+
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::Enter,
+            egui::Modifiers::NONE,
+        );
+        assert!(!retain, "Enter in browsing is a nav activate, consumed here");
+        assert!(matches!(steps.as_slice(), [SidebarNavStep::Nav(egui::Key::Enter)]));
+
+        // A modifier-bound key is left for handle_shortcuts.
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::Enter,
+            egui::Modifiers::CTRL,
+        );
+        assert!(retain);
+        assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn search_enter_with_no_binding_falls_through_without_activating() {
+        // User freed Enter (no search binding): it must not hard-fire browsing
+        // activate — it falls through for the terminal/shortcuts instead.
+        let binds: Vec<crate::bindings::KeyBinding> = Vec::new();
+        let mut f = searching_filter();
+
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::Enter,
+            egui::Modifiers::NONE,
+        );
+        assert!(retain, "an unbound Enter in search is retained, not consumed as nav");
+        assert!(steps.is_empty());
     }
 
     #[test]

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -283,10 +283,6 @@ pub struct AlacritreeApp {
     sidebar_auto_shown: bool,
     /// One-shot: scroll the cursor row into view on the next sidebar paint.
     sidebar_cursor_moved: bool,
-    /// One-shot scroll target for the projects sidebar, independent of focus and
-    /// cursor: a search confirm activates a row and focuses the terminal (nulling
-    /// the paint-time cursor), so the row to reveal is carried here instead.
-    pending_sidebar_scroll: Option<SidebarRow>,
     /// Fuzzy-search query and `s`/`a` toggle state for the projects panel.
     /// Transient: never persisted, never touches the `expanded` flag.
     project_filter: PanelFilter,
@@ -615,7 +611,6 @@ impl AlacritreeApp {
             reorder_mode: false,
             sidebar_auto_shown: false,
             sidebar_cursor_moved: false,
-            pending_sidebar_scroll: None,
             project_filter: PanelFilter::new(&['s', 'a']),
             git_filter: PanelFilter::new(&['m', 'd', 'u']),
             git_cursor: None,
@@ -2172,7 +2167,7 @@ impl AlacritreeApp {
                 }
             },
             BindingAction::Named(NamedAction::SidebarSearchConfirm) => {
-                self.sidebar_search_confirm(ctx);
+                self.sidebar_search_confirm();
             },
             BindingAction::Named(NamedAction::SidebarSearchCancel) => {
                 self.sidebar_search_cancel();
@@ -2189,55 +2184,63 @@ impl AlacritreeApp {
         }
     }
 
-    /// Confirm the focused sidebar's fuzzy search: activate the highlighted row
-    /// and mark it to scroll into view once search exits (the row may be a child
-    /// force-shown only during search, so a now-hidden one resolves to its
-    /// owning header). No-op unless the focused panel is in search mode.
-    fn sidebar_search_confirm(&mut self, ctx: &Context) {
+    /// Confirm the focused sidebar's fuzzy search: leave search and land the
+    /// cursor on the highlighted row, scrolled into view, keeping focus in the
+    /// sidebar. Selecting a row never activates it — a following browsing
+    /// `Enter` does that. No-op unless the focused panel is in search mode.
+    fn sidebar_search_confirm(&mut self) {
         match self.focus {
             PaneFocus::ProjectsSidebar
                 if self.project_filter.mode() == panel_filter::Mode::Search =>
             {
                 let acted = self.sidebar_cursor.clone();
-                self.project_filter.exit_search();
-                if let Some(row) = acted {
-                    self.activate_sidebar_row(ctx, &row);
-                    self.pending_sidebar_scroll = self.resolve_confirm_scroll_target(&row);
+                if let Some(row) = acted.as_ref() {
+                    self.reveal_search_row(row);
                 }
+                self.finish_project_search_at(acted);
             },
             PaneFocus::GitSidebar if self.git_filter.mode() == panel_filter::Mode::Search => {
                 let cursor = self.git_cursor.clone();
-                self.git_filter.exit_search();
-                self.recompute_git_rows();
-                if let Some(c) = cursor {
-                    if let Some(req) = git_row_diff_request(&c, self.git_branch_base.as_deref()) {
-                        self.open_diff(ctx, req);
-                    }
-                    // Focus stays in the git panel, so the render pass scrolls the
-                    // cursor row via `git_cursor_moved`.
-                    self.git_cursor = git_nav::ensure_cursor(&self.git_rows, Some(&c));
-                    self.git_cursor_moved = true;
-                }
+                self.finish_git_search_at(cursor);
             },
             _ => {},
         }
     }
 
-    /// The confirm scroll target: the acted-on row when it still renders after
-    /// search exits, else its owning project header (never Home, which
-    /// `ensure_cursor` would otherwise pick for a vanished child).
-    fn resolve_confirm_scroll_target(&mut self, acted: &SidebarRow) -> Option<SidebarRow> {
-        let rows = self.current_project_rows();
-        if rows.contains(acted) {
-            return sidebar_nav::ensure_cursor(&rows, Some(acted));
-        }
-        let header = {
+    /// Expand the project owning a worktree/session row so the row outlives the
+    /// search exit: search lists matched children whatever their project's
+    /// `expanded` flag says, so a child under a collapsed project would vanish
+    /// the moment the query clears. Expand-only, and headers are left alone, so
+    /// confirming a project row never toggles it.
+    fn reveal_search_row(&mut self, row: &SidebarRow) {
+        let root = {
             let session_workspace = |id: SessionId| {
                 self.sessions.iter().find(|s| s.id == id).map(|s| s.working_directory.clone())
             };
-            row_project_root(&self.projects, session_workspace, acted).map(SidebarRow::Project)
+            search_reveal_root(&self.projects, session_workspace, row)
         };
-        sidebar_nav::ensure_cursor(&rows, header.as_ref())
+        if let Some(root) = root {
+            self.set_project_expanded(&root, true);
+        }
+    }
+
+    /// Leave search and land the projects cursor on `requested`, falling back
+    /// through `ensure_cursor` when it no longer renders. The scroll is forced
+    /// rather than keyed on the cursor changing: restoring the unfiltered list
+    /// can move the very same row far off-screen.
+    fn finish_project_search_at(&mut self, requested: Option<SidebarRow>) {
+        self.project_filter.exit_search();
+        let rows = self.current_project_rows();
+        self.sidebar_cursor = sidebar_nav::ensure_cursor(&rows, requested.as_ref());
+        self.sidebar_cursor_moved = true;
+    }
+
+    /// Git-panel counterpart of `finish_project_search_at`.
+    fn finish_git_search_at(&mut self, requested: Option<git_nav::GitRow>) {
+        self.git_filter.exit_search();
+        self.recompute_git_rows();
+        self.git_cursor = git_nav::ensure_cursor(&self.git_rows, requested.as_ref());
+        self.git_cursor_moved = true;
     }
 
     /// Cancel the focused sidebar's fuzzy search, staying in the sidebar with the
@@ -2248,22 +2251,17 @@ impl AlacritreeApp {
             PaneFocus::ProjectsSidebar
                 if self.project_filter.mode() == panel_filter::Mode::Search =>
             {
-                self.project_filter.exit_search();
                 let seed = sidebar_nav::seed(
                     &self.projects,
                     self.current_workspace.as_deref(),
                     &self.listed_session_ids(),
                     self.active_session.get(&self.current_workspace).copied(),
                 );
-                let rows = self.current_project_rows();
-                let target = sidebar_nav::ensure_cursor(&rows, Some(&seed));
-                self.sidebar_cursor = target.clone();
-                self.sidebar_cursor_moved = true;
-                self.pending_sidebar_scroll = target;
+                self.finish_project_search_at(Some(seed));
             },
             PaneFocus::GitSidebar if self.git_filter.mode() == panel_filter::Mode::Search => {
-                self.git_filter.exit_search();
-                self.after_git_filter_changed();
+                let cursor = self.git_cursor.clone();
+                self.finish_git_search_at(cursor);
             },
             _ => {},
         }
@@ -2468,12 +2466,7 @@ impl AlacritreeApp {
             None
         };
         let cursor_moved = std::mem::take(&mut self.sidebar_cursor_moved);
-        // Focus-independent scroll target from a search confirm/cancel: honored
-        // when its row renders this pass, dropped otherwise (taken either way).
-        let scroll_target = self.pending_sidebar_scroll.take();
-        let scrolls = |row: &SidebarRow, is_cursor: bool| {
-            (is_cursor && cursor_moved) || scroll_target.as_ref() == Some(row)
-        };
+        let scrolls = |is_cursor: bool| is_cursor && cursor_moved;
 
         // Membership for the active filter, resolved once so paint can skip
         // non-surviving rows.  While filtering, matched projects render their
@@ -2695,7 +2688,7 @@ impl AlacritreeApp {
                             ui,
                             self.current_workspace.is_none(),
                             home_is_cursor,
-                            scrolls(&SidebarRow::Home, home_is_cursor),
+                            scrolls(home_is_cursor),
                             home_attention,
                             home_agent_glyph,
                             &icons,
@@ -2712,7 +2705,7 @@ impl AlacritreeApp {
                                 &cursor_row,
                                 Some(SidebarRow::Session(id)) if *id == row.id
                             );
-                            let scroll = scrolls(&SidebarRow::Session(row.id), is_cursor);
+                            let scroll = scrolls(is_cursor);
                             let act = session_row(ui, row, is_cursor, scroll, &icons, &theme);
                             if act.activate {
                                 activate_session_request.set(Some((None, row.id)));
@@ -2819,16 +2812,13 @@ impl AlacritreeApp {
                         );
                         let header_is_cursor =
                             matches!(&cursor_row, Some(SidebarRow::Project(r)) if *r == project.root);
-                        let header_row = SidebarRow::Project(project.root.clone());
-                        if header_is_cursor || scroll_target.as_ref() == Some(&header_row) {
+                        if header_is_cursor {
                             let rect = egui::Rect::from_x_y_ranges(
                                 ui.max_rect().x_range(),
                                 row_rect.y_range(),
                             );
-                            if header_is_cursor {
-                                paint_cursor_outline(ui, rect, &theme);
-                            }
-                            if scrolls(&header_row, header_is_cursor) {
+                            paint_cursor_outline(ui, rect, &theme);
+                            if scrolls(header_is_cursor) {
                                 ui.scroll_to_rect(rect, None);
                             }
                         }
@@ -2961,8 +2951,7 @@ impl AlacritreeApp {
                                     &cursor_row,
                                     Some(SidebarRow::Worktree(p)) if *p == wt.path
                                 );
-                                let wt_scroll =
-                                    scrolls(&SidebarRow::Worktree(wt.path.clone()), is_cursor);
+                                let wt_scroll = scrolls(is_cursor);
                                 let is_deleting = deleting_paths.contains(&wt.path);
                                 let action = worktree_row(
                                     ui,
@@ -3007,8 +2996,7 @@ impl AlacritreeApp {
                                         &cursor_row,
                                         Some(SidebarRow::Session(id)) if *id == row.id
                                     );
-                                    let scroll =
-                                        scrolls(&SidebarRow::Session(row.id), is_cursor);
+                                    let scroll = scrolls(is_cursor);
                                     let act = session_row(
                                         ui,
                                         row,
@@ -4686,6 +4674,22 @@ fn project_main_for(projects: &[Project], ws: &Path) -> Option<PathBuf> {
     let project = projects.iter().find(|p| p.worktrees.iter().any(|w| w.path == ws))?;
     let main = project.worktrees.iter().find(|w| w.is_main)?;
     if main.path == ws { None } else { Some(main.path.clone()) }
+}
+
+/// The project to expand so `row` still renders once search exits, if any.
+/// Only child rows qualify: search lists matched worktrees and sessions whatever
+/// their project's `expanded` flag says, so they vanish when the query clears.
+/// A header is already its own row, and expanding it would turn selecting a
+/// project into a toggle.
+fn search_reveal_root(
+    projects: &[Project],
+    session_workspace: impl Fn(SessionId) -> Option<WorkspaceKey>,
+    row: &SidebarRow,
+) -> Option<PathBuf> {
+    if !matches!(row, SidebarRow::Worktree(_) | SidebarRow::Session(_)) {
+        return None;
+    }
+    row_project_root(projects, session_workspace, row)
 }
 
 /// The root of the project owning `row`: a worktree resolves by its path, a
@@ -6499,10 +6503,6 @@ impl eframe::App for AlacritreeApp {
             {
                 paint_focus_outline(ctx, r, &theme);
             }
-        } else {
-            // A confirm that focuses the terminal can hide an auto-shown sidebar
-            // before it paints; drop its scroll target so it can't fire later.
-            self.pending_sidebar_scroll = None;
         }
 
         if self.show_right_sidebar {
@@ -7514,6 +7514,30 @@ mod tests {
         );
         // Home belongs to no project.
         assert_eq!(row_project_root(&projects, none, &SidebarRow::Home), None);
+    }
+
+    #[test]
+    fn search_confirm_reveals_only_child_rows() {
+        let projects = vec![project_with("/repo", &["/repo/wt"])];
+        let root = PathBuf::from("/repo");
+        let none = |_id: SessionId| -> Option<WorkspaceKey> { None };
+
+        // A worktree matched under a collapsed project would vanish once the
+        // query clears, so its project is expanded to keep it selectable.
+        assert_eq!(
+            search_reveal_root(&projects, none, &SidebarRow::Worktree(PathBuf::from("/repo/wt"))),
+            Some(root.clone())
+        );
+        // A session resolves through its workspace to the same project.
+        let lookup = |id: SessionId| (id == 7).then(|| Some(PathBuf::from("/repo/wt")));
+        assert_eq!(search_reveal_root(&projects, lookup, &SidebarRow::Session(7)), Some(root));
+        // Confirming a header selects it without expanding or collapsing it.
+        assert_eq!(
+            search_reveal_root(&projects, none, &SidebarRow::Project(PathBuf::from("/repo"))),
+            None
+        );
+        // Home owns no project to reveal.
+        assert_eq!(search_reveal_root(&projects, none, &SidebarRow::Home), None);
     }
 
     #[test]

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -235,7 +235,7 @@ impl NamedAction {
             Self::FocusLeft => "Move panel focus left (TUIs get the key first)".into(),
             Self::FocusRight => "Move panel focus right (TUIs get the key first)".into(),
             Self::SidebarSearchConfirm => {
-                "Confirm the sidebar search and open the highlighted row".into()
+                "Leave the sidebar search with the highlighted row selected".into()
             },
             Self::SidebarSearchCancel => "Cancel the sidebar search, staying in the sidebar".into(),
             Self::SidebarSearchCancelToTerminal => {

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -98,6 +98,14 @@ pub enum NamedAction {
     /// `app.rs`).
     FocusLeft,
     FocusRight,
+    /// Confirm the focused sidebar's fuzzy search: activate the highlighted row
+    /// and scroll it into view. Only fires while that panel is in search mode.
+    SidebarSearchConfirm,
+    /// Cancel the focused sidebar's fuzzy search, staying in the sidebar with the
+    /// cursor on the previously active row.
+    SidebarSearchCancel,
+    /// Cancel the focused sidebar's fuzzy search and return focus to the terminal.
+    SidebarSearchCancelToTerminal,
 }
 
 impl NamedAction {
@@ -134,6 +142,19 @@ impl NamedAction {
                 | Self::ScrollToTop
                 | Self::ScrollToBottom
                 | Self::ClearHistory
+        )
+    }
+
+    /// Actions that only act while the *focused* sidebar panel is in fuzzy-search
+    /// mode. Their default keys (`Enter`, `Esc`, `Shift+Esc`) are terminal input
+    /// otherwise, so dispatch is owned by the sidebar nav pass and suppressed in
+    /// `handle_shortcuts`, keeping the terminal's own keys untouched.
+    pub fn is_search_scoped(&self) -> bool {
+        matches!(
+            self,
+            Self::SidebarSearchConfirm
+                | Self::SidebarSearchCancel
+                | Self::SidebarSearchCancelToTerminal
         )
     }
 
@@ -213,6 +234,13 @@ impl NamedAction {
             Self::SetBaseBranch => "Choose the branch the git panel diffs against".into(),
             Self::FocusLeft => "Move panel focus left (TUIs get the key first)".into(),
             Self::FocusRight => "Move panel focus right (TUIs get the key first)".into(),
+            Self::SidebarSearchConfirm => {
+                "Confirm the sidebar search and open the highlighted row".into()
+            },
+            Self::SidebarSearchCancel => "Cancel the sidebar search, staying in the sidebar".into(),
+            Self::SidebarSearchCancelToTerminal => {
+                "Cancel the sidebar search and focus the terminal".into()
+            },
             Self::NoOp | Self::ReceiveChar => String::new(),
         }
     }
@@ -393,6 +421,23 @@ fn default_bindings() -> Vec<KeyBinding> {
         KeyBinding { key: Key::W, mods: ctrl_shift, action: BindingAction::Named(CloseSession) },
         KeyBinding { key: Key::T, mods: ctrl, action: BindingAction::Named(SpawnNewInstance) },
         KeyBinding { key: Key::Q, mods: ctrl, action: BindingAction::Named(Quit) },
+        // Sidebar fuzzy-search: gated to the focused searching panel, so these
+        // pass straight through to the PTY whenever the terminal owns focus.
+        KeyBinding {
+            key: Key::Enter,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(SidebarSearchConfirm),
+        },
+        KeyBinding {
+            key: Key::Escape,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(SidebarSearchCancel),
+        },
+        KeyBinding {
+            key: Key::Escape,
+            mods: shift,
+            action: BindingAction::Named(SidebarSearchCancelToTerminal),
+        },
     ]);
 
     // macOS uses Cmd instead of Ctrl+Shift for clipboard / window actions.
@@ -751,6 +796,9 @@ pub fn parse_action(name: &str) -> BindingAction {
         "ReceiveChar" => BindingAction::Named(ReceiveChar),
         "FocusLeft" => BindingAction::Named(FocusLeft),
         "FocusRight" => BindingAction::Named(FocusRight),
+        "SidebarSearchConfirm" => BindingAction::Named(SidebarSearchConfirm),
+        "SidebarSearchCancel" => BindingAction::Named(SidebarSearchCancel),
+        "SidebarSearchCancelToTerminal" => BindingAction::Named(SidebarSearchCancelToTerminal),
         other => BindingAction::Unsupported(other.to_string()),
     }
 }
@@ -1035,6 +1083,59 @@ mod tests {
             let b = parse_bindings(vec![raw_action("F1", None, name)]);
             assert_eq!(named_matches(&b, Key::F1, Modifiers::NONE), vec![expected], "{name}");
         }
+    }
+
+    #[test]
+    fn search_action_names_parse() {
+        for (name, expected) in [
+            ("SidebarSearchConfirm", NamedAction::SidebarSearchConfirm),
+            ("SidebarSearchCancel", NamedAction::SidebarSearchCancel),
+            ("SidebarSearchCancelToTerminal", NamedAction::SidebarSearchCancelToTerminal),
+        ] {
+            let b = parse_bindings(vec![raw_action("F1", None, name)]);
+            assert_eq!(named_matches(&b, Key::F1, Modifiers::NONE), vec![expected], "{name}");
+        }
+    }
+
+    #[test]
+    fn is_search_scoped_is_exactly_the_three_search_actions() {
+        assert!(NamedAction::SidebarSearchConfirm.is_search_scoped());
+        assert!(NamedAction::SidebarSearchCancel.is_search_scoped());
+        assert!(NamedAction::SidebarSearchCancelToTerminal.is_search_scoped());
+        for a in [
+            NamedAction::Paste,
+            NamedAction::FocusTerminal,
+            NamedAction::SidebarTop,
+            NamedAction::ToggleProjectExpanded,
+            NamedAction::Quit,
+        ] {
+            assert!(!a.is_search_scoped(), "{a:?} must not be search-scoped");
+        }
+    }
+
+    #[test]
+    fn search_actions_have_default_bindings() {
+        let b = parse_bindings(vec![]);
+        assert_eq!(
+            named_matches(&b, Key::Enter, Modifiers::NONE),
+            vec![NamedAction::SidebarSearchConfirm]
+        );
+        assert_eq!(
+            named_matches(&b, Key::Escape, Modifiers::NONE),
+            vec![NamedAction::SidebarSearchCancel]
+        );
+        assert_eq!(
+            named_matches(&b, Key::Escape, Modifiers::SHIFT),
+            vec![NamedAction::SidebarSearchCancelToTerminal]
+        );
+        // Plain Esc and Shift+Esc are distinct triggers, not aliases.
+        assert!(named_matches(&b, Key::Enter, Modifiers::SHIFT).is_empty());
+    }
+
+    #[test]
+    fn user_binding_replaces_search_confirm_default() {
+        let b = parse_bindings(vec![raw_action("Enter", None, "ReceiveChar")]);
+        assert_eq!(named_matches(&b, Key::Enter, Modifiers::NONE), vec![NamedAction::ReceiveChar]);
     }
 
     #[test]

--- a/alacritree/src/command_palette.rs
+++ b/alacritree/src/command_palette.rs
@@ -109,7 +109,7 @@ pub fn action_items(bindings: &[KeyBinding]) -> Vec<PaletteItem> {
 /// Every simple (non-parametrized) `NamedAction`, kept in sync with the enum by
 /// hand. Mirrors the old shortcuts window's bindable list; `SelectTab`/
 /// `SpawnProfile` are excluded here because they carry an index.
-fn bindable_actions() -> [NamedAction; 47] {
+fn bindable_actions() -> [NamedAction; 50] {
     use NamedAction::*;
     [
         Paste,
@@ -157,6 +157,9 @@ fn bindable_actions() -> [NamedAction; 47] {
         ToggleSessionRows,
         ToggleSessionTabs,
         SetBaseBranch,
+        SidebarSearchConfirm,
+        SidebarSearchCancel,
+        SidebarSearchCancelToTerminal,
         Quit,
         TogglePalette,
     ]
@@ -292,6 +295,15 @@ mod tests {
         // FocusTerminal has no default binding: present, discoverable, keyless.
         let focus = find(&items, "FocusTerminal").expect("FocusTerminal missing");
         assert!(focus.keys.is_empty());
+    }
+
+    #[test]
+    fn palette_lists_the_sidebar_search_actions() {
+        let items = action_items(&parse_bindings(vec![]));
+        for name in ["SidebarSearchConfirm", "SidebarSearchCancel", "SidebarSearchCancelToTerminal"]
+        {
+            assert!(items.iter().any(|i| i.secondary == name), "{name} should be a palette row");
+        }
     }
 
     #[test]

--- a/alacritree/src/panel_filter.rs
+++ b/alacritree/src/panel_filter.rs
@@ -26,7 +26,6 @@ pub enum Mode {
 pub enum Outcome {
     FilterChanged,
     MoveCursor(i32),
-    Activate,
     LeavePanel,
     Consumed,
 }
@@ -96,16 +95,9 @@ impl PanelFilter {
                 },
                 egui::Key::ArrowUp => Some(Outcome::MoveCursor(-1)),
                 egui::Key::ArrowDown => Some(Outcome::MoveCursor(1)),
-                egui::Key::Enter => {
-                    self.clear_query();
-                    self.mode = Mode::Browsing;
-                    Some(Outcome::Activate)
-                },
-                egui::Key::Escape => {
-                    self.clear_query();
-                    self.mode = Mode::Browsing;
-                    Some(Outcome::FilterChanged)
-                },
+                // Enter/Escape are search-scoped keyboard actions dispatched
+                // through the binding table by the sidebar nav handler, not
+                // consumed here, so they stay rebindable.
                 _ => None,
             },
         }
@@ -148,6 +140,14 @@ impl PanelFilter {
         self.pattern.score(haystack, &mut self.matcher).is_some()
     }
 
+    /// Leave search mode: clear the query (rebuilding the empty, match-all
+    /// pattern) and return to browsing. Toggle filters are a separate dimension
+    /// and are left intact.
+    pub fn exit_search(&mut self) {
+        self.clear_query();
+        self.mode = Mode::Browsing;
+    }
+
     fn clear_query(&mut self) {
         self.query.clear();
         self.rebuild_pattern();
@@ -185,26 +185,40 @@ mod tests {
     }
 
     #[test]
-    fn backspace_pops_and_esc_clears_back_to_browsing() {
+    fn backspace_pops_the_query_in_search() {
         let mut f = PanelFilter::new(TOGGLES);
         f.on_text("/");
         f.on_text("foo");
         assert_eq!(f.on_key(egui::Key::Backspace), Some(Outcome::FilterChanged));
         assert_eq!(f.query(), "fo");
-
-        assert_eq!(f.on_key(egui::Key::Escape), Some(Outcome::FilterChanged));
-        assert_eq!(f.mode(), Mode::Browsing);
-        assert_eq!(f.query(), "");
+        assert_eq!(f.mode(), Mode::Search);
     }
 
     #[test]
-    fn enter_in_search_activates_and_clears_the_query() {
+    fn enter_and_escape_in_search_fall_through_unconsumed() {
+        // Both are rebindable search actions dispatched via the binding table,
+        // so the filter must not consume them or mutate its own state.
         let mut f = PanelFilter::new(TOGGLES);
         f.on_text("/");
         f.on_text("foo");
-        assert_eq!(f.on_key(egui::Key::Enter), Some(Outcome::Activate));
+        assert_eq!(f.on_key(egui::Key::Enter), None);
+        assert_eq!(f.on_key(egui::Key::Escape), None);
+        assert_eq!(f.mode(), Mode::Search);
+        assert_eq!(f.query(), "foo");
+    }
+
+    #[test]
+    fn exit_search_clears_query_and_returns_to_browsing_keeping_toggles() {
+        let mut f = PanelFilter::new(TOGGLES);
+        f.on_text("s");
+        f.on_text("/");
+        f.on_text("foo");
+        assert!(f.is_toggled('s'));
+
+        f.exit_search();
         assert_eq!(f.mode(), Mode::Browsing);
         assert_eq!(f.query(), "");
+        assert!(f.is_toggled('s'), "exit_search must leave toggle filters intact");
     }
 
     #[test]

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -219,8 +219,10 @@ focused panel is in search mode, so their default keys pass straight through to
 the terminal whenever it owns focus (the terminal's own `Enter`/`Esc` are never
 affected):
 
-- `SidebarSearchConfirm` (default `Enter`) — open the highlighted row and scroll
-  it into view.
+- `SidebarSearchConfirm` (default `Enter`) — leave search with the cursor on the
+  highlighted row, scrolled into view. Selecting never opens the row: press
+  `Enter` again, outside search, to activate it. A worktree or session matched
+  under a collapsed project expands that project so the row stays selectable.
 - `SidebarSearchCancel` (default `Esc`) — leave search, staying in the sidebar on
   the previously active row.
 - `SidebarSearchCancelToTerminal` (default `Shift+Esc`) — leave search and return

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -211,6 +211,26 @@ a project header it toggles expansion instead), `Escape` returns without
 switching. All other keys keep their bindings; unbound keys reach
 neither the shell nor the UI.
 
+### Sidebar search
+
+Typing `/` in a focused sidebar opens a fuzzy-search prompt. The confirm and
+cancel keys are rebindable, **search-scoped** actions — they act only while the
+focused panel is in search mode, so their default keys pass straight through to
+the terminal whenever it owns focus (the terminal's own `Enter`/`Esc` are never
+affected):
+
+- `SidebarSearchConfirm` (default `Enter`) — open the highlighted row and scroll
+  it into view.
+- `SidebarSearchCancel` (default `Esc`) — leave search, staying in the sidebar on
+  the previously active row.
+- `SidebarSearchCancelToTerminal` (default `Shift+Esc`) — leave search and return
+  focus to the terminal.
+
+Rebind them to any non-text-producing key or chord (`Enter`, `Esc`, `Shift+Esc`,
+function keys, `Ctrl`/`Shift` chords). Binding a search action to a key that also
+produces text (a bare, `Shift`-, or `AltGr`-printable) is unsupported: the
+keystroke would both type into the query and fire the action.
+
 ### Misc
 
 - `None` — consume the key without doing anything. Useful to unbind a


### PR DESCRIPTION
DON'T MERGE YET!

There is a small bug with it passing through enter and toggling folding on projects that's really annoying.

## What & why

Sidebar fuzzy-search `Enter`/`Esc` were hardcoded in `panel_filter` and could not be rebound, and `Enter` never scrolled the activated row into view.

This turns the two search-mode operations into named, rebindable actions dispatched through the existing `[[keyboard.bindings]]` system, and fixes the missing scroll-into-view — without touching the terminal input path, IME, or the nav/shortcuts pass structure.

## Changes

- Three search-scoped `NamedAction`s: `SidebarSearchConfirm` (`Enter`), `SidebarSearchCancel` (`Esc`), `SidebarSearchCancelToTerminal` (`Shift+Esc`).
- Dispatched in event order from the focused panel's nav pass (`drain_search_or_nav`); `handle_shortcuts` drops search-scoped actions so the **terminal's own `Enter`/`Esc` still reach the PTY**.
- Confirm scrolls the acted-on row into view via a focus-independent pending target, mapping a now-hidden child to its owning project header. Cancel returns to the seed row and preserves the `s`/`a` toggle filters.

## Testing

`cargo test -p alacritree` -> 453 passed. Pure decision logic (`drain_search_or_nav`), `panel_filter`, `bindings`, and palette are unit-tested. App-level effects (row activation, scroll consume, terminal passthrough) are **not** yet automated — verify terminal `Enter`/`Esc` by hand before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
