### PR TITLE
fix(projects): keep worktrees when unreachable [2]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -22,7 +22,7 @@ use crate::ipc;
 use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
 use crate::pr_status::{PrCache, PrInfo, PrState};
-use crate::projects::{Project, Worktree, project_json};
+use crate::projects::{Discovered, Project, Worktree, project_json};
 use crate::scratchpad;
 use crate::session::{
     AttentionVerdict, Session, SessionId, SessionKind, TermSize, poll_attention_debounce,
@@ -352,7 +352,7 @@ pub struct AlacritreeApp {
     /// In-flight background re-discoveries, keyed by project root.  WSL
     /// discovery shells out to wsl.exe and must never block paint; results
     /// are adopted in `poll_project_refreshes`.
-    pending_project_refresh: HashMap<PathBuf, Receiver<Project>>,
+    pending_project_refresh: HashMap<PathBuf, Receiver<Discovered>>,
     /// Resolved absolute path of `delta` inside each WSL distro, so diff panes
     /// stop re-sourcing a login profile on every open.  Successes only: a miss
     /// is never stored, so installing delta mid-session is picked up later.
@@ -571,7 +571,7 @@ impl AlacritreeApp {
                 // background discovery later swaps in via `poll_project_refreshes`.
                 let root = wsl::normalize_root(p.root.clone());
                 let mut project = match wsl::classify(&root) {
-                    wsl::Location::Windows(_) => Project::discover(root),
+                    wsl::Location::Windows(_) => Project::discover(root).project,
                     wsl::Location::Wsl { .. } => Project::placeholder(root),
                 };
                 project.expanded = p.expanded;
@@ -761,17 +761,15 @@ impl AlacritreeApp {
         }
     }
 
-    /// Adopt completed background discoveries.  Only worktrees and the
-    /// default branch are copied — `expanded`, the shell override, and the
-    /// label are user state that survives refreshes (mirrors
-    /// `Project::refresh`).
+    /// Adopt completed background discoveries through `Project::apply`, which
+    /// drops a result the backend could not vouch for and keeps `expanded`,
+    /// the shell override, and the label either way.
     fn poll_project_refreshes(&mut self) {
         let projects = &mut self.projects;
         self.pending_project_refresh.retain(|root, rx| match rx.try_recv() {
-            Ok(fresh) => {
+            Ok(found) => {
                 if let Some(project) = projects.iter_mut().find(|p| p.root == *root) {
-                    project.worktrees = fresh.worktrees;
-                    project.default_branch = fresh.default_branch;
+                    project.apply(found);
                 }
                 false
             },
@@ -1241,7 +1239,9 @@ impl AlacritreeApp {
             return;
         }
         match wsl::classify(&path) {
-            wsl::Location::Windows(_) => self.projects.push(Project::discover(path.clone())),
+            wsl::Location::Windows(_) => {
+                self.projects.push(Project::discover(path.clone()).project)
+            },
             wsl::Location::Wsl { .. } => {
                 self.projects.push(Project::placeholder(path.clone()));
                 let idx = self.projects.len() - 1;
@@ -1260,7 +1260,7 @@ impl AlacritreeApp {
         if let Some(idx) = self.projects.iter().position(|p| p.root == path) {
             return &self.projects[idx];
         }
-        self.projects.push(Project::discover(path.clone()));
+        self.projects.push(Project::discover(path.clone()).project);
         self.persist_project(&path);
         self.projects.last().expect("just pushed")
     }

--- a/alacritree/src/cli/offline.rs
+++ b/alacritree/src/cli/offline.rs
@@ -88,7 +88,7 @@ fn add(state_path: &Path, path: &Path) -> Project {
             s.projects.push(PersistedProject { root, expanded: true, shell: None, label: None });
         }
     });
-    Project::discover(path.to_path_buf())
+    Project::discover(path.to_path_buf()).project
 }
 
 fn remove(state_path: &Path, root: &Path) -> Result<(), String> {
@@ -123,7 +123,7 @@ fn discover_all(state_path: &Path) -> Vec<Project> {
     projects
         .into_iter()
         .map(|p| {
-            let mut project = Project::discover(p.root);
+            let mut project = Project::discover(p.root).project;
             project.expanded = p.expanded;
             project.label = p.label;
             project

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -34,19 +34,65 @@ pub struct Worktree {
     pub prunable: bool,
 }
 
+/// A discovery result and whether it can be trusted to replace an existing
+/// worktree list.  A backend that could not be reached returns a placeholder
+/// standing in for an unknown tree, which must never overwrite what the
+/// caller already knows.
+#[derive(Debug, Clone)]
+pub struct Discovered {
+    pub project: Project,
+    pub authoritative: bool,
+}
+
+impl Discovered {
+    fn found(project: Project) -> Self {
+        Self { project, authoritative: true }
+    }
+
+    fn unavailable(project: Project) -> Self {
+        Self { project, authoritative: false }
+    }
+}
+
+/// What an in-distro discovery round trip established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WslAnswer {
+    Repo,
+    NotARepo,
+    /// The distro could not be reached, or answered malformed — the tree is
+    /// unknown rather than empty.
+    Unreachable,
+}
+
+/// Decide what a discovery round trip established, kept separate from running
+/// it so all three outcomes are reachable without a WSL host.
+fn classify_wsl_answer(reached: bool, is_repo: bool, worktrees_parsed: usize) -> WslAnswer {
+    if !reached {
+        WslAnswer::Unreachable
+    } else if !is_repo {
+        WslAnswer::NotARepo
+    } else if worktrees_parsed == 0 {
+        // A repository always has at least its main checkout.
+        WslAnswer::Unreachable
+    } else {
+        WslAnswer::Repo
+    }
+}
+
 impl Project {
     /// Classify the root and discover through the owning backend: in-distro
     /// git for WSL paths, git2 for Windows paths, and a pseudo-worktree
     /// placeholder when the root is not a repository.
-    pub fn discover(root: PathBuf) -> Self {
+    pub fn discover(root: PathBuf) -> Discovered {
         let name = display_name(&root);
         match wsl::classify(&root) {
             wsl::Location::Wsl { distro, linux_path } => {
                 Self::discover_wsl(root, name, &distro, &linux_path)
             },
+            // A directory that is not a repository is a fact, not a failure.
             wsl::Location::Windows(_) => match Repository::open(&root) {
-                Ok(repo) => Self::from_repo(root, name, &repo),
-                Err(_) => Self::placeholder(root),
+                Ok(repo) => Discovered::found(Self::from_repo(root, name, &repo)),
+                Err(_) => Discovered::found(Self::placeholder(root)),
             },
         }
     }
@@ -73,27 +119,20 @@ impl Project {
     }
 
     /// One wsl.exe round trip answers everything discovery needs; sections
-    /// are split on `wsl::SECTION_SEP`.  Any failure degrades to the same
-    /// pseudo-worktree a non-git folder gets.
-    fn discover_wsl(root: PathBuf, name: String, distro: &str, linux_path: &str) -> Self {
-        let stdout = match wsl::run_batch(distro, DISCOVER_SCRIPT, &[linux_path]) {
-            Ok(s) => s,
-            Err(e) => {
-                log::warn!("WSL discovery failed for {}: {e}", root.display());
-                return Self::placeholder(root);
-            },
-        };
-        let sections = wsl::split_sections(&stdout);
+    /// are split on `wsl::SECTION_SEP`.  A round trip that never landed yields
+    /// the same pseudo-worktree a non-git folder gets, but marked
+    /// non-authoritative so it cannot overwrite a known worktree list.
+    fn discover_wsl(root: PathBuf, name: String, distro: &str, linux_path: &str) -> Discovered {
+        let batch = wsl::run_batch(distro, DISCOVER_SCRIPT, &[linux_path]).map_err(|e| {
+            log::warn!("WSL discovery failed for {}: {e}", root.display());
+        });
+        let sections = batch.as_ref().map(|s| wsl::split_sections(s)).unwrap_or_default();
         let text = |i: usize| {
             sections
                 .get(i)
                 .map(|s| String::from_utf8_lossy(s).trim().to_string())
                 .unwrap_or_default()
         };
-
-        if text(0) != "yes" {
-            return Self::placeholder(root);
-        }
 
         let records = parse_worktree_list_z(sections.get(1).copied().unwrap_or_default());
         let worktrees: Vec<Worktree> = records
@@ -112,18 +151,19 @@ impl Project {
                 Worktree { name: wt_name, path, branch, is_main: i == 0, prunable }
             })
             .collect();
-        if worktrees.is_empty() {
-            return Self::placeholder(root);
-        }
 
-        Project {
-            default_branch: default_branch_from_batch(&text(2), &text(3), &text(4)),
-            worktrees,
-            root,
-            name,
-            label: None,
-            expanded: true,
-            shell_override: None,
+        match classify_wsl_answer(batch.is_ok(), text(0) == "yes", worktrees.len()) {
+            WslAnswer::Unreachable => Discovered::unavailable(Self::placeholder(root)),
+            WslAnswer::NotARepo => Discovered::found(Self::placeholder(root)),
+            WslAnswer::Repo => Discovered::found(Project {
+                default_branch: default_branch_from_batch(&text(2), &text(3), &text(4)),
+                worktrees,
+                root,
+                name,
+                label: None,
+                expanded: true,
+                shell_override: None,
+            }),
         }
     }
 
@@ -179,9 +219,20 @@ impl Project {
     }
 
     pub fn refresh(&mut self) {
-        let updated = Project::discover(self.root.clone());
-        self.worktrees = updated.worktrees;
-        self.default_branch = updated.default_branch;
+        let found = Project::discover(self.root.clone());
+        self.apply(found);
+    }
+
+    /// Adopt a discovery result.  A non-authoritative result leaves the
+    /// worktree list and default branch alone: an unreachable backend must not
+    /// read as deletion.  `expanded`, `shell_override`, and `label` are user
+    /// state and are never touched either way.
+    pub fn apply(&mut self, found: Discovered) {
+        if !found.authoritative {
+            return;
+        }
+        self.worktrees = found.project.worktrees;
+        self.default_branch = found.project.default_branch;
     }
 }
 
@@ -367,13 +418,85 @@ mod tests {
     use crate::test_util::{add_worktree, init_repo};
 
     #[test]
+    fn refresh_keeps_worktrees_when_discovery_is_not_authoritative() {
+        let mut project = Project::placeholder(PathBuf::from("/nonexistent-root"));
+        project.default_branch = Some("develop".to_string());
+        project.worktrees = vec![
+            Worktree {
+                name: "main".to_string(),
+                path: PathBuf::from("/nonexistent-root"),
+                branch: None,
+                is_main: true,
+                prunable: false,
+            },
+            Worktree {
+                name: "feature".to_string(),
+                path: PathBuf::from("/nonexistent-root-feature"),
+                branch: Some("feature".to_string()),
+                is_main: false,
+                prunable: false,
+            },
+        ];
+
+        let before = project.worktrees.clone();
+        project.apply(Discovered {
+            project: Project::placeholder(project.root.clone()),
+            authoritative: false,
+        });
+
+        assert_eq!(project.worktrees.len(), before.len());
+        assert_eq!(project.worktrees[1].name, "feature");
+        assert_eq!(
+            project.default_branch.as_deref(),
+            Some("develop"),
+            "an unreachable backend must not erase the known default branch either"
+        );
+    }
+
+    #[test]
+    fn apply_adopts_an_authoritative_result() {
+        let mut project = Project::placeholder(PathBuf::from("/root"));
+        let mut fresh = Project::placeholder(PathBuf::from("/root"));
+        fresh.worktrees.clear();
+        fresh.default_branch = Some("main".to_string());
+
+        project.apply(Discovered { project: fresh, authoritative: true });
+
+        assert!(project.worktrees.is_empty());
+        assert_eq!(project.default_branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn only_a_reachable_distro_gives_an_authoritative_answer() {
+        let (reached, unreachable) = (true, false);
+        let (repo, not_repo) = (true, false);
+
+        // The round trip failed: the tree is unknown, not empty.
+        assert_eq!(classify_wsl_answer(unreachable, not_repo, 0), WslAnswer::Unreachable);
+        // The distro answered "this is not a repository" — that is the truth.
+        assert_eq!(classify_wsl_answer(reached, not_repo, 0), WslAnswer::NotARepo);
+        // A repository always has at least its main checkout, so parsing none of
+        // them means the round trip came back malformed.
+        assert_eq!(classify_wsl_answer(reached, repo, 0), WslAnswer::Unreachable);
+        assert_eq!(classify_wsl_answer(reached, repo, 2), WslAnswer::Repo);
+    }
+
+    #[test]
+    fn a_non_git_windows_root_is_authoritative() {
+        let dir = tempfile::tempdir().unwrap();
+        let found = Project::discover(dir.path().to_path_buf());
+        assert!(found.authoritative, "a directory that is genuinely not a repo is the truth");
+        assert_eq!(found.project.worktrees.len(), 1);
+    }
+
+    #[test]
     fn live_worktree_is_not_prunable() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_dir = tmp.path().join("repo");
         let repo = init_repo(&repo_dir);
         add_worktree(&repo, "feature");
 
-        let project = Project::discover(repo_dir);
+        let project = Project::discover(repo_dir).project;
         let wt = project.worktrees.iter().find(|w| w.name == "feature").unwrap();
         assert!(!wt.prunable);
         assert_eq!(wt.branch.as_deref(), Some("feature"));
@@ -387,7 +510,7 @@ mod tests {
         let wt_path = add_worktree(&repo, "feature");
         std::fs::remove_dir_all(&wt_path).unwrap();
 
-        let project = Project::discover(repo_dir);
+        let project = Project::discover(repo_dir).project;
         let wt = project.worktrees.iter().find(|w| w.name == "feature").unwrap();
         assert!(wt.prunable);
         assert_eq!(wt.branch.as_deref(), Some("feature"));
@@ -399,7 +522,7 @@ mod tests {
         let repo_dir = tmp.path().join("repo");
         init_repo(&repo_dir);
 
-        let project = Project::discover(repo_dir);
+        let project = Project::discover(repo_dir).project;
         assert!(project.worktrees[0].is_main);
         assert!(!project.worktrees[0].prunable);
     }
@@ -410,7 +533,7 @@ mod tests {
         let repo_dir = tmp.path().join("repo");
         init_repo(&repo_dir);
 
-        let mut project = Project::discover(repo_dir);
+        let mut project = Project::discover(repo_dir).project;
         assert_eq!(project.display_name(), "repo");
 
         project.label = Some("Work".to_string());


### PR DESCRIPTION
A transient `wsl.exe` failure silently collapses a WSL project's worktree list to a single pseudo-worktree. `Project::discover` now reports whether its answer is authoritative, and callers adopt through `Project::apply`, which drops a result the backend could not vouch for.

## The bug

`discover_wsl` returned `Project::placeholder` on a failed round trip — the same single pseudo-worktree a non-git folder gets. Both `Project::refresh` and `AlacritreeApp::poll_project_refreshes` copied that straight over `worktrees` and `default_branch`, so one flaky round trip was indistinguishable from "every worktree in this project was deleted". The sidebar collapsed to one row and stayed that way until a later refresh happened to succeed.

Same failure shape as `17f95c23 fix(wsl): keep last probe when helper is briefly down`, which fixed the foreground-TUI probe cache: a transport error collapsing into the same value as a definitive negative answer.

## The change

- `Project::discover` returns `Discovered { project, authoritative }`.
- `classify_wsl_answer(reached, is_repo, worktrees_parsed) -> WslAnswer` is a pure function, so all three outcomes are reachable in a test without a WSL host. `discover_wsl` classifies once at the end rather than returning early three times.
- `Project::apply` adopts a result, ignoring a non-authoritative one. `expanded`, `shell_override`, and `label` remain untouched either way, as before.
- Callers in `app.rs` and `cli/offline.rs` take `.project`; the background refresh channel carries `Discovered`.

A distro that answers "this is not a repository" is still authoritative — that is the truth, and the placeholder is correct. Only a round trip that never landed, or one that came back claiming a repo with no main checkout, is treated as unknown.

## Testing

Four new tests in `projects::tests`. They failed to compile first, then the finished code was hotpatched to drop the `if !found.authoritative { return; }` guard, reproducing the bug:

```
assertion `left == right` failed
  left: 1
 right: 2
```

Guard restored, green. Full suite: 480 passed. `cargo clippy -p alacritree --all-targets` warning count unchanged from `master`, none in the touched files.

Still to verify manually: add a project on a WSL path, break `wsl.exe` on `PATH`, force a refresh, and confirm the worktree list survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)