### PR TITLE
fix(ci): use stable title for skipped artifact job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
 
   # Build and packages all the platform-specific things
   build-local-artifacts:
-    name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
+    name: build-local-artifacts
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -5,6 +5,9 @@ members = ["cargo:."]
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.32.0"
+# Keep the static build job name in our customized release workflow. The
+# generated matrix expression is displayed literally when the job is skipped.
+allow-dirty = ["ci"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
## Summary

- use a static name for the release artifact matrix job
- avoid displaying an unresolved matrix expression when the job is skipped on pull requests

## Validation

- actionlint .github/workflows/release.yml
- git diff --check