### PR TITLE
homebrew: bump alacritree to v0.7.1

### DIFF
--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -1,7 +1,7 @@
 class Alacritree < Formula
   desc "Alacritty fork with worktree-aware sidebars"
   homepage "https://github.com/mathix420/alacritree"
-  version "0.6.0"
+  version "0.7.1"
   license "Apache-2.0"
 
   # Linked dynamically through the `fontconfig` Rust crate (alacritty's font
@@ -22,7 +22,7 @@ class Alacritree < Formula
   on_macos do
     on_arm do
       url "https://github.com/mathix420/alacritree/releases/download/v#{version}/alacritree-aarch64-apple-darwin.tar.gz"
-      sha256 "a88cc24b0acbab78a3ec969de909e8e1919d4e336d792852b7ea1bac53621f43"
+      sha256 "381c8908eed21f77048fcf287ee1997123c831d934a115a9aa21c1e3d8fa2405"
     end
   end
 


### PR DESCRIPTION
Automated formula bump triggered by the release of `v0.7.1`.