### PR TITLE
feat(wsl): advertise the binary path and hold the probe cache [1]

### DIFF
--- a/alacritree/src/ipc.rs
+++ b/alacritree/src/ipc.rs
@@ -37,6 +37,11 @@ use crate::worktree::{self as wt, CreateRequest, Progress};
 
 pub const SOCKET_ENV: &str = "ALACRITREE_SOCKET";
 
+/// Absolute path to the running binary.  A shell can exec the CLI through it
+/// without a PATH lookup — which is the only reliable way in a distro, where
+/// the Windows binary is reachable through interop but is not on `$PATH`.
+pub const EXE_ENV: &str = "ALACRITREE_EXE";
+
 /// How long a connection waits for the UI thread before giving up — long
 /// enough for a busy frame, short enough that a wedged app doesn't hang
 /// clients forever.
@@ -146,13 +151,18 @@ pub fn spawn_listener(ctx: egui::Context) -> std::io::Result<(SocketHandle, Rece
     // no other thread is reading the environment concurrently.
     unsafe { std::env::set_var(SOCKET_ENV, listener.0.path()) };
 
+    match std::env::current_exe() {
+        Ok(exe) => unsafe { std::env::set_var(EXE_ENV, exe) },
+        Err(e) => log::warn!("cannot advertise {EXE_ENV}: {e}"),
+    }
+
     // Only WSLENV-listed variables cross the wsl.exe boundary — in either
     // direction.  Listing the socket lets programs in a distro find this
     // instance, whether they read the variable themselves or exec the
     // Windows CLI through interop (which inherits the distro's view); the
-    // session id lets them name their own session in requests.  No
-    // conversion flags: neither a pipe name nor an id is a path WSL should
-    // translate.
+    // session id lets them name their own session in requests; the binary
+    // path lets them exec the CLI at all, since the Windows image is not on
+    // the distro's `$PATH`.
     #[cfg(windows)]
     unsafe {
         std::env::set_var(
@@ -164,19 +174,24 @@ pub fn spawn_listener(ctx: egui::Context) -> std::io::Result<(SocketHandle, Rece
     Ok(listener)
 }
 
-/// `WSLENV` extended with the variables alacritree exports — [`SOCKET_ENV`]
-/// and [`crate::session::SESSION_ID_ENV`] — preserving whatever the user
-/// already shares across the boundary.
+/// `WSLENV` extended with the variables alacritree exports — [`SOCKET_ENV`],
+/// [`crate::session::SESSION_ID_ENV`] and [`EXE_ENV`] — preserving whatever
+/// the user already shares across the boundary.
+///
+/// Only the binary path carries a conversion flag: `/p` has WSL rewrite it
+/// into the distro's view of the drive, honouring whatever automount root
+/// that distro uses.  A pipe name and an id are not paths.
 #[cfg(any(test, windows))]
 fn wslenv_with_alacritree_vars(current: Option<&str>) -> String {
     let mut wslenv = current.unwrap_or("").to_string();
-    for name in [SOCKET_ENV, crate::session::SESSION_ID_ENV] {
+    for (name, flags) in [(SOCKET_ENV, ""), (crate::session::SESSION_ID_ENV, ""), (EXE_ENV, "/p")] {
         let listed = wslenv.split(':').any(|entry| entry.split('/').next() == Some(name));
         if !listed {
             if !wslenv.is_empty() {
                 wslenv.push(':');
             }
             wslenv.push_str(name);
+            wslenv.push_str(flags);
         }
     }
     wslenv
@@ -490,7 +505,7 @@ mod tests {
 
     #[test]
     fn wslenv_gains_the_socket_exactly_once() {
-        let ours = format!("{SOCKET_ENV}:{SESSION_ID_ENV}");
+        let ours = format!("{SOCKET_ENV}:{SESSION_ID_ENV}:{EXE_ENV}/p");
         assert_eq!(wslenv_with_alacritree_vars(None), ours);
         assert_eq!(wslenv_with_alacritree_vars(Some("")), ours);
         assert_eq!(wslenv_with_alacritree_vars(Some("LESS:FOO/p")), format!("LESS:FOO/p:{ours}"));
@@ -499,7 +514,20 @@ mod tests {
         let flagged = format!("{SOCKET_ENV}/u:LESS");
         assert_eq!(
             wslenv_with_alacritree_vars(Some(&flagged)),
-            format!("{flagged}:{SESSION_ID_ENV}")
+            format!("{flagged}:{SESSION_ID_ENV}:{EXE_ENV}/p")
+        );
+    }
+
+    /// The binary path is the one variable WSL must rewrite: a distro sees the
+    /// Windows image through its automount root, not at `C:\…`.
+    #[test]
+    fn wslenv_lists_the_exe_path_for_conversion() {
+        assert!(wslenv_with_alacritree_vars(None).ends_with(&format!("{EXE_ENV}/p")));
+        // A user who already shares it, however flagged, keeps their spelling.
+        let theirs = format!("{EXE_ENV}/up");
+        assert_eq!(
+            wslenv_with_alacritree_vars(Some(&theirs)),
+            format!("{theirs}:{SOCKET_ENV}:{SESSION_ID_ENV}")
         );
     }
 
@@ -507,9 +535,15 @@ mod tests {
     /// socket, it only crosses wsl.exe if listed.
     #[test]
     fn wslenv_gains_the_session_id_exactly_once() {
-        assert_eq!(wslenv_with_alacritree_vars(None), format!("{SOCKET_ENV}:{SESSION_ID_ENV}"));
+        assert_eq!(
+            wslenv_with_alacritree_vars(None),
+            format!("{SOCKET_ENV}:{SESSION_ID_ENV}:{EXE_ENV}/p")
+        );
         let flagged = format!("{SESSION_ID_ENV}/u");
-        assert_eq!(wslenv_with_alacritree_vars(Some(&flagged)), format!("{flagged}:{SOCKET_ENV}"));
+        assert_eq!(
+            wslenv_with_alacritree_vars(Some(&flagged)),
+            format!("{flagged}:{SOCKET_ENV}:{EXE_ENV}/p")
+        );
     }
 
     /// The client/server round trip over whatever transport the platform uses:
@@ -535,5 +569,10 @@ mod tests {
         // The advertised path has to be connectable: it is how a shell running
         // inside a session reaches its own instance.
         assert_eq!(std::env::var_os(SOCKET_ENV).map(PathBuf::from).as_deref(), Some(handle.path()));
+        assert_eq!(
+            std::env::var_os(EXE_ENV).map(PathBuf::from),
+            std::env::current_exe().ok(),
+            "a shell needs the binary path to exec the CLI back"
+        );
     }
 }

--- a/alacritree/src/wsl_helper.rs
+++ b/alacritree/src/wsl_helper.rs
@@ -636,7 +636,17 @@ fn ensure_poller() {
                     std::thread::sleep(PROBE_POLL_INTERVAL);
                     let keys: Vec<(String, String)> = lock(probe_cache()).keys().cloned().collect();
                     for entry in keys {
-                        let comm = client(&entry.0).and_then(|c| c.probe(&entry.1).ok()).flatten();
+                        // Only a definitive reply overwrites the cache.  A missing
+                        // client (helper down or in respawn cooldown) or a transport
+                        // error means "unknown", not "no TUI" — clobbering to None
+                        // there would disable passthrough for a still-running TUI
+                        // until the next successful probe.  Still call client() every
+                        // tick so a cooled-down helper keeps getting nudged back up.
+                        let Some(client) = client(&entry.0) else { continue };
+                        let comm = match client.probe(&entry.1) {
+                            Ok(comm) => comm,
+                            Err(_) => continue,
+                        };
                         if let Some(slot) = lock(probe_cache()).get_mut(&entry) {
                             *slot = comm;
                         }


### PR DESCRIPTION
Two independent fixes to the WSL boundary, both about a shell inside a distro
being able to talk back to the instance that spawned it.

## `fix(wsl)`: keep the last probe when the helper is briefly down

The probe poller collapsed three different outcomes into the same `None`:
a genuine "no foreground TUI", a missing client, and a transport error.
Any transient helper outage therefore blanked every session's cached
foreground command name, and while the helper sat in its respawn cooldown
the cache stayed blank — disabling `FocusLeft`/`FocusRight` passthrough for
a still-running nvim or tmux until the helper came back on its own.

The cache is now overwritten only on a definitive reply. A missing client or
a probe error leaves the last-known value in place. `client()` is still
called every tick, so a cooled-down helper keeps getting nudged back up.

## `feat(ipc)`: advertise the binary path to WSL shells

A shell inside a distro could already find a running instance through
`ALACRITREE_SOCKET`, but had no way to invoke the CLI: the Windows image is
reachable over interop yet is not on the distro's `$PATH`, so callers had to
hardcode a path or guess at one.

The running image is now exported as `ALACRITREE_EXE` and listed in `WSLENV`
with `/p` — the flag that has WSL rewrite the value into the distro's view of
the drive, honouring whatever automount root that distro uses instead of
assuming `/mnt`. It is the only one of the three exported variables that
carries a conversion flag; a pipe name and a session id are not paths. A user
who already lists `ALACRITREE_EXE` themselves keeps their own spelling.

## Testing

`cargo test -p alacritree` — 477 pass. New coverage:

- `ipc::tests::wslenv_lists_the_exe_path_for_conversion` — the `/p` flag is
  applied, and an existing user entry is left alone.
- `ipc::tests::a_client_reaches_the_listener_it_advertises` now also asserts
  `ALACRITREE_EXE` matches `current_exe()`.

The existing `wslenv_gains_*` tests were updated for the third variable.
