### PR TITLE
feat(palette): add nav keys, sections, and columns [4]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -10,7 +10,7 @@ use egui::{Color32, Context, Frame, Margin, RichText, ScrollArea, SidePanel, Str
 
 use serde_json::{Value, json};
 
-use crate::bindings::{BindingAction, NamedAction};
+use crate::bindings::{self, BindingAction, KeyBinding, NamedAction};
 use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
 use crate::command_palette::{self, CommandPalette, PaletteAction, PaletteItem};
@@ -1430,6 +1430,11 @@ impl AlacritreeApp {
                         // the PTY when the terminal (or a non-searching panel)
                         // has focus.
                         .filter(|a| !matches!(a, BindingAction::Named(n) if n.is_search_scoped()))
+                        // Palette cursor moves are owned by the palette modal,
+                        // which suppresses this pass entirely while it is up.
+                        // Reaching here means it is closed, so their keys belong
+                        // to the sidebar or the PTY.
+                        .filter(|a| !matches!(a, BindingAction::Named(n) if n.is_palette_scoped()))
                         .collect();
                     if !matched.is_empty() {
                         let suppress_chars = matched
@@ -3832,6 +3837,53 @@ fn modal_frame(theme: &Theme) -> Frame {
         .inner_margin(Margin { left: pad_x, right: pad_x, top: pad_y, bottom: pad_y })
 }
 
+/// Take this frame's palette cursor jumps off the event queue, honoring
+/// rebinds.  The palette owns these keys only while it is up, which is why they
+/// are read here rather than dispatched like an ordinary action — and why they
+/// can share the sidebar's unmodified Home/End/PageUp/PageDown.
+fn consume_palette_keys(ctx: &Context, bindings: &[KeyBinding]) -> Vec<NamedAction> {
+    ctx.input_mut(|i| {
+        let mut jumps = Vec::new();
+        i.events.retain(|ev| {
+            let egui::Event::Key { key, pressed: true, modifiers, .. } = ev else {
+                return true;
+            };
+            let matched: Vec<NamedAction> = bindings::all_matches(bindings, *key, *modifiers)
+                .into_iter()
+                .filter_map(|a| match a {
+                    BindingAction::Named(n) if n.is_palette_scoped() => Some(*n),
+                    _ => None,
+                })
+                .collect();
+            if matched.is_empty() {
+                return true;
+            }
+            jumps.extend(matched);
+            false
+        });
+        jumps
+    })
+}
+
+/// The palette's footer, naming the keys actually bound to its cursor moves so
+/// a rebind shows up here instead of the hint quietly going stale.
+fn palette_hint(bindings: &[KeyBinding]) -> String {
+    let mut parts = vec!["↑↓ move".to_string()];
+    for (action, label) in [
+        (NamedAction::PaletteTop, "top"),
+        (NamedAction::PaletteBottom, "bottom"),
+        (NamedAction::PalettePageUp, "page up"),
+        (NamedAction::PalettePageDown, "page down"),
+    ] {
+        if let Some(key) = command_palette::first_key(bindings, action) {
+            parts.push(format!("{key} {label}"));
+        }
+    }
+    parts.push("Enter run".into());
+    parts.push("Esc close".into());
+    parts.join(" · ")
+}
+
 fn consume_modal_keys(ctx: &Context) -> (bool, bool) {
     ctx.input_mut(|i| {
         (
@@ -3873,27 +3925,154 @@ fn single_line_galley(
     ctx.fonts(|f| f.layout_job(job))
 }
 
-/// Paint one command-palette row: the description leads on the left (bright,
-/// the primary column), with the shortcut (accent) pinned to the far right and
-/// the action/context tag (dim) just inside it.  Every field is a one-line
-/// galley so nothing wraps, and the description claims all the width the
-/// right-hand columns leave it.  A selected row gets a soft accent wash and a
-/// crisp accent bar; a hovered one a faint fill.
+/// Text wrapped to `max_w` over as many lines as it needs — the description
+/// column, which reads as a sentence and so must not be cut short.
+fn wrapped_galley(
+    ctx: &Context,
+    text: &str,
+    family: egui::FontFamily,
+    size: f32,
+    color: Color32,
+    max_w: f32,
+) -> std::sync::Arc<egui::Galley> {
+    use egui::text::{LayoutJob, TextFormat};
+    let mut job = LayoutJob::single_section(text.to_owned(), TextFormat {
+        font_id: egui::FontId::new(size, family),
+        color,
+        ..Default::default()
+    });
+    job.wrap.max_width = max_w.max(0.0);
+    ctx.fonts(|f| f.layout_job(job))
+}
+
+/// Fixed geometry for the palette's `description | action | keys` grid.  Every
+/// row and the header lay out against the same widths, so the columns line up
+/// down the list instead of each row packing its own way.
+struct PaletteColumns {
+    width: f32,
+    pad: f32,
+    desc: f32,
+    action: f32,
+    keys: f32,
+    gap: f32,
+}
+
+impl PaletteColumns {
+    fn new(theme: &Theme, width: f32) -> Self {
+        let s = theme.ui_scale;
+        let pad = 10.0 * s;
+        let gap = 14.0 * s;
+        let action = 200.0 * s;
+        let keys = 180.0 * s;
+        let desc = (width - 2.0 * pad - 2.0 * gap - action - keys).max(120.0 * s);
+        Self { width, pad, desc, action, keys, gap }
+    }
+
+    fn desc_x(&self, left: f32) -> f32 {
+        left + self.pad
+    }
+
+    fn action_x(&self, left: f32) -> f32 {
+        self.desc_x(left) + self.desc + self.gap
+    }
+
+    fn keys_x(&self, left: f32) -> f32 {
+        self.action_x(left) + self.action + self.gap
+    }
+}
+
+/// The palette's column captions, on the same grid as its rows and outside the
+/// scrolling list so they stay put while it moves.
+fn paint_palette_header(ui: &mut egui::Ui, theme: &Theme, cols: &PaletteColumns) {
+    let s = theme.ui_scale;
+    let size = (theme.font_normal - 2.0).max(8.0);
+    let (rect, _) =
+        ui.allocate_exact_size(egui::vec2(cols.width, size + 10.0 * s), egui::Sense::hover());
+    let painter = ui.painter().clone();
+    let left = rect.left();
+    for (text, x, w) in [
+        ("DESCRIPTION", cols.desc_x(left), cols.desc),
+        ("ACTION", cols.action_x(left), cols.action),
+        ("KEYS", cols.keys_x(left), cols.keys),
+    ] {
+        let g = single_line_galley(
+            ui.ctx(),
+            text,
+            egui::FontFamily::Proportional,
+            size,
+            theme.text_muted,
+            w,
+        );
+        painter.galley(egui::pos2(x, rect.top() + 2.0 * s), g, theme.text_muted);
+    }
+    painter.hline(rect.x_range(), rect.bottom(), Stroke::new(1.0_f32, theme.sidebar_border));
+}
+
+/// A section heading in the palette list.  Not selectable — the cursor steps
+/// over rows only.
+fn paint_palette_section(ui: &mut egui::Ui, theme: &Theme, cols: &PaletteColumns, title: &str) {
+    let s = theme.ui_scale;
+    let size = (theme.font_normal - 2.0).max(8.0);
+    let (rect, _) =
+        ui.allocate_exact_size(egui::vec2(cols.width, size + 14.0 * s), egui::Sense::hover());
+    let g = single_line_galley(
+        ui.ctx(),
+        &title.to_uppercase(),
+        egui::FontFamily::Proportional,
+        size,
+        theme.accent,
+        cols.desc,
+    );
+    ui.painter().galley(
+        egui::pos2(cols.desc_x(rect.left()), rect.bottom() - size - 3.0 * s),
+        g,
+        theme.accent,
+    );
+}
+
+/// Paint one command-palette row across the three columns: the description
+/// (bright, wrapped over as many lines as it needs), the action's config name
+/// (dim), and every key bound to it (accent).  A selected row gets a soft
+/// accent wash and a crisp accent bar; a hovered one a faint fill.
 fn paint_palette_row(
     ui: &mut egui::Ui,
     theme: &Theme,
+    cols: &PaletteColumns,
     item: &PaletteItem,
     selected: bool,
 ) -> egui::Response {
     let s = theme.ui_scale;
-    let pad = 10.0 * s;
-    let gap = 14.0 * s;
-    let row_h = (theme.font_normal + 12.0 * s).round();
-
-    let (rect, resp) =
-        ui.allocate_exact_size(egui::vec2(ui.available_width(), row_h), egui::Sense::click());
-    let painter = ui.painter().clone();
+    let v_pad = 6.0 * s;
     let ctx = ui.ctx();
+
+    let desc = wrapped_galley(
+        ctx,
+        &item.primary,
+        egui::FontFamily::Proportional,
+        theme.font_normal,
+        theme.text,
+        cols.desc,
+    );
+    let action = single_line_galley(
+        ctx,
+        &item.secondary,
+        egui::FontFamily::Proportional,
+        theme.font_normal,
+        theme.text_dim,
+        cols.action,
+    );
+    let keys = single_line_galley(
+        ctx,
+        &item.keys,
+        egui::FontFamily::Monospace,
+        theme.font_normal,
+        theme.accent,
+        cols.keys,
+    );
+
+    let row_h = (desc.size().y.max(action.size().y) + 2.0 * v_pad).round();
+    let (rect, resp) = ui.allocate_exact_size(egui::vec2(cols.width, row_h), egui::Sense::click());
+    let painter = ui.painter().clone();
 
     if selected {
         let wash =
@@ -3905,52 +4084,12 @@ fn paint_palette_row(
         painter.rect_filled(rect, 5.0 * s, theme.row_hover_bg);
     }
 
-    let mid_y = rect.center().y;
-    let draw = |g: std::sync::Arc<egui::Galley>, x: f32| {
-        painter.galley(egui::pos2(x, mid_y - g.size().y / 2.0), g, theme.text);
-    };
-
-    // The secondary columns hug the right edge, right to left; the description
-    // then takes everything to their left, so it always leads the row.
-    let mut right = rect.right() - pad;
-    if !item.keys.is_empty() {
-        let g = single_line_galley(
-            ctx,
-            &item.keys,
-            egui::FontFamily::Monospace,
-            theme.font_normal,
-            theme.accent,
-            240.0 * s,
-        );
-        let w = g.size().x;
-        draw(g, right - w);
-        right -= w + gap;
-    }
-    if !item.secondary.is_empty() {
-        let tag_max = (rect.width() * 0.42).min(360.0 * s);
-        let g = single_line_galley(
-            ctx,
-            &item.secondary,
-            egui::FontFamily::Proportional,
-            theme.font_normal,
-            theme.text_dim,
-            tag_max,
-        );
-        let w = g.size().x;
-        draw(g, right - w);
-        right -= w + gap;
-    }
-
-    let left = rect.left() + pad;
-    let desc = single_line_galley(
-        ctx,
-        &item.primary,
-        egui::FontFamily::Proportional,
-        theme.font_normal,
-        theme.text,
-        (right - left).max(20.0 * s),
-    );
-    draw(desc, left);
+    // Top-aligned, so a wrapped description's first line shares a baseline with
+    // the single-line columns beside it.
+    let (left, top) = (rect.left(), rect.top() + v_pad);
+    painter.galley(egui::pos2(cols.desc_x(left), top), desc, theme.text);
+    painter.galley(egui::pos2(cols.action_x(left), top), action, theme.text_dim);
+    painter.galley(egui::pos2(cols.keys_x(left), top), keys, theme.accent);
 
     resp
 }
@@ -5489,8 +5628,9 @@ impl AlacritreeApp {
         let s = theme.ui_scale;
 
         // Drain the nav/confirm/cancel keys before the TextEdit runs so it
-        // never steals Enter (run), Esc (clear then close), or the arrows.
-        // Ctrl+K shuts the palette with the same key that opened it.
+        // never steals Enter (run), Esc (clear then close), the arrows, or the
+        // bound cursor jumps.  Ctrl+K shuts the palette with the same key that
+        // opened it.
         let (cancel, confirm) = consume_modal_keys(ctx);
         let (up, down) = ctx.input_mut(|i| {
             (
@@ -5498,9 +5638,11 @@ impl AlacritreeApp {
                 i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown),
             )
         });
+        let jumps = consume_palette_keys(ctx, &self.config.bindings);
         let toggle = ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::K));
 
         let items = self.palette_items();
+        let hint = palette_hint(&self.config.bindings);
         let mut chosen: Option<PaletteAction> = None;
 
         let modal = {
@@ -5508,8 +5650,9 @@ impl AlacritreeApp {
             egui::Modal::new(egui::Id::new("alacritree_command_palette"))
                 .frame(modal_frame(&theme))
                 .show(ctx, |ui| {
-                    ui.set_width(640.0 * s);
+                    ui.set_width(760.0 * s);
                     ui.spacing_mut().item_spacing.y = 6.0 * s;
+                    let cols = PaletteColumns::new(&theme, ui.available_width());
 
                     let input_id = egui::Id::new("alacritree_command_palette_query");
                     let query_changed = ui
@@ -5523,52 +5666,70 @@ impl AlacritreeApp {
                     focus_default(ui.ctx(), input_id);
 
                     let ranked = palette.rank(&items);
-                    // A query edit reseeds to the top match; arrows then nudge
-                    // the cursor within this frame's results.
+                    // A query edit reseeds to the top match; the cursor keys
+                    // then move within this frame's results.
                     palette.reseed(query_changed, ranked.len());
+                    let groups = command_palette::group(&items, &ranked);
+                    // Sections reorder the ranked rows, so the cursor steps over
+                    // this flattened view rather than the ranking itself.
+                    let flat: Vec<usize> =
+                        groups.iter().flat_map(|(_, rows)| rows.iter().copied()).collect();
                     if up {
                         palette.select_prev();
                     }
                     if down {
-                        palette.select_next(ranked.len());
+                        palette.select_next(flat.len());
                     }
+                    for jump in &jumps {
+                        match jump {
+                            NamedAction::PaletteTop => palette.select_top(),
+                            NamedAction::PaletteBottom => palette.select_bottom(flat.len()),
+                            NamedAction::PalettePageUp => palette.page_up(),
+                            NamedAction::PalettePageDown => palette.page_down(flat.len()),
+                            _ => {},
+                        }
+                    }
+                    let moved = query_changed || up || down || !jumps.is_empty();
                     if confirm {
-                        chosen = ranked.get(palette.selected()).map(|&i| items[i].action.clone());
+                        chosen = flat.get(palette.selected()).map(|&i| items[i].action.clone());
                     }
                     let selected = palette.selected();
 
                     ui.add_space(2.0 * s);
+                    paint_palette_header(ui, &theme, &cols);
                     egui::ScrollArea::vertical()
                         .max_height(400.0 * s)
                         .auto_shrink([false, false])
                         .show(ui, |ui| {
                             ui.spacing_mut().item_spacing.y = 2.0 * s;
-                            if ranked.is_empty() {
+                            if flat.is_empty() {
                                 ui.add_space(4.0 * s);
                                 ui.label(RichText::new("  no matches").color(theme.text_dim));
                                 return;
                             }
-                            for (row, &i) in ranked.iter().enumerate() {
-                                let is_sel = row == selected;
-                                let resp = paint_palette_row(ui, &theme, &items[i], is_sel)
-                                    .on_hover_cursor(egui::CursorIcon::PointingHand);
-                                if resp.clicked() {
-                                    chosen = Some(items[i].action.clone());
-                                }
-                                // Keep the keyboard-selected row in view as it
-                                // moves past the fold.
-                                if is_sel && (query_changed || up || down) {
-                                    resp.scroll_to_me(Some(egui::Align::Center));
+                            let mut row = 0usize;
+                            for (section, rows) in &groups {
+                                paint_palette_section(ui, &theme, &cols, section.title());
+                                for &i in rows {
+                                    let is_sel = row == selected;
+                                    let resp =
+                                        paint_palette_row(ui, &theme, &cols, &items[i], is_sel)
+                                            .on_hover_cursor(egui::CursorIcon::PointingHand);
+                                    if resp.clicked() {
+                                        chosen = Some(items[i].action.clone());
+                                    }
+                                    // Keep the keyboard-selected row in view as
+                                    // it moves past the fold.
+                                    if is_sel && moved {
+                                        resp.scroll_to_me(Some(egui::Align::Center));
+                                    }
+                                    row += 1;
                                 }
                             }
                         });
 
                     ui.add_space(6.0 * s);
-                    ui.label(
-                        RichText::new("↑↓ move · Enter run · Esc close")
-                            .color(theme.text_muted)
-                            .small(),
-                    );
+                    ui.label(RichText::new(hint).color(theme.text_muted).small());
                 })
         };
 

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -76,6 +76,14 @@ pub enum NamedAction {
     ToggleProjectExpanded,
     /// Open (or close) the Ctrl+K command palette.
     TogglePalette,
+    /// Move the palette cursor to the first row.
+    PaletteTop,
+    /// Move the palette cursor to the last row.
+    PaletteBottom,
+    /// Move the palette cursor a screenful up.
+    PalettePageUp,
+    /// Move the palette cursor a screenful down.
+    PalettePageDown,
     FocusProjectsSidebar,
     FocusGitSidebar,
     FocusTerminal,
@@ -158,6 +166,17 @@ impl NamedAction {
         )
     }
 
+    /// Actions that only act while the command palette is open. It is a modal
+    /// that owns every key while it is up, so these are dispatched there and
+    /// nowhere else — their default keys (unmodified Home/End/PageUp/PageDown)
+    /// stay the sidebar's and the terminal's the rest of the time.
+    pub fn is_palette_scoped(&self) -> bool {
+        matches!(
+            self,
+            Self::PaletteTop | Self::PaletteBottom | Self::PalettePageUp | Self::PalettePageDown
+        )
+    }
+
     /// The name `parse_action` accepts for this action — what a user writes
     /// in `[[keyboard.bindings]]`, and the label the shortcuts window shows.
     pub fn config_name(&self) -> String {
@@ -229,6 +248,10 @@ impl NamedAction {
             Self::SpawnProfile(n) => format!("Open a session with shell profile {n}"),
             Self::Quit => "Open the quit confirmation dialog".into(),
             Self::TogglePalette => "Open the command palette".into(),
+            Self::PaletteTop => "Move the palette cursor to the first row".into(),
+            Self::PaletteBottom => "Move the palette cursor to the last row".into(),
+            Self::PalettePageUp => "Move the palette cursor a screenful up".into(),
+            Self::PalettePageDown => "Move the palette cursor a screenful down".into(),
             Self::ToggleSessionRows => "Toggle single-session sidebar rows".into(),
             Self::ToggleSessionTabs => "Toggle single-session tab segments".into(),
             Self::SetBaseBranch => "Choose the branch the git panel diffs against".into(),
@@ -437,6 +460,28 @@ fn default_bindings() -> Vec<KeyBinding> {
             key: Key::Escape,
             mods: shift,
             action: BindingAction::Named(SidebarSearchCancelToTerminal),
+        },
+        // Palette list navigation: the same unmodified keys the sidebar uses,
+        // claimed only while the palette modal is up.
+        KeyBinding {
+            key: Key::Home,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(PaletteTop),
+        },
+        KeyBinding {
+            key: Key::End,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(PaletteBottom),
+        },
+        KeyBinding {
+            key: Key::PageUp,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(PalettePageUp),
+        },
+        KeyBinding {
+            key: Key::PageDown,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(PalettePageDown),
         },
     ]);
 
@@ -775,6 +820,10 @@ pub fn parse_action(name: &str) -> BindingAction {
         "RenameSelected" => BindingAction::Named(RenameSelected),
         "ToggleProjectExpanded" => BindingAction::Named(ToggleProjectExpanded),
         "TogglePalette" => BindingAction::Named(TogglePalette),
+        "PaletteTop" => BindingAction::Named(PaletteTop),
+        "PaletteBottom" => BindingAction::Named(PaletteBottom),
+        "PalettePageUp" => BindingAction::Named(PalettePageUp),
+        "PalettePageDown" => BindingAction::Named(PalettePageDown),
         "FocusProjectsSidebar" => BindingAction::Named(FocusProjectsSidebar),
         "FocusGitSidebar" => BindingAction::Named(FocusGitSidebar),
         "FocusTerminal" => BindingAction::Named(FocusTerminal),
@@ -1252,12 +1301,54 @@ mod tests {
             (Key::PageDown, NamedAction::SidebarNextProject, "SidebarNextProject"),
             (Key::PageUp, NamedAction::SidebarPreviousProject, "SidebarPreviousProject"),
         ] {
-            assert_eq!(named_matches(&b, key, Modifiers::NONE), vec![expected], "{name}");
+            assert!(named_matches(&b, key, Modifiers::NONE).contains(&expected), "{name}");
             assert!(
                 matches!(parse_action(name), BindingAction::Named(a) if a == expected),
                 "{name} does not parse"
             );
         }
+    }
+
+    /// The palette shares the sidebar's unmodified nav keys: both actions match
+    /// the press, and scope decides which one acts.
+    #[test]
+    fn palette_nav_actions_have_unmodified_defaults_and_parse() {
+        let b = parse_bindings(vec![]);
+        for (key, expected, name) in [
+            (Key::Home, NamedAction::PaletteTop, "PaletteTop"),
+            (Key::End, NamedAction::PaletteBottom, "PaletteBottom"),
+            (Key::PageUp, NamedAction::PalettePageUp, "PalettePageUp"),
+            (Key::PageDown, NamedAction::PalettePageDown, "PalettePageDown"),
+        ] {
+            assert!(named_matches(&b, key, Modifiers::NONE).contains(&expected), "{name}");
+            assert!(
+                matches!(parse_action(name), BindingAction::Named(a) if a == expected),
+                "{name} does not parse"
+            );
+            assert!(expected.is_palette_scoped(), "{name} must be palette-scoped");
+            assert!(!expected.is_sidebar_scoped(), "{name} must not be sidebar-scoped");
+        }
+    }
+
+    #[test]
+    fn only_palette_nav_actions_are_palette_scoped() {
+        for a in [
+            NamedAction::Paste,
+            NamedAction::TogglePalette,
+            NamedAction::SidebarTop,
+            NamedAction::SidebarSearchConfirm,
+            NamedAction::Quit,
+        ] {
+            assert!(!a.is_palette_scoped(), "{a:?} must not be palette-scoped");
+        }
+    }
+
+    /// Rebinding a palette key replaces the default on that trigger, sidebar
+    /// action included — the shared key stays one trigger, not two.
+    #[test]
+    fn user_binding_replaces_palette_nav_default() {
+        let b = parse_bindings(vec![raw_action("End", None, "PaletteTop")]);
+        assert_eq!(named_matches(&b, Key::End, Modifiers::NONE), vec![NamedAction::PaletteTop]);
     }
 
     /// Only the sidebar cursor actions and RefreshProjects are focus-scoped:

--- a/alacritree/src/command_palette.rs
+++ b/alacritree/src/command_palette.rs
@@ -11,7 +11,6 @@
 //! owns the item model, the ranking, and the palette's own query/selection
 //! state; painting and dispatch live in `app.rs`.
 
-use std::collections::HashSet;
 use std::path::PathBuf;
 
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
@@ -35,11 +34,68 @@ pub enum PaletteAction {
     CreateWorktree(PathBuf),
 }
 
+/// The heading a row files under. Grouping keeps the list readable now that a
+/// row per action (rather than per binding) still runs to fifty-odd entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaletteSection {
+    Clipboard,
+    Scrollback,
+    Sessions,
+    Workspaces,
+    Sidebar,
+    Window,
+    OpenSessions,
+    SwitchWorkspace,
+    NewWorktree,
+}
+
+impl PaletteSection {
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::Clipboard => "Clipboard",
+            Self::Scrollback => "Scrollback",
+            Self::Sessions => "Sessions",
+            Self::Workspaces => "Workspaces & projects",
+            Self::Sidebar => "Sidebar & focus",
+            Self::Window => "Window & application",
+            Self::OpenSessions => "Open sessions",
+            Self::SwitchWorkspace => "Switch workspace",
+            Self::NewWorktree => "New worktree",
+        }
+    }
+}
+
+/// Where an action row files. Hidden actions land in `Window` and never paint.
+fn section_of(a: NamedAction) -> PaletteSection {
+    use NamedAction::*;
+    use PaletteSection::*;
+    match a {
+        Paste | PasteSelection | Copy | CopySelection => Clipboard,
+        ScrollPageUp | ScrollPageDown | ScrollHalfPageUp | ScrollHalfPageDown => Scrollback,
+        ScrollLineUp | ScrollLineDown | ScrollToTop | ScrollToBottom => Scrollback,
+        ClearHistory => Scrollback,
+        SpawnNewInstance | SpawnProfile(_) | CloseSession => Sessions,
+        SelectNextTab | SelectPreviousTab | SelectTab(_) | SelectLastTab => Sessions,
+        SelectNextSession | SelectPreviousSession => Sessions,
+        ToggleSessionRows | ToggleSessionTabs => Sessions,
+        SelectNextWorkspace | SelectPreviousWorkspace => Workspaces,
+        AddProject | RefreshProjects | SetBaseBranch => Workspaces,
+        ToggleLeftSidebar | ToggleRightSidebar | ToggleSidebarFocus => Sidebar,
+        SidebarTop | SidebarBottom | SidebarNextProject | SidebarPreviousProject => Sidebar,
+        DeleteSelected | RenameSelected | ToggleProjectExpanded => Sidebar,
+        FocusProjectsSidebar | FocusGitSidebar | FocusTerminal => Sidebar,
+        FocusLeft | FocusRight => Sidebar,
+        SidebarSearchConfirm | SidebarSearchCancel | SidebarSearchCancelToTerminal => Sidebar,
+        _ => Window,
+    }
+}
+
 /// One selectable row. `keys`/`primary`/`secondary` are what the row paints;
 /// `search` is the precomputed haystack the matcher scores, so ranking never
 /// re-allocates a per-item string on every keystroke.
 pub struct PaletteItem {
     pub action: PaletteAction,
+    pub section: PaletteSection,
     pub keys: String,
     pub primary: String,
     pub secondary: String,
@@ -47,63 +103,113 @@ pub struct PaletteItem {
 }
 
 impl PaletteItem {
-    fn new(action: PaletteAction, keys: String, primary: String, secondary: String) -> Self {
+    fn new(
+        action: PaletteAction,
+        section: PaletteSection,
+        keys: String,
+        primary: String,
+        secondary: String,
+    ) -> Self {
         let search = format!("{primary} {secondary} {keys}");
-        Self { action, keys, primary, secondary, search }
+        Self { action, section, keys, primary, secondary, search }
     }
 
     fn action(a: NamedAction, keys: String) -> Self {
-        Self::new(PaletteAction::Run(a), keys, a.description(), a.config_name())
+        Self::new(PaletteAction::Run(a), section_of(a), keys, a.description(), a.config_name())
     }
 
     pub fn session(id: SessionId, primary: String, secondary: String) -> Self {
-        Self::new(PaletteAction::ActivateSession(id), String::new(), primary, secondary)
+        Self::new(
+            PaletteAction::ActivateSession(id),
+            PaletteSection::OpenSessions,
+            String::new(),
+            primary,
+            secondary,
+        )
     }
 
     pub fn workspace(ws: WorkspaceKey, primary: String, secondary: String) -> Self {
-        Self::new(PaletteAction::SwitchWorkspace(ws), String::new(), primary, secondary)
+        Self::new(
+            PaletteAction::SwitchWorkspace(ws),
+            PaletteSection::SwitchWorkspace,
+            String::new(),
+            primary,
+            secondary,
+        )
     }
 
     pub fn create_worktree(root: PathBuf, primary: String, secondary: String) -> Self {
-        Self::new(PaletteAction::CreateWorktree(root), String::new(), primary, secondary)
+        Self::new(
+            PaletteAction::CreateWorktree(root),
+            PaletteSection::NewWorktree,
+            String::new(),
+            primary,
+            secondary,
+        )
     }
 }
 
 /// Rows the palette must not offer to run: unbinds, the pass-through marker,
-/// and its own toggle (running which from inside would just reopen it).
+/// its own toggle (running which from inside would just reopen it), and the
+/// palette's own cursor moves — activating a row closes the palette, so a
+/// "scroll the palette" row could never do anything. Their keys are advertised
+/// in the palette's footer hint instead.
 fn is_hidden(a: NamedAction) -> bool {
     matches!(a, NamedAction::NoOp | NamedAction::ReceiveChar | NamedAction::TogglePalette)
+        || a.is_palette_scoped()
 }
 
-/// Every runnable keyboard action as a palette row: one per binding first (so a
-/// multi-bound action shows once per key, and a concrete `SelectTab`/
-/// `SpawnProfile` binding carries its index), then the actions no binding names
-/// yet — runnable all the same, shown without keys so the full vocabulary stays
-/// discoverable. The parametrized families themselves are left out: they need
-/// an index to run, and the palette's session rows already cover "jump to the
-/// Nth session" more directly.
+/// Every runnable keyboard action as one row, listing every key bound to it.
+/// The fixed vocabulary comes first, then whatever else the config binds — the
+/// parametrized `SelectTab`/`SpawnProfile` families, which need an index to
+/// run and so only exist as concrete bindings. Actions no binding names are
+/// listed too, keyless: runnable from here all the same, and that is how the
+/// full vocabulary stays discoverable without the docs.
 pub fn action_items(bindings: &[KeyBinding]) -> Vec<PaletteItem> {
-    let mut items = Vec::new();
+    let mut order: Vec<NamedAction> =
+        bindable_actions().into_iter().filter(|a| !is_hidden(*a)).collect();
     for b in bindings {
         if let BindingAction::Named(a) = &b.action {
-            if !is_hidden(*a) {
-                items.push(PaletteItem::action(*a, format_shortcut(b.key, b.mods)));
+            if !is_hidden(*a) && !order.contains(a) {
+                order.push(*a);
             }
         }
     }
-    let bound: HashSet<String> = bindings
+    order.into_iter().map(|a| PaletteItem::action(a, keys_for(bindings, a))).collect()
+}
+
+/// Every trigger bound to `action`, in binding order — user bindings before the
+/// defaults they did not replace.
+fn keys_for(bindings: &[KeyBinding], action: NamedAction) -> String {
+    bindings
         .iter()
-        .filter_map(|b| match &b.action {
-            BindingAction::Named(a) => Some(a.config_name()),
-            _ => None,
-        })
-        .collect();
-    for a in bindable_actions() {
-        if !is_hidden(a) && !bound.contains(&a.config_name()) {
-            items.push(PaletteItem::action(a, String::new()));
+        .filter(|b| matches!(&b.action, BindingAction::Named(a) if *a == action))
+        .map(|b| format_shortcut(b.key, b.mods))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The first key bound to `action`, for the footer hint.
+pub fn first_key(bindings: &[KeyBinding], action: NamedAction) -> Option<String> {
+    bindings
+        .iter()
+        .find(|b| matches!(&b.action, BindingAction::Named(a) if *a == action))
+        .map(|b| format_shortcut(b.key, b.mods))
+}
+
+/// Ranked rows grouped under their headings. A section appears where its
+/// best-ranked row does, so the top match always leads the list and an
+/// unfiltered palette keeps the natural order.
+pub fn group(items: &[PaletteItem], ranked: &[usize]) -> Vec<(PaletteSection, Vec<usize>)> {
+    let mut out: Vec<(PaletteSection, Vec<usize>)> = Vec::new();
+    for &i in ranked {
+        let section = items[i].section;
+        match out.iter_mut().find(|(s, _)| *s == section) {
+            Some((_, rows)) => rows.push(i),
+            None => out.push((section, vec![i])),
         }
     }
-    items
+    out
 }
 
 /// Every simple (non-parametrized) `NamedAction`, kept in sync with the enum by
@@ -269,7 +375,27 @@ impl CommandPalette {
             self.selected = (self.selected + 1).min(len - 1);
         }
     }
+
+    pub fn select_top(&mut self) {
+        self.selected = 0;
+    }
+
+    pub fn select_bottom(&mut self, len: usize) {
+        self.selected = len.saturating_sub(1);
+    }
+
+    pub fn page_up(&mut self) {
+        self.selected = self.selected.saturating_sub(PAGE);
+    }
+
+    pub fn page_down(&mut self, len: usize) {
+        self.selected = (self.selected + PAGE).min(len.saturating_sub(1));
+    }
 }
+
+/// Rows a page jump covers — a screenful of the palette's list at its default
+/// height, so PgUp/PgDn moves about as far as the eye already sees.
+const PAGE: usize = 10;
 
 #[cfg(test)]
 mod tests {
@@ -304,6 +430,77 @@ mod tests {
         {
             assert!(items.iter().any(|i| i.secondary == name), "{name} should be a palette row");
         }
+    }
+
+    /// A multi-bound action stays one row that lists both keys, rather than one
+    /// row per key.
+    #[test]
+    fn a_multi_bound_action_is_one_row_listing_every_key() {
+        let bindings = parse_bindings(vec![]);
+        let items = action_items(&bindings);
+        let rows: Vec<_> = items.iter().filter(|i| i.secondary == "IncreaseFontSize").collect();
+        assert_eq!(rows.len(), 1, "IncreaseFontSize should be a single row");
+        let expected = keys_for(&bindings, NamedAction::IncreaseFontSize);
+        assert!(expected.contains(", "), "IncreaseFontSize has two default keys: {expected}");
+        assert_eq!(rows[0].keys, expected);
+    }
+
+    /// The palette's own cursor moves are keyboard-only: a row for them would
+    /// close the palette it is meant to scroll.
+    #[test]
+    fn palette_nav_actions_are_not_rows() {
+        let items = action_items(&parse_bindings(vec![]));
+        for name in ["PaletteTop", "PaletteBottom", "PalettePageUp", "PalettePageDown"] {
+            assert!(!items.iter().any(|i| i.secondary == name), "{name} must not be a row");
+        }
+    }
+
+    #[test]
+    fn sections_follow_the_best_match_and_hold_natural_order_unfiltered() {
+        let items = action_items(&parse_bindings(vec![]));
+        let mut palette = CommandPalette::new();
+
+        let sections: Vec<_> =
+            group(&items, &palette.rank(&items)).into_iter().map(|(s, _)| s).collect();
+        assert_eq!(
+            sections.first().copied(),
+            Some(PaletteSection::Clipboard),
+            "an unfiltered palette keeps the declared order"
+        );
+
+        palette.query_mut().push_str("scrollback");
+        let ranked = palette.rank(&items);
+        let grouped = group(&items, &ranked);
+        assert_eq!(
+            grouped.first().map(|(s, _)| *s),
+            Some(PaletteSection::Scrollback),
+            "the section holding the best match leads"
+        );
+        // Grouping is a regrouping of the ranked rows, never a filter.
+        let total: usize = grouped.iter().map(|(_, rows)| rows.len()).sum();
+        assert_eq!(total, ranked.len());
+    }
+
+    #[test]
+    fn page_and_edge_moves_clamp_to_the_result_count() {
+        let mut palette = CommandPalette::new();
+        palette.page_down(100);
+        assert_eq!(palette.selected(), PAGE);
+        palette.page_up();
+        assert_eq!(palette.selected(), 0);
+        // Already at the top, a page up stays there rather than wrapping.
+        palette.page_up();
+        assert_eq!(palette.selected(), 0);
+
+        palette.select_bottom(4);
+        assert_eq!(palette.selected(), 3);
+        palette.page_down(4);
+        assert_eq!(palette.selected(), 3);
+        palette.select_top();
+        assert_eq!(palette.selected(), 0);
+        // An empty result set has no row to land on.
+        palette.select_bottom(0);
+        assert_eq!(palette.selected(), 0);
     }
 
     #[test]

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -66,6 +66,8 @@ and your TOML entries are checked first — so your config overrides any default
 | `Delete`             | Sidebar focused: close/delete/remove the selected row |
 | `Shift+R`            | Sidebar focused: rename the selected project          |
 | `Ctrl+K`             | Open the command palette                              |
+| `Home` / `End`       | Palette open: cursor to the first / last row          |
+| `PageUp` / `PageDown`| Palette open: cursor a screenful up / down            |
 
 ### Additional defaults on macOS
 
@@ -175,12 +177,28 @@ forward-delete in TUIs.
 - `TogglePalette` — open (or close) the command palette: one fuzzy-searchable,
   executable list of every keyboard action, every open session, and every
   switchable workspace. The same fzf-style matcher the sidebars use ranks the
-  rows, so the full action vocabulary stays discoverable without the docs. Type
-  to filter, `Up`/`Down` move the selection, `Enter` runs the highlighted row
-  (dispatching an action, jumping to a session, or switching workspace),
-  `Escape` clears the query and then closes, and a click outside dismisses it.
-  The default is `Ctrl+K` (which shadows `Ctrl+K` for terminal apps; rebind or
-  free it with `ReceiveChar` if you need it there).
+  rows, so the full action vocabulary stays discoverable without the docs. Rows
+  are grouped under section headings and laid out in three columns —
+  description, action name, and every key bound to that action — so a
+  multi-bound action reads as one row listing all its keys. A query promotes
+  whichever section holds the best match. Type to filter, `Up`/`Down` move the
+  selection, `Enter` runs the highlighted row (dispatching an action, jumping to
+  a session, or switching workspace), `Escape` clears the query and then closes,
+  and a click outside dismisses it. The default is `Ctrl+K` (which shadows
+  `Ctrl+K` for terminal apps; rebind or free it with `ReceiveChar` if you need it
+  there).
+- `PaletteTop` / `PaletteBottom` — move the palette cursor to the first / last
+  row. Defaults: unmodified `Home` / `End`.
+- `PalettePageUp` / `PalettePageDown` — move the palette cursor a screenful (ten
+  rows) up / down. Defaults: unmodified `PageUp` / `PageDown`.
+
+These four act only while the palette is open — it is a modal that owns every
+key while it is up — so they share the sidebar's unmodified defaults without
+shadowing them, and pass through to the terminal whenever the palette is
+closed. Rebinding one replaces the whole default trigger, sidebar action
+included: `key = "End"` bound to `PaletteTop` also unbinds `SidebarBottom`.
+Because the palette's query box has focus, `Home`/`End` no longer move the text
+caret there; bind them elsewhere if you want the caret back.
 - `SpawnProfile1` … `SpawnProfile9` — spawn the Nth `[[ui.profiles]]` entry
   in the current workspace. Out-of-range indices show an error toast.
   Example binding:


### PR DESCRIPTION
**DO NOT MERGE YET. MUST MERGE AFTER #138**

---

Adds command-palette list navigation, section headings, and a real column layout.

**Stacks on #138** — the palette groups the `SidebarSearch*` actions that PR introduces, so this branch is based on `feat/sidebar-search-actions`. Until #138 merges, the diff below carries its two commits; the change here is `88b11917` alone.

- **Nav keys** — new `PaletteTop` / `PaletteBottom` / `PalettePageUp` / `PalettePageDown` actions, defaulting to unmodified `Home` / `End` / `PageUp` / `PageDown` and rebindable like any other. Palette-scoped (`is_palette_scoped()`, mirroring the existing sidebar and search scoping), so they act only while the modal is up and the same keys still reach the sidebar and the PTY otherwise. A page is 10 rows.
- **Sections** — every row carries a `PaletteSection`; `group()` regroups the ranked list so a section appears where its best-ranked row does. The top match still leads, and an empty query keeps the natural order.
- **Columns** — `DESCRIPTION | ACTION | KEYS` on a fixed grid shared by the rows and a pinned header, replacing the right-packed layout. A multi-bound action is now one row listing all its keys (`Ctrl+=, Ctrl++`) rather than one row per binding.
- **Wrapping** — the description column wraps over as many lines as it needs and row height follows. Modal widened 640 → 760 px to give it room.

The footer hint is generated from the live bindings, so a rebind shows up there instead of the hint going stale.

Trade-off: `Home` / `End` no longer move the caret in the palette's query box — the palette consumes them before the `TextEdit` sees them.

487 tests pass; clippy warnings unchanged from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)