### PR TITLE
fix(ci): authorize downstream workflow dispatch

### DIFF
--- a/.github/workflows/publish-downstream.yml
+++ b/.github/workflows/publish-downstream.yml
@@ -19,7 +19,10 @@ jobs:
     steps:
       - name: Re-run downstream publishers
         env:
-          GH_TOKEN: ${{ secrets.ALACRITREE_BOT_TOKEN }}
+          # The caller grants actions:write to this repository-scoped token.
+          # Unlike the bot PAT, it can dispatch workflows without requiring
+          # repository-level Actions access on a separate credential.
+          GH_TOKEN: ${{ github.token }}
           PLAN: ${{ inputs.plan }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@
 
 name: Release
 permissions:
+  "actions": "write"
   "contents": "write"
 
 # This task will run whenever you push a git tag that looks like a version


### PR DESCRIPTION
Follow-up to the `v0.7.1` release run. The core release and all platform artifacts succeeded, but the post-release publisher fan-out failed because `ALACRITREE_BOT_TOKEN` cannot access the Actions workflow-dispatch API.

Grant the release workflow `actions: write` and use its repository-scoped `GITHUB_TOKEN` for the three workflow dispatches. The downstream workflows can continue using the bot PAT for their git/AUR operations.

The three `v0.7.1` publishers were dispatched manually after assets were attached, so the current release is not waiting on this change.