### PR TITLE
feat(scratchpad): add per-workspace notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@
 
 The first ultrafast, FOSS alternative to the LLM/worktree management apps cropping up everywhere. Built around the amazing [Alacritty] terminal emulator and drop-in compatible with your `alacritty.toml`.
 
-Minimalist approach, only 3 features:
+Minimalist approach, with the terminal at the center:
 
 - **Worktree management.** Sidebar lists projects and worktrees; one click spawns a shell. Create fresh worktrees in seconds with pre-configured AI configs.
 - **Git status bar.** Per-workspace panel with branch + staged/unstaged files, refreshed in the background.
 - **Branch diffs.** Beautiful and meaningful diffs powered by [Delta].
+- **Workspace scratchpads.** `Ctrl+Backtick` opens a minimal built-in Markdown
+  editor that saves every change, with one file per worktree and MCP access.
 
 No Chromium, no bundled agents, no telemetry. No company behind it, and there never will be.
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -23,6 +23,7 @@ use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
 use crate::pr_status::{PrCache, PrInfo, PrState};
 use crate::projects::{Project, Worktree, project_json};
+use crate::scratchpad;
 use crate::session::{
     AttentionVerdict, Session, SessionId, SessionKind, TermSize, poll_attention_debounce,
 };
@@ -815,6 +816,44 @@ impl AlacritreeApp {
         Ok(id)
     }
 
+    fn toggle_scratchpad_tab(&mut self, ctx: &Context) {
+        let workspace = self.current_workspace.clone();
+        if let Some(index) = self.scratchpad_session_index(&workspace) {
+            let id = self.sessions[index].id;
+            if self.active_session.get(&workspace).copied() == Some(id) {
+                // Scratchpad edits are persisted as they happen, so toggling
+                // the active tab closed never needs the session-close prompt.
+                self.close_session(ctx, id);
+                return;
+            }
+            self.active_session.insert(workspace, id);
+        } else if let Err(e) = self.spawn_scratchpad(ctx, workspace) {
+            self.last_error = Some(format!("failed to open scratchpad: {e}"));
+            return;
+        }
+        self.focus_terminal();
+    }
+
+    fn spawn_scratchpad(
+        &mut self,
+        ctx: &Context,
+        workspace: WorkspaceKey,
+    ) -> std::io::Result<SessionId> {
+        let file = scratchpad::ensure_file(&workspace)?;
+        let session = Session::spawn_scratchpad(
+            ctx.clone(),
+            &self.config,
+            workspace.clone(),
+            TermSize::new(80, 24),
+            (8.0, 16.0),
+            file,
+        )?;
+        let id = session.id;
+        self.sessions.push(session);
+        self.active_session.insert(workspace, id);
+        Ok(id)
+    }
+
     /// Mirror Doppler scopes into a worktree the first time a shell opens
     /// there.  The create-time hook in `worktree.rs` covers worktrees we
     /// make; this lazy pass covers ones created outside alacritree, which
@@ -1052,6 +1091,9 @@ impl AlacritreeApp {
             .iter()
             .position(|s| s.id == id)
             .ok_or_else(|| format!("no session with id {id} — see list_sessions"))?;
+        if matches!(&self.sessions[idx].kind, SessionKind::Scratchpad { .. }) {
+            return Err("scratchpads belong to their backing workspace and cannot be moved".into());
+        }
         let source = self.sessions[idx].working_directory.clone();
         let target: WorkspaceKey = Some(target);
         if source == target {
@@ -1095,6 +1137,13 @@ impl AlacritreeApp {
             .filter(|(_, s)| s.working_directory == *ws)
             .map(|(i, _)| i)
             .collect()
+    }
+
+    fn scratchpad_session_index(&self, ws: &WorkspaceKey) -> Option<usize> {
+        self.sessions.iter().position(|session| {
+            session.working_directory == *ws
+                && matches!(&session.kind, SessionKind::Scratchpad { .. })
+        })
     }
 
     fn current_session_indices(&self) -> Vec<usize> {
@@ -1343,6 +1392,10 @@ impl AlacritreeApp {
     /// is `ReceiveChar` (alacritty's pass-through marker).
     fn handle_shortcuts(&mut self, ctx: &Context) {
         let sidebar_focused = self.focus == PaneFocus::ProjectsSidebar && !self.palette.is_open();
+        let scratchpad_focused = self.focus == PaneFocus::Terminal
+            && self
+                .active_session_index()
+                .is_some_and(|idx| self.sessions[idx].scratchpad.is_some());
         let actions: Vec<BindingAction> = ctx.input_mut(|i| {
             let mut actions = Vec::new();
             i.events.retain(|ev| {
@@ -1357,8 +1410,17 @@ impl AlacritreeApp {
                     let matched: Vec<_> = matched
                         .into_iter()
                         .filter(|a| {
-                            sidebar_focused
-                                || !matches!(a, BindingAction::Named(n) if n.is_sidebar_scoped())
+                            let valid_for_focus = sidebar_focused
+                                || !matches!(a, BindingAction::Named(n) if n.is_sidebar_scoped());
+                            // Terminal byte/scroll bindings would swallow
+                            // useful editor keys like Shift+Home and
+                            // Shift+PageUp. Leave those events for TextEdit.
+                            let terminal_only = match a {
+                                BindingAction::Chars(_) => true,
+                                BindingAction::Named(n) => n.is_terminal_only(),
+                                BindingAction::Unsupported(_) => false,
+                            };
+                            valid_for_focus && !(scratchpad_focused && terminal_only)
                         })
                         .collect();
                     if !matched.is_empty() {
@@ -1829,32 +1891,67 @@ impl AlacritreeApp {
         match action {
             BindingAction::Chars(bytes) => {
                 if let Some(idx) = self.active_session_index() {
-                    paste::on_terminal_input_start(&self.sessions[idx]);
-                    self.sessions[idx].write(bytes);
+                    let id = self.sessions[idx].id;
+                    if let Some(editor) = self.sessions[idx].scratchpad.as_mut() {
+                        // Custom `Chars` bindings can carry terminal control
+                        // sequences (Shift+Tab is ESC [ Z, for example).  A
+                        // document should only accept actual text here; native
+                        // editing keys are handled by egui's TextEdit itself.
+                        if let Ok(text) = std::str::from_utf8(&bytes)
+                            && !text.chars().any(|c| c.is_control() && c != '\n' && c != '\t')
+                        {
+                            editor.insert_at_cursor(ctx, id, text);
+                        }
+                    } else {
+                        paste::on_terminal_input_start(&self.sessions[idx]);
+                        self.sessions[idx].write(bytes);
+                    }
                 }
             },
             BindingAction::Named(NamedAction::Paste) => {
                 if let (Some(text), Some(idx)) =
                     (clipboard::read(Target::Clipboard), self.active_session_index())
                 {
-                    paste::paste(&self.sessions[idx], &text, true);
+                    let id = self.sessions[idx].id;
+                    if let Some(editor) = self.sessions[idx].scratchpad.as_mut() {
+                        editor.insert_at_cursor(ctx, id, &text);
+                    } else {
+                        paste::paste(&self.sessions[idx], &text, true);
+                    }
                 }
             },
             BindingAction::Named(NamedAction::PasteSelection) => {
                 if let (Some(text), Some(idx)) =
                     (clipboard::read(Target::Primary), self.active_session_index())
                 {
-                    paste::paste(&self.sessions[idx], &text, true);
+                    let id = self.sessions[idx].id;
+                    if let Some(editor) = self.sessions[idx].scratchpad.as_mut() {
+                        editor.insert_at_cursor(ctx, id, &text);
+                    } else {
+                        paste::paste(&self.sessions[idx], &text, true);
+                    }
                 }
             },
             BindingAction::Named(NamedAction::Copy) => {
                 if let Some(idx) = self.active_session_index() {
-                    paste::copy_selection(&self.sessions[idx], &self.config, Target::Clipboard);
+                    if let Some(editor) = self.sessions[idx].scratchpad.as_ref() {
+                        if let Some(text) = editor.selected_text(ctx, self.sessions[idx].id) {
+                            clipboard::write(Target::Clipboard, &text);
+                        }
+                    } else {
+                        paste::copy_selection(&self.sessions[idx], &self.config, Target::Clipboard);
+                    }
                 }
             },
             BindingAction::Named(NamedAction::CopySelection) => {
                 if let Some(idx) = self.active_session_index() {
-                    paste::copy_selection(&self.sessions[idx], &self.config, Target::Primary);
+                    if let Some(editor) = self.sessions[idx].scratchpad.as_ref() {
+                        if let Some(text) = editor.selected_text(ctx, self.sessions[idx].id) {
+                            clipboard::write(Target::Primary, &text);
+                        }
+                    } else {
+                        paste::copy_selection(&self.sessions[idx], &self.config, Target::Primary);
+                    }
                 }
             },
             BindingAction::Named(NamedAction::SpawnNewInstance) => {
@@ -1869,7 +1966,9 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::ClearHistory) => {
                 use alacritty_terminal::vte::ansi::{ClearMode, Handler};
                 if let Some(idx) = self.active_session_index() {
-                    self.sessions[idx].term.lock().clear_screen(ClearMode::Saved);
+                    if self.sessions[idx].scratchpad.is_none() {
+                        self.sessions[idx].term.lock().clear_screen(ClearMode::Saved);
+                    }
                 }
             },
             BindingAction::Named(NamedAction::ToggleFullscreen) => {
@@ -1937,6 +2036,7 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::SelectPreviousWorkspace) => {
                 self.cycle_workspaces(ctx, -1);
             },
+            BindingAction::Named(NamedAction::OpenScratchpad) => self.toggle_scratchpad_tab(ctx),
             BindingAction::Named(NamedAction::AddProject) => self.add_project_via_dialog(ctx),
             BindingAction::Named(NamedAction::ToggleSidebarFocus) => match self.focus {
                 PaneFocus::Terminal => self.focus_sidebar(),
@@ -2103,6 +2203,9 @@ impl AlacritreeApp {
             return;
         };
         let session = &mut self.sessions[idx];
+        if session.scratchpad.is_some() {
+            return;
+        }
         let mut term = session.term.lock();
         let lines_per_page = term.grid().screen_lines() as i32;
         let scroll = match action {
@@ -6062,15 +6165,19 @@ impl AlacritreeApp {
                 Ok(json!({ "session_id": session_id, "workspace": workspace }))
             },
             Req::SendText { session_id, text } => {
-                let session = self
+                let idx = self
                     .sessions
                     .iter()
-                    .find(|s| s.id == session_id)
+                    .position(|s| s.id == session_id)
                     .ok_or_else(|| format!("no session with id {session_id}"))?;
-                paste::on_terminal_input_start(session);
-                let bytes = text.into_bytes();
-                let written = bytes.len();
-                session.write(bytes);
+                let written = text.len();
+                if let Some(editor) = self.sessions[idx].scratchpad.as_mut() {
+                    editor.insert_at_cursor(ctx, session_id, &text);
+                } else {
+                    let session = &self.sessions[idx];
+                    paste::on_terminal_input_start(session);
+                    session.write(text.into_bytes());
+                }
                 Ok(json!({ "bytes_written": written }))
             },
             Req::ReadScreen { session_id, scrollback_lines } => {
@@ -6086,6 +6193,17 @@ impl AlacritreeApp {
                     "cursor": { "line": snapshot.cursor_line, "column": snapshot.cursor_column },
                     "scrollback_available": snapshot.history_size,
                 }))
+            },
+            Req::ReadScratchpad { workspace } => {
+                let workspace = match workspace.as_deref() {
+                    None | Some("current") => self.current_workspace.clone(),
+                    Some("home") => None,
+                    Some(path) => Some(
+                        self.known_worktree_path(Path::new(path))
+                            .ok_or_else(|| unknown_worktree(Path::new(path)))?,
+                    ),
+                };
+                scratchpad::read_json(&workspace)
             },
             Req::RefreshProject { root } => {
                 let project =
@@ -6165,6 +6283,7 @@ fn session_json(session: &Session, is_active_tab: bool) -> Value {
         "kind": match &session.kind {
             SessionKind::Shell => "shell",
             SessionKind::Diff { .. } => "diff",
+            SessionKind::Scratchpad { .. } => "scratchpad",
         },
         "columns": session.size.columns,
         "lines": session.size.screen_lines,
@@ -6264,17 +6383,35 @@ impl eframe::App for AlacritreeApp {
                     );
                     return;
                 };
+                let editor_text = rgb_to_color32(self.config.palette.fg);
+                let editor_hint = blend_toward(editor_text, theme.terminal_bg, 0.55);
+                let editor_error = rgb_to_color32(self.config.palette.normal[1]);
                 let session = &mut self.sessions[idx];
-                let ime = &mut self.ime;
-                let response = terminal_view::show(
-                    ui,
-                    session,
-                    &self.config,
-                    !modal_open && !self.palette.is_open() && self.focus == PaneFocus::Terminal,
-                    &mut self.builtin_glyphs,
-                    ime,
-                    &mut self.color_glyphs,
-                );
+                let allow_focus =
+                    !modal_open && !self.palette.is_open() && self.focus == PaneFocus::Terminal;
+                let response = if let Some(editor) = session.scratchpad.as_mut() {
+                    self.ime.clear();
+                    scratchpad::show_editor(
+                        ui,
+                        session.id,
+                        editor,
+                        allow_focus,
+                        theme.ui_scale,
+                        editor_text,
+                        editor_hint,
+                        editor_error,
+                    )
+                } else {
+                    terminal_view::show(
+                        ui,
+                        session,
+                        &self.config,
+                        allow_focus,
+                        &mut self.builtin_glyphs,
+                        &mut self.ime,
+                        &mut self.color_glyphs,
+                    )
+                };
                 // egui fake-clicks the natively focused widget on Space/Enter,
                 // and the terminal keeps native focus while the sidebar owns
                 // app focus — so keyboard "clicks" must not steal it back.

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -53,6 +53,8 @@ pub enum NamedAction {
     ToggleRightSidebar,
     SelectNextWorkspace,
     SelectPreviousWorkspace,
+    /// Open/select the current workspace's scratchpad, or close it when active.
+    OpenScratchpad,
     AddProject,
     ToggleSidebarFocus,
     CloseSession,
@@ -117,6 +119,24 @@ impl NamedAction {
         )
     }
 
+    /// Actions whose keys should remain native text-editing input while the
+    /// scratchpad owns focus. For example, Shift+Home selects to the start of
+    /// a line in the editor instead of trying to scroll a terminal grid.
+    pub fn is_terminal_only(&self) -> bool {
+        matches!(
+            self,
+            Self::ScrollPageUp
+                | Self::ScrollPageDown
+                | Self::ScrollHalfPageUp
+                | Self::ScrollHalfPageDown
+                | Self::ScrollLineUp
+                | Self::ScrollLineDown
+                | Self::ScrollToTop
+                | Self::ScrollToBottom
+                | Self::ClearHistory
+        )
+    }
+
     /// The name `parse_action` accepts for this action — what a user writes
     /// in `[[keyboard.bindings]]`, and the label the shortcuts window shows.
     pub fn config_name(&self) -> String {
@@ -164,6 +184,7 @@ impl NamedAction {
             Self::ToggleRightSidebar => "Toggle the git sidebar".into(),
             Self::SelectNextWorkspace => "Switch to the next workspace".into(),
             Self::SelectPreviousWorkspace => "Switch to the previous workspace".into(),
+            Self::OpenScratchpad => "Toggle the workspace scratchpad tab".into(),
             Self::AddProject => "Add a project to the sidebar".into(),
             Self::ToggleSidebarFocus => "Toggle keyboard focus between terminal and sidebar".into(),
             Self::CloseSession => "Close the cursored or active session".into(),
@@ -304,6 +325,7 @@ fn default_bindings() -> Vec<KeyBinding> {
     b.extend([
         KeyBinding { key: Key::B, mods: ctrl, action: BindingAction::Named(ToggleLeftSidebar) },
         KeyBinding { key: Key::G, mods: ctrl, action: BindingAction::Named(ToggleRightSidebar) },
+        KeyBinding { key: Key::Backtick, mods: ctrl, action: BindingAction::Named(OpenScratchpad) },
         KeyBinding { key: Key::Tab, mods: ctrl, action: BindingAction::Named(SelectNextTab) },
         KeyBinding {
             key: Key::Tab,
@@ -695,6 +717,7 @@ pub fn parse_action(name: &str) -> BindingAction {
         "ToggleRightSidebar" => BindingAction::Named(ToggleRightSidebar),
         "SelectNextWorkspace" => BindingAction::Named(SelectNextWorkspace),
         "SelectPreviousWorkspace" => BindingAction::Named(SelectPreviousWorkspace),
+        "OpenScratchpad" => BindingAction::Named(OpenScratchpad),
         "AddProject" => BindingAction::Named(AddProject),
         "ToggleSidebarFocus" => BindingAction::Named(ToggleSidebarFocus),
         "CloseSession" => BindingAction::Named(CloseSession),
@@ -1063,6 +1086,7 @@ mod tests {
         for (key, mods, expected) in [
             (Key::B, ctrl, ToggleLeftSidebar),
             (Key::G, ctrl, ToggleRightSidebar),
+            (Key::Backtick, ctrl, OpenScratchpad),
             (Key::Tab, ctrl, SelectNextTab),
             (Key::Tab, ctrl_shift, SelectPreviousTab),
             (Key::ArrowRight, alt, SelectNextWorkspace),
@@ -1158,6 +1182,27 @@ mod tests {
         }
     }
 
+    #[test]
+    fn only_terminal_grid_actions_are_terminal_only() {
+        use NamedAction::*;
+        for action in [
+            ScrollPageUp,
+            ScrollPageDown,
+            ScrollHalfPageUp,
+            ScrollHalfPageDown,
+            ScrollLineUp,
+            ScrollLineDown,
+            ScrollToTop,
+            ScrollToBottom,
+            ClearHistory,
+        ] {
+            assert!(action.is_terminal_only(), "{action:?}");
+        }
+        for action in [Paste, Copy, OpenScratchpad, CloseSession, Quit] {
+            assert!(!action.is_terminal_only(), "{action:?}");
+        }
+    }
+
     /// Delete is forward-delete inside a shell, so the default binding only
     /// works because the action is sidebar-scoped.
     #[test]
@@ -1222,5 +1267,18 @@ mod tests {
         // The F1 shortcuts window is gone and the palette lists every action,
         // so the old `ShowShortcuts` name is no longer recognized.
         assert!(matches!(parse_action("ShowShortcuts"), BindingAction::Unsupported(_)));
+    }
+
+    #[test]
+    fn scratchpad_tab_is_a_default_ctrl_backtick_binding_and_parses() {
+        let b = parse_bindings(vec![]);
+        assert_eq!(
+            named_matches(&b, Key::Backtick, Modifiers::CTRL),
+            vec![NamedAction::OpenScratchpad]
+        );
+        assert!(matches!(
+            parse_action("OpenScratchpad"),
+            BindingAction::Named(NamedAction::OpenScratchpad)
+        ));
     }
 }

--- a/alacritree/src/cli/offline.rs
+++ b/alacritree/src/cli/offline.rs
@@ -17,7 +17,7 @@ use crate::ipc::{IpcRequest, IpcResult};
 use crate::projects::{self, Project, project_json};
 use crate::state::{self, PersistedProject, PersistedState};
 use crate::worktree::{self as wt, CreateRequest};
-use crate::{git_status, ipc};
+use crate::{git_status, ipc, scratchpad};
 
 pub fn handle(request: &IpcRequest) -> IpcResult {
     let Some(path) = state::config_path() else {
@@ -62,6 +62,13 @@ fn handle_at(state_path: &Path, request: &IpcRequest) -> IpcResult {
         },
         IpcRequest::CreateWorktree { project_root, branch } => {
             create_worktree(project_root.clone(), branch.clone())
+        },
+        IpcRequest::ReadScratchpad { workspace } => match workspace.as_deref() {
+            None | Some("current") => {
+                Err("alacritree is not running; specify `home` or a workspace path".to_string())
+            },
+            Some("home") => scratchpad::read_json(&None),
+            Some(path) => scratchpad::read_json(&Some(PathBuf::from(path))),
         },
         IpcRequest::ListSessions
         | IpcRequest::SelectWorkspace { .. }

--- a/alacritree/src/cli/render.rs
+++ b/alacritree/src/cli/render.rs
@@ -34,6 +34,9 @@ pub fn human(request: &IpcRequest, value: &Value) {
             None => println!("moved session {} to home", text(&value["session_id"])),
         },
         IpcRequest::ReadScreen { .. } => screen(value),
+        IpcRequest::ReadScratchpad { .. } => {
+            print!("{}", value["content"].as_str().unwrap_or_default());
+        },
         IpcRequest::GitStatus { .. } => git_status(value),
         IpcRequest::CreateWorktree { .. } => {
             println!("{}", text(&value["path"]));
@@ -151,6 +154,7 @@ mod tests {
             IpcRequest::ListSessions,
             IpcRequest::GitStatus { path: "/repo".into() },
             IpcRequest::ReadScreen { session_id: 1, scrollback_lines: 0 },
+            IpcRequest::ReadScratchpad { workspace: Some("home".into()) },
         ] {
             human(&request, &serde_json::json!({}));
         }

--- a/alacritree/src/command_palette.rs
+++ b/alacritree/src/command_palette.rs
@@ -109,7 +109,7 @@ pub fn action_items(bindings: &[KeyBinding]) -> Vec<PaletteItem> {
 /// Every simple (non-parametrized) `NamedAction`, kept in sync with the enum by
 /// hand. Mirrors the old shortcuts window's bindable list; `SelectTab`/
 /// `SpawnProfile` are excluded here because they carry an index.
-fn bindable_actions() -> [NamedAction; 46] {
+fn bindable_actions() -> [NamedAction; 47] {
     use NamedAction::*;
     [
         Paste,
@@ -139,6 +139,7 @@ fn bindable_actions() -> [NamedAction; 46] {
         SelectPreviousSession,
         SelectNextWorkspace,
         SelectPreviousWorkspace,
+        OpenScratchpad,
         ToggleLeftSidebar,
         ToggleRightSidebar,
         AddProject,

--- a/alacritree/src/ipc.rs
+++ b/alacritree/src/ipc.rs
@@ -74,6 +74,13 @@ pub enum IpcRequest {
         #[serde(default)]
         scrollback_lines: usize,
     },
+    /// Read the auto-saved Markdown document, independently of whether its
+    /// editor tab is open. `None`/`"current"` resolves on the UI thread;
+    /// `"home"` and absolute worktree paths are explicit targets.
+    ReadScratchpad {
+        #[serde(default)]
+        workspace: Option<String>,
+    },
     RefreshProject {
         root: PathBuf,
     },

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -27,6 +27,7 @@ mod paste;
 mod pr_status;
 mod projects;
 mod row_label;
+mod scratchpad;
 mod session;
 mod sidebar_nav;
 mod stale_exe;

--- a/alacritree/src/mcp.rs
+++ b/alacritree/src/mcp.rs
@@ -130,7 +130,7 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "list_sessions",
-            "description": "List terminal sessions across all workspaces: id, title, workspace path (null = the home workspace), kind (shell or diff pane), grid size, whether it is its workspace's active tab, and whether it flagged for attention (bell / agent finished).",
+            "description": "List tabs across all workspaces: id, title, workspace path (null = the home workspace), kind (shell, diff, or scratchpad editor), grid size, whether it is its workspace's active tab, and whether it flagged for attention (bell / agent finished).",
             "inputSchema": { "type": "object", "properties": {} },
         },
         {
@@ -198,6 +198,16 @@ fn tool_definitions() -> Value {
                     "scrollback_lines": { "type": "integer", "description": "History lines to include above the visible screen (default 0)." },
                 },
                 "required": ["session_id"],
+            },
+        },
+        {
+            "name": "read_scratchpad",
+            "description": "Read the auto-saved contents of a workspace's persistent Markdown scratchpad. Use this whenever the user refers to their scratchpad, workspace notes, reminders, or saved context. Omit workspace (or pass \"current\") for the focused workspace, pass \"home\" for Home, or pass an absolute worktree path from list_projects. The built-in editor writes every text change to this same backing file immediately.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "workspace": { "type": "string", "description": "\"current\" (default), \"home\", or an absolute worktree path from list_projects." },
+                },
             },
         },
         {
@@ -303,6 +313,7 @@ mod tests {
             IpcRequest::SendText { session_id: 1, text: "hi".into() },
             IpcRequest::MoveSession { session_id: 1, path: repo() },
             IpcRequest::ReadScreen { session_id: 1, scrollback_lines: 0 },
+            IpcRequest::ReadScratchpad { workspace: None },
             IpcRequest::GitStatus { path: repo() },
             IpcRequest::CreateWorktree { project_root: repo(), branch: "topic".into() },
             IpcRequest::RefreshProject { root: repo() },
@@ -323,6 +334,7 @@ mod tests {
             IpcRequest::SendText { .. } => "send_text",
             IpcRequest::MoveSession { .. } => "move_session",
             IpcRequest::ReadScreen { .. } => "read_screen",
+            IpcRequest::ReadScratchpad { .. } => "read_scratchpad",
             IpcRequest::GitStatus { .. } => "git_status",
             IpcRequest::CreateWorktree { .. } => "create_worktree",
             IpcRequest::RefreshProject { .. } => "refresh_project",

--- a/alacritree/src/scratchpad.rs
+++ b/alacritree/src/scratchpad.rs
@@ -1,0 +1,353 @@
+//! Persistent per-workspace scratchpad documents and their built-in editor.
+//!
+//! Closing the editor tab or deleting a worktree must never delete the notes.
+//! File names include a deterministic digest of the workspace path so equal
+//! leaf names in different projects cannot collide.
+
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use egui::text::{CCursor, CCursorRange};
+use egui::{
+    Color32, FontId, Frame, Id, Margin, Response, RichText, ScrollArea, TextBuffer, TextEdit,
+};
+use serde_json::{Value, json};
+
+use crate::app::WorkspaceKey;
+use crate::state;
+
+// A scratchpad is normally a few notes. Bounding an MCP response keeps an
+// accidentally huge file from consuming the client's entire context window.
+const MAX_MCP_BYTES: usize = 256 * 1024;
+
+/// In-memory state for the built-in editor. Every mutation is immediately
+/// written to `path`; `save_error` is painted in-place instead of replacing
+/// the editor with a modal, so a transient filesystem failure never loses the
+/// user's buffer.
+pub struct Editor {
+    path: PathBuf,
+    text: String,
+    save_error: Option<String>,
+}
+
+impl Editor {
+    pub fn open(path: PathBuf) -> io::Result<Self> {
+        let text = fs::read_to_string(&path)?;
+        Ok(Self { path, text, save_error: None })
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn insert_at_cursor(&mut self, ctx: &egui::Context, session_id: u64, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        let id = editor_id(session_id);
+        let mut state = TextEdit::load_state(ctx, id).unwrap_or_default();
+        let end = self.text.chars().count();
+        let range =
+            state.cursor.char_range().unwrap_or_else(|| CCursorRange::one(CCursor::new(end)));
+        let [min, max] = range.sorted();
+        self.text.delete_char_range(min.index..max.index);
+        let inserted = self.text.insert_text(text, min.index);
+        state.cursor.set_char_range(Some(CCursorRange::one(CCursor::new(min.index + inserted))));
+        TextEdit::store_state(ctx, id, state);
+        self.save();
+    }
+
+    pub fn selected_text(&self, ctx: &egui::Context, session_id: u64) -> Option<String> {
+        let state = TextEdit::load_state(ctx, editor_id(session_id))?;
+        let [min, max] = state.cursor.char_range()?.sorted();
+        (min.index != max.index).then(|| self.text.char_range(min.index..max.index).to_string())
+    }
+
+    fn save(&mut self) {
+        self.save_error = fs::write(&self.path, self.text.as_bytes())
+            .err()
+            .map(|error| format!("Autosave failed: {error}"));
+    }
+}
+
+pub fn editor_id(session_id: u64) -> Id {
+    Id::new(("scratchpad-editor", session_id))
+}
+
+/// Full-pane editor inspired by notes.vercel.app: no toolbar, border, status
+/// chrome, or explicit save action—just a padded text surface that inherits
+/// the terminal pane's background.
+pub fn show_editor(
+    ui: &mut egui::Ui,
+    session_id: u64,
+    editor: &mut Editor,
+    allow_focus: bool,
+    ui_scale: f32,
+    text_color: Color32,
+    hint_color: Color32,
+    error_color: Color32,
+) -> Response {
+    let available = ui.available_size();
+    let padding = 16.0 * ui_scale;
+    let font_size = 20.0 * ui_scale;
+    let editor_id = editor_id(session_id);
+    if !allow_focus {
+        ui.memory_mut(|memory| memory.surrender_focus(editor_id));
+    }
+
+    let response = Frame::default()
+        .inner_margin(Margin::same(padding as i8))
+        .show(ui, |ui| {
+            let inner_size = egui::vec2(
+                (available.x - padding * 2.0).max(1.0),
+                (available.y - padding * 2.0).max(1.0),
+            );
+            ui.set_min_size(inner_size);
+            let rows = (inner_size.y / (font_size * 1.35)).floor().max(4.0) as usize;
+            let output = ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .max_height(inner_size.y)
+                .show(ui, |ui| {
+                    TextEdit::multiline(&mut editor.text)
+                        .id(editor_id)
+                        .font(FontId::monospace(font_size))
+                        .text_color(text_color)
+                        .hint_text(
+                            RichText::new(
+                                "Start typing.\n\nEverything is automatically saved to this workspace.",
+                            )
+                            .color(hint_color)
+                            .monospace()
+                            .size(font_size),
+                        )
+                        .frame(false)
+                        .margin(Margin::ZERO)
+                        .desired_width(inner_size.x)
+                        .desired_rows(rows)
+                        .show(ui)
+                })
+                .inner;
+            if allow_focus && !output.response.has_focus() {
+                output.response.request_focus();
+            }
+            if output.response.changed() {
+                editor.save();
+            }
+            if let Some(error) = &editor.save_error {
+                ui.painter().text(
+                    ui.max_rect().right_bottom() - egui::vec2(4.0, 4.0),
+                    egui::Align2::RIGHT_BOTTOM,
+                    error,
+                    FontId::monospace(11.0 * ui_scale),
+                    error_color,
+                );
+            }
+            output.response
+        })
+        .inner;
+    response
+}
+
+pub fn ensure_file(workspace: &WorkspaceKey) -> io::Result<PathBuf> {
+    let config_dir = state::config_dir().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "could not locate alacritree's config directory")
+    })?;
+    ensure_file_in(&config_dir, workspace)
+}
+
+fn ensure_file_in(config_dir: &Path, workspace: &WorkspaceKey) -> io::Result<PathBuf> {
+    let path = path_for_in(config_dir, workspace);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    OpenOptions::new().create(true).append(true).open(&path)?;
+    Ok(path)
+}
+
+pub fn path_for(workspace: &WorkspaceKey) -> Option<PathBuf> {
+    Some(path_for_in(&state::config_dir()?, workspace))
+}
+
+fn path_for_in(config_dir: &Path, workspace: &WorkspaceKey) -> PathBuf {
+    let name = match workspace {
+        None => "home.md".to_string(),
+        Some(path) => {
+            let label = path
+                .file_name()
+                .map(|name| slug(&name.to_string_lossy()))
+                .filter(|name| !name.is_empty())
+                .unwrap_or_else(|| "workspace".to_string());
+            let identity = workspace_identity(path);
+            format!("{label}-{:012x}.md", stable_digest(identity.as_bytes()) & 0xffffffffffff)
+        },
+    };
+    config_dir.join("scratchpads").join(name)
+}
+
+fn workspace_identity(path: &Path) -> String {
+    let path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let text = path.to_string_lossy().replace('\\', "/");
+    if cfg!(windows) { text.to_ascii_lowercase() } else { text }
+}
+
+fn slug(input: &str) -> String {
+    let mut out = String::new();
+    let mut separator = false;
+    for ch in input.chars() {
+        if ch.is_alphanumeric() || matches!(ch, '-' | '_') {
+            out.push(ch);
+            separator = false;
+        } else if !separator && !out.is_empty() {
+            out.push('-');
+            separator = true;
+        }
+        if out.len() >= 48 {
+            break;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+/// FNV-1a is small, deterministic across Rust versions, and sufficient here:
+/// the digest disambiguates human-readable file names rather than protecting
+/// an adversarial namespace.
+fn stable_digest(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+pub fn read_json(workspace: &WorkspaceKey) -> Result<Value, String> {
+    let path = path_for(workspace)
+        .ok_or_else(|| "could not locate alacritree's config directory".to_string())?;
+    read_json_at(&path, workspace)
+}
+
+fn read_json_at(path: &Path, workspace: &WorkspaceKey) -> Result<Value, String> {
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return Ok(json!({
+                "workspace": workspace,
+                "path": path,
+                "exists": false,
+                "content": "",
+                "truncated": false,
+            }));
+        },
+        Err(e) => return Err(format!("failed to read {}: {e}", path.display())),
+    };
+    let truncated = bytes.len() > MAX_MCP_BYTES;
+    let content = String::from_utf8_lossy(&bytes[..bytes.len().min(MAX_MCP_BYTES)]).into_owned();
+    let modified_ms = fs::metadata(&path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis());
+    Ok(json!({
+        "workspace": workspace,
+        "path": path,
+        "exists": true,
+        "content": content,
+        "modified_unix_ms": modified_ms,
+        "truncated": truncated,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use egui::{Event, Pos2, RawInput, Rect, Vec2};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn home_and_same_named_workspaces_get_distinct_readable_files() {
+        let dir = TempDir::new().unwrap();
+        let home = path_for_in(dir.path(), &None);
+        let a = path_for_in(dir.path(), &Some(PathBuf::from("/one/topic")));
+        let b = path_for_in(dir.path(), &Some(PathBuf::from("/two/topic")));
+
+        assert_eq!(home.file_name().unwrap(), "home.md");
+        assert!(a.file_name().unwrap().to_string_lossy().starts_with("topic-"));
+        assert_ne!(a, b);
+        assert_eq!(a, path_for_in(dir.path(), &Some(PathBuf::from("/one/topic"))));
+    }
+
+    #[test]
+    fn built_in_editor_inserts_at_the_cursor_and_saves_immediately() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("note.md");
+        fs::write(&path, "hello").unwrap();
+        let mut editor = Editor::open(path.clone()).unwrap();
+        let ctx = egui::Context::default();
+
+        editor.insert_at_cursor(&ctx, 7, "!");
+        assert_eq!(editor.text(), "hello!");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "hello!");
+
+        let mut state = egui::text_edit::TextEditState::default();
+        state.cursor.set_char_range(Some(CCursorRange::two(CCursor::new(0), CCursor::new(5))));
+        TextEdit::store_state(&ctx, editor_id(7), state);
+        editor.insert_at_cursor(&ctx, 7, "saved");
+        assert_eq!(fs::read_to_string(path).unwrap(), "saved!");
+    }
+
+    #[test]
+    fn typed_characters_are_saved_after_each_ui_event() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("note.md");
+        fs::write(&path, "").unwrap();
+        let mut editor = Editor::open(path.clone()).unwrap();
+        let ctx = egui::Context::default();
+
+        let mut frame = |events| {
+            let input = RawInput {
+                screen_rect: Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0))),
+                events,
+                ..Default::default()
+            };
+            let _ = ctx.run(input, |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    show_editor(
+                        ui,
+                        9,
+                        &mut editor,
+                        true,
+                        1.0,
+                        Color32::WHITE,
+                        Color32::GRAY,
+                        Color32::RED,
+                    );
+                });
+            });
+        };
+
+        frame(Vec::new());
+        frame(vec![Event::Text("a".into())]);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "a");
+        frame(vec![Event::Text("b".into())]);
+        assert_eq!(fs::read_to_string(path).unwrap(), "ab");
+    }
+
+    #[test]
+    fn file_contents_survive_editor_session_lifetimes() {
+        let dir = TempDir::new().unwrap();
+        let workspace = Some(PathBuf::from("/repo/topic"));
+        let path = ensure_file_in(dir.path(), &workspace).unwrap();
+        fs::write(&path, "# Notes\n\nkeep me\n").unwrap();
+
+        // Reading has no dependency on a live editor tab; closing/restarting
+        // the app therefore cannot erase the document.
+        let value = read_json_at(&path, &workspace).unwrap();
+        assert_eq!(value["content"], "# Notes\n\nkeep me\n");
+        assert_eq!(value["exists"], true);
+        assert_eq!(ensure_file_in(dir.path(), &workspace).unwrap(), path);
+        assert_eq!(fs::read_to_string(path).unwrap(), "# Notes\n\nkeep me\n");
+    }
+}

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -18,6 +18,7 @@ use alacritty_terminal::vte::ansi::Rgb;
 use crate::clipboard::Target;
 use crate::colors;
 use crate::config::{Config, Palette};
+use crate::scratchpad;
 use crate::wsl_helper::{self, WslProbe};
 
 #[derive(Clone)]
@@ -68,19 +69,24 @@ impl Dimensions for TermSize {
 
 pub type SessionId = u64;
 
-/// What this session is showing.  Shells are persistent; Diff panes are
-/// throwaway — replaced when the user clicks a different file in the git
-/// sidebar, and reaped on the user's `q` inside delta.  The key disambiguates
-/// (file, source) so the sidebar can highlight the active row and toggle the
-/// pane closed on a repeat click.
+/// What this session is showing. Shells are persistent; diff panes are
+/// throwaway terminal commands; scratchpads are built-in document editors.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum SessionKind {
     Shell,
-    Diff { key: String },
+    Diff {
+        key: String,
+    },
+    /// Alacritree's built-in editor for the workspace's Markdown document.
+    /// It participates in the ordinary tab/sidebar model without a PTY.
+    Scratchpad {
+        path: PathBuf,
+    },
 }
 
-/// PTY child + parsed terminal state.  The read/write loop is on its own
-/// thread and survives workspace switches, so running processes aren't killed.
+/// One tab in a workspace. Shell/diff tabs own a PTY and parsed terminal;
+/// scratchpad tabs retain the same lightweight terminal allocation so the tab
+/// model stays uniform, but own no child process or event-loop thread.
 pub struct Session {
     pub id: SessionId,
     pub title: String,
@@ -90,6 +96,7 @@ pub struct Session {
     pub cell_size: (f32, f32),
     pub term: Arc<FairMutex<Term<EventProxy>>>,
     pub events: mpsc::Receiver<TermEvent>,
+    pub scratchpad: Option<scratchpad::Editor>,
     /// Latched attention flag, cleared when the user views this session.
     pub needs_attention: bool,
     /// When a not-yet-surfaced attention trigger arrived.  `None` once it
@@ -114,8 +121,8 @@ pub struct Session {
     /// shim published, unregistered again on drop.  The Windows process
     /// table ends at wsl.exe, so this is the only live view inside.
     wsl_probe: Option<WslProbe>,
-    notifier: Notifier,
-    sender: EventLoopSender,
+    notifier: Option<Notifier>,
+    sender: Option<EventLoopSender>,
     exited: bool,
 }
 
@@ -806,6 +813,40 @@ impl Session {
         )
     }
 
+    pub fn spawn_scratchpad(
+        ctx: egui::Context,
+        config: &Config,
+        working_directory: Option<PathBuf>,
+        size: TermSize,
+        cell_size: (f32, f32),
+        path: PathBuf,
+    ) -> std::io::Result<Self> {
+        let editor = scratchpad::Editor::open(path.clone())?;
+        let (proxy, events) = EventProxy::new(ctx);
+        let term = Arc::new(FairMutex::new(Term::new(term_config(config), &size, proxy)));
+        Ok(Self {
+            id: next_session_id(),
+            title: "scratchpad".to_string(),
+            working_directory,
+            kind: SessionKind::Scratchpad { path },
+            size,
+            cell_size,
+            term,
+            events,
+            scratchpad: Some(editor),
+            needs_attention: false,
+            pending_attention: None,
+            accumulated_scroll: (0.0, 0.0),
+            last_report_cell: None,
+            shell_pid: None,
+            agent_cache: Cell::new(AgentCache::default()),
+            wsl_probe: None,
+            notifier: None,
+            sender: None,
+            exited: false,
+        })
+    }
+
     /// Spawn a session running `program args` instead of the user's shell.
     /// Used by the git sidebar to drop into `delta` for an inline diff view —
     /// once the command exits, `reap_exited_sessions` removes the tab.
@@ -897,6 +938,7 @@ impl Session {
             cell_size,
             term,
             events,
+            scratchpad: None,
             needs_attention: false,
             pending_attention: None,
             accumulated_scroll: (0.0, 0.0),
@@ -904,14 +946,16 @@ impl Session {
             shell_pid,
             agent_cache: Cell::new(AgentCache::default()),
             wsl_probe,
-            notifier: Notifier(sender.clone()),
-            sender,
+            notifier: Some(Notifier(sender.clone())),
+            sender: Some(sender),
             exited: false,
         })
     }
 
     pub fn write(&self, bytes: Vec<u8>) {
-        self.notifier.notify(bytes);
+        if let Some(notifier) = &self.notifier {
+            notifier.notify(bytes);
+        }
     }
 
     /// Pull every pending event out of the PTY channel.  Called once per frame
@@ -966,7 +1010,10 @@ impl Session {
         self.size = size;
         self.cell_size = cell_size;
         let ws = window_size(size, cell_size);
-        let _ = self.sender.send(Msg::Resize(ws));
+        let Some(sender) = &self.sender else {
+            return;
+        };
+        let _ = sender.send(Msg::Resize(ws));
         self.term.lock().resize(size);
     }
 
@@ -983,6 +1030,9 @@ impl Session {
     /// nothing, accept a decorative title as a permissive fallback so
     /// agents we don't have in the process map still show *something*.
     pub fn agent_glyph(&self) -> Option<char> {
+        if self.scratchpad.is_some() {
+            return None;
+        }
         let proc_glyph = self.process_agent_glyph();
         let title_glyph = title_decorative_glyph(&self.title);
         if proc_glyph.is_some() {
@@ -997,6 +1047,9 @@ impl Session {
     /// foreground process is a recognized agent, or its title is in a
     /// spinner state — the signal the close-confirmation policy keys on.
     pub fn is_busy(&self) -> bool {
+        if self.scratchpad.is_some() {
+            return false;
+        }
         self.process_probe().1 || looks_busy(self.agent_glyph(), &self.title)
     }
 
@@ -1012,6 +1065,9 @@ impl Session {
     /// stream, so a launcher touching it after vim starts clobbers vim's
     /// own title until vim re-emits it.
     pub fn nav_tui_running(&self) -> bool {
+        if self.scratchpad.is_some() {
+            return false;
+        }
         self.process_probe().2
     }
 
@@ -1045,6 +1101,15 @@ impl Session {
     /// the user's display offset so IPC clients always see where output and
     /// the cursor actually are.
     pub fn screen_snapshot(&self, scrollback_lines: usize) -> ScreenSnapshot {
+        if let Some(editor) = &self.scratchpad {
+            let mut lines: Vec<String> = editor.text().lines().map(str::to_owned).collect();
+            if lines.is_empty() || editor.text().ends_with('\n') {
+                lines.push(String::new());
+            }
+            let cursor_line = lines.len() - 1;
+            let cursor_column = lines[cursor_line].chars().count();
+            return ScreenSnapshot { lines, cursor_line, cursor_column, history_size: 0 };
+        }
         use alacritty_terminal::index::{Column, Line};
         use alacritty_terminal::term::cell::Flags;
 
@@ -1088,7 +1153,9 @@ impl Session {
     }
 
     pub fn shutdown(&self) {
-        let _ = self.sender.send(Msg::Shutdown);
+        if let Some(sender) = &self.sender {
+            let _ = sender.send(Msg::Shutdown);
+        }
     }
 }
 

--- a/alacritree/src/state.rs
+++ b/alacritree/src/state.rs
@@ -62,26 +62,27 @@ fn default_true() -> bool {
 }
 
 pub fn config_path() -> Option<PathBuf> {
-    Some(config_dir()?.join("alacritree").join("state.toml"))
+    Some(config_dir()?.join("state.toml"))
 }
 
 /// Per-user config base: XDG on Unix, the roaming app-data dir on Windows
 /// (which has neither `$XDG_CONFIG_HOME` nor `$HOME`).
 #[cfg(not(windows))]
-fn config_dir() -> Option<PathBuf> {
+pub(crate) fn config_dir() -> Option<PathBuf> {
     if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-        return Some(PathBuf::from(xdg));
+        return Some(PathBuf::from(xdg).join("alacritree"));
     }
     let home = std::env::var_os("HOME")?;
-    Some(PathBuf::from(home).join(".config"))
+    Some(PathBuf::from(home).join(".config").join("alacritree"))
 }
 
 #[cfg(windows)]
-fn config_dir() -> Option<PathBuf> {
+pub(crate) fn config_dir() -> Option<PathBuf> {
     std::env::var_os("APPDATA")
         .or_else(|| std::env::var_os("LOCALAPPDATA"))
         .map(PathBuf::from)
         .or_else(home::home_dir)
+        .map(|dir| dir.join("alacritree"))
 }
 
 /// Reorder `state.projects` to follow `order` (a list of roots).  Roots absent

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -27,9 +27,35 @@ per workspace is remembered as you switch between them.
   them (or quit the app). Scrollback, running commands, and PTY state survive
   arbitrary switches between worktrees.
 
-Each session has its own background read/write thread, a unique `window_id`
-(so OSC 7 / signal events route correctly), and forwards terminal events
-through an `EventProxy` that requests an egui repaint on every PTY message.
+### Workspace scratchpads
+
+`Ctrl+Backtick` opens the scratchpad tab dedicated to the current workspace.
+If its editor tab already exists, Alacritree selects that tab; otherwise it
+creates and activates a new tab. Scratchpads participate in the normal tab
+strip, sidebar session list, session cycling, command palette, and close flow.
+Pressing `Ctrl+Backtick` while the scratchpad is already active closes it
+immediately without confirmation because every edit has already been saved.
+
+The first invocation creates a Markdown document under Alacritree's config
+folder and opens it in a built-in, borderless text editor. Its padded writing
+surface inherits the terminal background and deliberately has no toolbar or
+save button. Every text change is written to the backing file immediately,
+including typing, deletion, paste, undo, and redo. A filesystem error is shown
+inside the pane while the in-memory text remains intact.
+
+Switching to another tab or workspace leaves the editor state intact. Closing
+the scratchpad tab releases that state; the next invocation reloads the same
+auto-saved file. Deleting a worktree also retains its scratchpad document.
+
+Files live in `$XDG_CONFIG_HOME/alacritree/scratchpads/` (normally
+`~/.config/alacritree/scratchpads/`) or `%APPDATA%\alacritree\scratchpads\` on
+Windows. Home uses `home.md`; worktrees use a readable leaf name plus a stable
+path digest so same-named worktrees cannot collide.
+
+Each terminal session has its own background read/write thread, a unique
+`window_id` (so OSC 7 / signal events route correctly), and forwards terminal
+events through an `EventProxy` that requests an egui repaint on every PTY
+message.
 
 ## Left sidebar — projects and worktrees
 
@@ -293,10 +319,12 @@ WSL auto-selection by project location → `default_profile` →
 
 ## Persistence
 
-Two files are written:
+Persistent files written by Alacritree:
 
 - `$XDG_CONFIG_HOME/alacritree/state.toml` — projects, expanded state,
   sidebar visibility.
+- `$XDG_CONFIG_HOME/alacritree/scratchpads/*.md` — one persistent Markdown
+  scratchpad per workspace. Worktree deletion does not remove these notes.
 - `<worktree>/.claude/settings.local.json` — touched only during worktree
   creation, only to set `preferredNotifChannel = "terminal_bell"`.
 
@@ -329,12 +357,17 @@ Tools:
 | `select_workspace` | Focus a workspace, like clicking it in the sidebar |
 | `create_session` | Open a new shell session in a workspace |
 | `close_session` | Close a session |
-| `send_text` | Type into a session's terminal (control chars pass through; `\r` submits) |
+| `send_text` | Type into a terminal or insert into a scratchpad; scratchpad changes auto-save |
 | `read_screen` | Read a session's screen text, cursor position, and optional scrollback |
+| `read_scratchpad` | Read the auto-saved Markdown scratchpad for the current, Home, or a specified workspace |
 | `move_session` | Re-home a session under another worktree (`alacritree session move <session_id> <path>`); path may be anywhere inside it |
 | `git_status` | Staged/unstaged files and per-file +/- vs the default branch |
 | `create_worktree` | Create a worktree + branch, same flow as the sidebar's `+` button |
 | `refresh_project` | Re-scan a project's worktrees |
+
+`read_scratchpad` reads the backing file directly, so it remains useful when
+the editor tab is closed. Because the built-in editor writes every change
+immediately, MCP clients see the same auto-saved contents as the editor.
 
 Under the hood this mirrors Alacritty's IPC design (unix only): the app
 listens on `$XDG_RUNTIME_DIR/alacritree/alacritree-<pid>.sock` and advertises

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -46,6 +46,7 @@ and your TOML entries are checked first — so your config overrides any default
 | -------------------- | ----------------------------------------------------- |
 | `Ctrl+Shift+V`       | Paste from the clipboard                              |
 | `Ctrl+Shift+C`       | Copy the current selection                            |
+| `Ctrl+Backtick`      | Toggle the workspace's persistent scratchpad tab      |
 | `Shift+Insert`       | Paste from the primary (X11) selection                |
 | `Ctrl+0`             | Reset font size                                       |
 | `Ctrl+=` / `Ctrl++`  | Increase font size                                    |
@@ -122,6 +123,10 @@ entry. Names match alacritty's own action names, so existing configs port over.
   new shell session in the current workspace. (Alacritty distinguishes
   windows from tabs; alacritree has a single window with sessions per
   workspace, so they collapse to the same action.)
+- `OpenScratchpad` — open or select the current workspace's persistent
+  Markdown scratchpad tab in Alacritree's minimal built-in editor, or close it
+  without confirmation when already active. Every text change is saved
+  immediately; closing the tab keeps its backing file. Default: `Ctrl+Backtick`.
 - `SelectNextTab` / `SelectPreviousTab` — cycle through sessions in the
   current workspace.
 - `SelectNextSession` / `SelectPreviousSession` — cycle through every open


### PR DESCRIPTION
## Summary

- add a per-workspace scratchpad as a normal Alacritree tab, toggled with Ctrl+Backtick
- persist Markdown files under the Alacritree config directory and auto-save every editor change
- use a minimal built-in editor that inherits the terminal theme, with native selection and clipboard behavior
- expose auto-saved scratchpad contents through the Alacritree MCP server and IPC

## Test plan

- `cargo test -p alacritree` (449 passed, 2 ignored)