### PR TITLE
fix: make missing worktree error dismissible

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -898,7 +898,10 @@ impl AlacritreeApp {
         // click. Switching first would strand the user on a dead workspace
         // with a failed spawn — stay put and let the sidebar re-mark the row.
         if !path.is_dir() {
-            self.last_error =
+            // This is recoverable from the sidebar, so use the dismissible
+            // dialog instead of replacing the terminal with `last_error`
+            // forever.
+            self.error_dialog =
                 Some("worktree directory is missing — prune it from the sidebar".to_string());
             if let Some(idx) =
                 self.projects.iter().position(|p| p.worktrees.iter().any(|w| w.path == path))


### PR DESCRIPTION
## Summary

- route the recoverable missing-worktree warning through the dismissible error dialog
- keep the current terminal visible instead of permanently replacing the central pane
- preserve the sidebar refresh that marks the vanished worktree as prunable

## Testing

- `cargo test -p alacritree` (443 passed, 2 ignored)