### PR TITLE
feat(sidebar): add configurable path abbreviation styles [5]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -3318,6 +3318,7 @@ impl AlacritreeApp {
                         theme.path_style.git_header,
                         egui::FontFamily::Proportional,
                         workspace_home.as_deref(),
+                        true,
                     );
                     if let Some(branch) = &status.branch {
                         // A greedy `truncate()` label in a plain `horizontal` row
@@ -4237,6 +4238,7 @@ fn file_row(
                     theme.path_style.git_rows,
                     egui::FontFamily::Proportional,
                     None,
+                    false,
                 );
                 fill_row(ui);
             },
@@ -4307,6 +4309,7 @@ fn branch_diff_row(
                                 theme.path_style.git_rows,
                                 egui::FontFamily::Proportional,
                                 None,
+                                false,
                             );
                             fill_row(ui);
                         },
@@ -4348,9 +4351,10 @@ fn path_label(
     style: PathStyle,
     family: egui::FontFamily,
     home: Option<&str>,
-) {
+    selectable: bool,
+) -> egui::Response {
     if style != PathStyle::Zed {
-        ui.add(
+        return ui.add(
             egui::Label::new(
                 RichText::new(path_style::render(path, style, home))
                     .color(base)
@@ -4358,9 +4362,8 @@ fn path_label(
                     .small(),
             )
             .truncate()
-            .selectable(false),
+            .selectable(selectable),
         );
-        return;
     }
 
     let size = egui::TextStyle::Small.resolve(ui.style()).size;
@@ -4385,13 +4388,25 @@ fn path_label(
             },
         );
     };
-    if parts.parent.is_empty() {
-        push(format!("{}{}", parts.root, parts.name), &theme.path_style.filename);
-    } else {
-        push(parts.name.clone(), &theme.path_style.filename);
-        push(format!(" {}{}", parts.root, parts.parent), &theme.path_style.parent);
+    let emphases = [&theme.path_style.filename, &theme.path_style.parent];
+    for (text, e) in zed_spans(&parts).into_iter().zip(emphases) {
+        push(text, e);
     }
-    ui.add(egui::Label::new(job).truncate().selectable(false));
+    ui.add(egui::Label::new(job).truncate().selectable(selectable))
+}
+
+/// The Zed style's span decomposition: the filename text, then — when there
+/// is a parent to show — the parent text with its separating space already
+/// folded in. Position carries the emphasis: span 0 always paints with the
+/// filename emphasis, span 1 (if present) with the parent emphasis. Shared by
+/// `path_label`'s job builder and its fidelity test so a regression in the
+/// split logic fails the test that exercises the real render path.
+fn zed_spans(parts: &path_style::Parts) -> Vec<String> {
+    if parts.parent.is_empty() {
+        vec![format!("{}{}", parts.root, parts.name)]
+    } else {
+        vec![parts.name.clone(), format!(" {}{}", parts.root, parts.parent)]
+    }
 }
 
 /// Extend a row's bounding rect to its parent's full width so the response
@@ -7873,8 +7888,9 @@ mod tests {
         }
     }
 
-    /// The job's two spans must reassemble into exactly what `render` produces,
-    /// so the emphasis only changes how the text looks, never what it says.
+    /// The job's spans, as `path_label` itself builds them via `zed_spans`,
+    /// must reassemble into exactly what `render` produces, so the emphasis
+    /// only changes how the text looks, never what it says.
     #[test]
     fn the_zed_job_spells_the_same_text_as_render() {
         for (path, home) in [
@@ -7885,12 +7901,54 @@ mod tests {
             ("/home/lev/Git/x/y.rs", Some("/home/lev")),
         ] {
             let parts = crate::path_style::split(path, PathStyle::Zed, home);
-            let spans = if parts.parent.is_empty() {
-                format!("{}{}", parts.root, parts.name)
-            } else {
-                format!("{} {}{}", parts.name, parts.root, parts.parent)
-            };
+            let spans = zed_spans(&parts).concat();
             assert_eq!(spans, crate::path_style::render(path, PathStyle::Zed, home), "{path:?}");
+        }
+    }
+
+    /// The header must stay text-selectable exactly as it was before
+    /// `path_label` existed; a row must stay non-selectable so its own click
+    /// wins the hit test instead of a text drag-select. Both the plain and
+    /// the `Zed` `LayoutJob` branch build their own label, so both are
+    /// checked here.
+    #[test]
+    fn path_label_selectability_matches_the_caller() {
+        let theme = Theme::from_config(&Config::default());
+        let ctx = egui::Context::default();
+
+        for style in [PathStyle::Full, PathStyle::Zed] {
+            for selectable in [true, false] {
+                let mut sense = None;
+                let input = egui::RawInput {
+                    screen_rect: Some(egui::Rect::from_min_size(
+                        egui::Pos2::ZERO,
+                        egui::Vec2::new(400.0, 100.0),
+                    )),
+                    ..Default::default()
+                };
+                let _ = ctx.run(input, |ctx| {
+                    egui::CentralPanel::default().show(ctx, |ui| {
+                        let resp = path_label(
+                            ui,
+                            "path/to/file.txt",
+                            theme.text,
+                            &theme,
+                            style,
+                            egui::FontFamily::Proportional,
+                            None,
+                            selectable,
+                        );
+                        sense = Some(resp.sense);
+                    });
+                });
+
+                let sense = sense.expect("path_label must run inside the panel closure");
+                assert_eq!(
+                    sense.senses_drag(),
+                    selectable,
+                    "style {style:?} selectable {selectable}: {sense:?}"
+                );
+            }
         }
     }
 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -15,7 +15,8 @@ use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
 use crate::command_palette::{self, CommandPalette, PaletteAction, PaletteItem};
 use crate::config::{
-    Config, FontConfig, Icons, LastSessionClose, PathStyleConfig, ScrollbarStyle, UiFont,
+    Config, FontConfig, Icons, LastSessionClose, PathStyleConfig, ScrollbarStyle, TextEmphasis,
+    UiFont,
 };
 use crate::doppler;
 use crate::git_nav::{self, GitSection, SectionCount};
@@ -24,7 +25,6 @@ use crate::ipc;
 use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
 use crate::path_style;
-#[cfg(test)]
 use crate::path_style::PathStyle;
 use crate::pr_status::{PrCache, PrInfo, PrState};
 use crate::projects::{Discovered, Project, Worktree, project_json};
@@ -3310,17 +3310,14 @@ impl AlacritreeApp {
                         return;
                     }
 
-                    ui.add(
-                        egui::Label::new(
-                            RichText::new(path_style::render(
-                                &wsl::display_path(&path),
-                                theme.path_style.git_header,
-                                workspace_home.as_deref(),
-                            ))
-                            .color(theme.text_muted)
-                            .small(),
-                        )
-                        .truncate(),
+                    path_label(
+                        ui,
+                        &wsl::display_path(&path),
+                        theme.text_muted,
+                        &theme,
+                        theme.path_style.git_header,
+                        egui::FontFamily::Proportional,
+                        workspace_home.as_deref(),
                     );
                     if let Some(branch) = &status.branch {
                         // A greedy `truncate()` label in a plain `horizontal` row
@@ -4232,19 +4229,14 @@ fn file_row(
                     )
                     .selectable(false),
                 );
-                ui.add(
-                    egui::Label::new(
-                        RichText::new(path_style::render(
-                            &change.path,
-                            theme.path_style.git_rows,
-                            None,
-                        ))
-                        .color(path_color)
-                        .monospace()
-                        .small(),
-                    )
-                    .truncate()
-                    .selectable(false),
+                path_label(
+                    ui,
+                    &change.path,
+                    path_color,
+                    theme,
+                    theme.path_style.git_rows,
+                    egui::FontFamily::Proportional,
+                    None,
                 );
                 fill_row(ui);
             },
@@ -4307,19 +4299,14 @@ fn branch_diff_row(
                         egui::Layout::left_to_right(egui::Align::Center),
                         |ui| {
                             ui.set_min_height(row_h);
-                            ui.add(
-                                egui::Label::new(
-                                    RichText::new(path_style::render(
-                                        &stat.path,
-                                        theme.path_style.git_rows,
-                                        None,
-                                    ))
-                                    .color(path_color)
-                                    .monospace()
-                                    .small(),
-                                )
-                                .truncate()
-                                .selectable(false),
+                            path_label(
+                                ui,
+                                &stat.path,
+                                path_color,
+                                theme,
+                                theme.path_style.git_rows,
+                                egui::FontFamily::Proportional,
+                                None,
                             );
                             fill_row(ui);
                         },
@@ -4331,6 +4318,80 @@ fn branch_diff_row(
         .interact(egui::Sense::click());
     paint_row_bg(ui, &resp, bg_idx, panel_x, theme, is_active);
     resp
+}
+
+/// Bold and italic are real faces rather than a colour swap, but only the
+/// terminal font registers them — an emphasized span at a proportional site
+/// keeps the weight and shifts family rather than losing the weight.
+fn emphasis_family(e: &TextEmphasis, base: &egui::FontFamily) -> egui::FontFamily {
+    match (e.bold, e.italic) {
+        (true, true) => egui::FontFamily::Name(crate::fonts::BOLD_ITALIC_FAMILY.into()),
+        (true, false) => egui::FontFamily::Name(crate::fonts::BOLD_FAMILY.into()),
+        (false, true) => egui::FontFamily::Name(crate::fonts::ITALIC_FAMILY.into()),
+        (false, false) => base.clone(),
+    }
+}
+
+/// Paint a path as one truncating label.
+///
+/// `Zed` needs two differently-formatted spans, and one `LayoutJob` is the
+/// only way to get them without an `item_spacing` gap between two labels, a
+/// second response competing for the row's click, and a filename that can
+/// overflow the width `row_with_trailing` is managing.  Putting the filename
+/// first only *prioritizes* it: epaint truncates the tail of one linear glyph
+/// stream, so a row narrower than the filename still elides it.
+fn path_label(
+    ui: &mut egui::Ui,
+    path: &str,
+    base: Color32,
+    theme: &Theme,
+    style: PathStyle,
+    family: egui::FontFamily,
+    home: Option<&str>,
+) {
+    if style != PathStyle::Zed {
+        ui.add(
+            egui::Label::new(
+                RichText::new(path_style::render(path, style, home))
+                    .color(base)
+                    .family(family)
+                    .small(),
+            )
+            .truncate()
+            .selectable(false),
+        );
+        return;
+    }
+
+    let size = egui::TextStyle::Small.resolve(ui.style()).size;
+    // A hand-built job does not inherit the ui's text valign the way RichText
+    // does, so it must be carried across or the path sits off-centre against
+    // the change glyph beside it.
+    let valign = ui.text_valign();
+    let parts = path_style::split(path, style, home);
+    let mut job = egui::text::LayoutJob::default();
+    let mut push = |text: String, e: &TextEmphasis| {
+        if text.is_empty() {
+            return;
+        }
+        job.append(
+            &text,
+            0.0,
+            egui::TextFormat {
+                font_id: egui::FontId::new(size, emphasis_family(e, &family)),
+                color: e.color.unwrap_or(base),
+                valign,
+                ..Default::default()
+            },
+        );
+    };
+    if parts.parent.is_empty() {
+        push(format!("{}{}", parts.root, parts.name), &theme.path_style.filename);
+    } else {
+        push(parts.name.clone(), &theme.path_style.filename);
+        push(format!(" {}{}", parts.root, parts.parent), &theme.path_style.parent);
+    }
+    ui.add(egui::Label::new(job).truncate().selectable(false));
 }
 
 /// Extend a row's bounding rect to its parent's full width so the response
@@ -7783,5 +7844,53 @@ mod tests {
             Some("/home/lev"),
         );
         assert_eq!(shown, "~/G/monorepo");
+    }
+
+    /// Every emphasis combination must resolve to a registered face; falling back
+    /// to the base family for, say, bold-italic would silently drop the weight.
+    /// An unemphasized span keeps whatever family the site already paints in.
+    #[test]
+    fn emphasis_resolves_to_the_registered_faces() {
+        let plain = TextEmphasis::default();
+        let bold = TextEmphasis { bold: true, ..Default::default() };
+        let italic = TextEmphasis { italic: true, ..Default::default() };
+        let both = TextEmphasis { bold: true, italic: true, ..Default::default() };
+
+        for base in [egui::FontFamily::Monospace, egui::FontFamily::Proportional] {
+            assert_eq!(emphasis_family(&plain, &base), base);
+            assert_eq!(
+                emphasis_family(&bold, &base),
+                egui::FontFamily::Name(crate::fonts::BOLD_FAMILY.into())
+            );
+            assert_eq!(
+                emphasis_family(&italic, &base),
+                egui::FontFamily::Name(crate::fonts::ITALIC_FAMILY.into())
+            );
+            assert_eq!(
+                emphasis_family(&both, &base),
+                egui::FontFamily::Name(crate::fonts::BOLD_ITALIC_FAMILY.into())
+            );
+        }
+    }
+
+    /// The job's two spans must reassemble into exactly what `render` produces,
+    /// so the emphasis only changes how the text looks, never what it says.
+    #[test]
+    fn the_zed_job_spells_the_same_text_as_render() {
+        for (path, home) in [
+            ("path/to/file.txt", None),
+            ("/a/b/c.txt", None),
+            ("f.txt", None),
+            ("/f.txt", None),
+            ("/home/lev/Git/x/y.rs", Some("/home/lev")),
+        ] {
+            let parts = crate::path_style::split(path, PathStyle::Zed, home);
+            let spans = if parts.parent.is_empty() {
+                format!("{}{}", parts.root, parts.name)
+            } else {
+                format!("{} {}{}", parts.name, parts.root, parts.parent)
+            };
+            assert_eq!(spans, crate::path_style::render(path, PathStyle::Zed, home), "{path:?}");
+        }
     }
 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -7172,6 +7172,7 @@ mod tests {
                 .collect(),
             expanded: true,
             shell_override: None,
+            home: None,
         }
     }
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -3288,9 +3288,7 @@ impl AlacritreeApp {
 
                     ui.add(
                         egui::Label::new(
-                            RichText::new(path.display().to_string())
-                                .color(theme.text_muted)
-                                .small(),
+                            RichText::new(wsl::display_path(&path)).color(theme.text_muted).small(),
                         )
                         .truncate(),
                     );
@@ -5773,7 +5771,7 @@ impl AlacritreeApp {
             items.push(PaletteItem::create_worktree(
                 project.root.clone(),
                 format!("{}: new worktree", project.display_name()),
-                format!("project · {}", project.root.display()),
+                format!("project · {}", wsl::display_path(&project.root)),
             ));
         }
         items
@@ -5794,14 +5792,14 @@ impl AlacritreeApp {
         }
         path.file_name()
             .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| path.display().to_string())
+            .unwrap_or_else(|| wsl::display_path(path))
     }
 
     /// The (primary, secondary) a workspace palette row shows.
     fn workspace_entry_label(&self, ws: &WorkspaceKey) -> (String, String) {
         let secondary = match ws {
             None => "workspace · home".to_string(),
-            Some(path) => format!("workspace · {}", path.display()),
+            Some(path) => format!("workspace · {}", wsl::display_path(path)),
         };
         (self.workspace_label(ws), secondary)
     }
@@ -6027,7 +6025,7 @@ impl AlacritreeApp {
                     .worktree
                     .file_name()
                     .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| picker.worktree.display().to_string());
+                    .unwrap_or_else(|| wsl::display_path(&picker.worktree));
                 ui.label(
                     RichText::new(format!("Base branch for `{name}`")).color(theme.text).strong(),
                 );

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -14,13 +14,18 @@ use crate::bindings::{self, BindingAction, KeyBinding, NamedAction};
 use crate::clipboard::{self, Target};
 use crate::colors::rgb_to_color32;
 use crate::command_palette::{self, CommandPalette, PaletteAction, PaletteItem};
-use crate::config::{Config, FontConfig, Icons, LastSessionClose, ScrollbarStyle, UiFont};
+use crate::config::{
+    Config, FontConfig, Icons, LastSessionClose, PathStyleConfig, ScrollbarStyle, UiFont,
+};
 use crate::doppler;
 use crate::git_nav::{self, GitSection, SectionCount};
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, GitStatus, StatusCache};
 use crate::ipc;
 use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
+use crate::path_style;
+#[cfg(test)]
+use crate::path_style::PathStyle;
 use crate::pr_status::{PrCache, PrInfo, PrState};
 use crate::projects::{Discovered, Project, Worktree, project_json};
 use crate::scratchpad;
@@ -83,6 +88,9 @@ struct Theme {
     /// existing layout proportions.
     ui_scale: f32,
     focus_outline: FocusOutlineTheme,
+    /// Per-site path abbreviation, so free-standing row painters can spell a
+    /// path without taking a `&Config`.
+    path_style: PathStyleConfig,
 }
 
 /// Logical-pixel (normal, heading) sizes for UI text.  `[ui.font] size`
@@ -135,6 +143,7 @@ impl Theme {
                 color: config.ui.focus_outline.color.unwrap_or(accent),
                 thickness: config.ui.focus_outline.thickness,
             },
+            path_style: config.ui.path_style,
         }
     }
 }
@@ -3119,6 +3128,20 @@ impl AlacritreeApp {
         self.current_workspace.clone()
     }
 
+    /// The home directory a workspace path should collapse to.  A WSL path's
+    /// home lives inside the distro and is only known through discovery, so a
+    /// project that has not finished discovering yet simply gets no `~`.
+    fn workspace_home(&self, path: &Path) -> Option<String> {
+        match wsl::classify(path) {
+            wsl::Location::Wsl { .. } => self
+                .projects
+                .iter()
+                .find(|p| p.worktrees.iter().any(|w| w.path == path))
+                .and_then(|p| p.home.clone()),
+            wsl::Location::Windows(_) => home::home_dir().map(|h| h.display().to_string()),
+        }
+    }
+
     fn project_default_branch_for(&self, path: &Path) -> Option<String> {
         for project in &self.projects {
             for wt in &project.worktrees {
@@ -3205,6 +3228,7 @@ impl AlacritreeApp {
                         return;
                     },
                 };
+                let workspace_home = self.workspace_home(&path);
 
                 let project_default = self.project_default_branch_for(&path);
                 let cache = self
@@ -3288,7 +3312,13 @@ impl AlacritreeApp {
 
                     ui.add(
                         egui::Label::new(
-                            RichText::new(wsl::display_path(&path)).color(theme.text_muted).small(),
+                            RichText::new(path_style::render(
+                                &wsl::display_path(&path),
+                                theme.path_style.git_header,
+                                workspace_home.as_deref(),
+                            ))
+                            .color(theme.text_muted)
+                            .small(),
                         )
                         .truncate(),
                     );
@@ -3532,7 +3562,10 @@ impl AlacritreeApp {
                 build_diff_command(delta_override.as_deref().unwrap_or("delta"), &req)
             },
         };
-        let title = format!("diff: {}", req.file);
+        let title = format!(
+            "diff: {}",
+            path_style::render(&req.file, self.config.ui.path_style.diff_title, None)
+        );
         match Session::spawn_command(
             ctx.clone(),
             &self.config,
@@ -4201,7 +4234,14 @@ fn file_row(
                 );
                 ui.add(
                     egui::Label::new(
-                        RichText::new(&change.path).color(path_color).monospace().small(),
+                        RichText::new(path_style::render(
+                            &change.path,
+                            theme.path_style.git_rows,
+                            None,
+                        ))
+                        .color(path_color)
+                        .monospace()
+                        .small(),
                     )
                     .truncate()
                     .selectable(false),
@@ -4269,7 +4309,14 @@ fn branch_diff_row(
                             ui.set_min_height(row_h);
                             ui.add(
                                 egui::Label::new(
-                                    RichText::new(&stat.path).color(path_color).monospace().small(),
+                                    RichText::new(path_style::render(
+                                        &stat.path,
+                                        theme.path_style.git_rows,
+                                        None,
+                                    ))
+                                    .color(path_color)
+                                    .monospace()
+                                    .small(),
                                 )
                                 .truncate()
                                 .selectable(false),
@@ -7707,5 +7754,34 @@ mod tests {
         assert_eq!(base_branch_target(false, None, none, &Some(wt.clone())), Some(wt));
         let none2 = |_id: SessionId| -> Option<WorkspaceKey> { None };
         assert_eq!(base_branch_target(false, None, none2, &None), None, "home has no base branch");
+    }
+
+    /// The row painters are free functions that only ever see a `Theme`, so the
+    /// configured style has to survive the trip through it.
+    #[test]
+    fn the_theme_carries_the_configured_path_style() {
+        let mut config = Config::default();
+        config.ui.path_style.git_rows = PathStyle::Fish;
+        config.ui.path_style.filename.bold = true;
+
+        let theme = Theme::from_config(&config);
+        assert_eq!(theme.path_style.git_rows, PathStyle::Fish);
+        assert_eq!(theme.path_style.git_header, PathStyle::Full);
+        assert!(theme.path_style.filename.bold);
+    }
+
+    /// The header is the one site whose path is absolute, so it is the one that
+    /// must convert before it abbreviates: fish-abbreviating the UNC spelling
+    /// would produce `\\w\k\h\l\monorepo` instead of `~/G/monorepo`.
+    #[cfg(windows)]
+    #[test]
+    fn the_git_header_converts_before_it_abbreviates() {
+        let unc = std::path::Path::new(r"\\wsl.localhost\kali-linux\home\lev\Git\monorepo");
+        let shown = crate::path_style::render(
+            &crate::wsl::display_path(unc),
+            crate::path_style::PathStyle::Fish,
+            Some("/home/lev"),
+        );
+        assert_eq!(shown, "~/G/monorepo");
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -22,6 +22,7 @@ use egui::Color32;
 use serde::Deserialize;
 
 use crate::bindings::{self, KeyBinding};
+use crate::path_style::PathStyle;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -269,6 +270,27 @@ fn parse_scrollbar(raw: Option<&str>) -> ScrollbarStyle {
     }
 }
 
+fn parse_path_style(raw: Option<&str>) -> PathStyle {
+    match raw {
+        None => PathStyle::default(),
+        Some("full") => PathStyle::Full,
+        Some("fish") => PathStyle::Fish,
+        Some("zed") => PathStyle::Zed,
+        Some(other) => {
+            log::warn!("unknown ui.path_style value {other:?}, using \"full\"");
+            PathStyle::default()
+        },
+    }
+}
+
+fn text_emphasis(raw: &RawTextEmphasis) -> TextEmphasis {
+    TextEmphasis {
+        color: raw.color.map(|v| rgb_to_color32(v.0)),
+        bold: raw.bold.unwrap_or(false),
+        italic: raw.italic.unwrap_or(false),
+    }
+}
+
 /// Text-presentation magnifier (U+2315).  Not in egui's bundled fonts; it
 /// resolves through the system fallback chain `fonts.rs` registers.
 const DEFAULT_SEARCH_ICON: &str = "⌕";
@@ -376,6 +398,31 @@ impl Default for Icons {
     }
 }
 
+/// How one text span is emphasized.  `color: None` inherits whatever color the
+/// site normally paints, so an emphasis that sets only `bold` still tracks the
+/// theme.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct TextEmphasis {
+    pub color: Option<Color32>,
+    pub bold: bool,
+    pub italic: bool,
+}
+
+/// `[ui.path_style]`: how each site spells a path, plus the two emphases the
+/// `Zed` style paints with.  Every field defaults to today's rendering.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PathStyleConfig {
+    /// The `diff: <path>` pane title.
+    pub diff_title: PathStyle,
+    /// Staged / Unstaged / Changes-vs file rows in the git panel.
+    pub git_rows: PathStyle,
+    /// The workspace path atop the git panel.
+    pub git_header: PathStyle,
+    /// `Zed` style only, and only at the two egui sites.
+    pub filename: TextEmphasis,
+    pub parent: TextEmphasis,
+}
+
 #[derive(Debug, Clone)]
 pub struct UiTheme {
     pub sidebar_background: Option<Color32>,
@@ -416,6 +463,9 @@ pub struct UiTheme {
     /// `[ui] project_name`: template for project row labels (`$name`, `$path`).
     /// A manual rename (`Project.label`) always wins over the template.
     pub project_name: Option<String>,
+    /// `[ui.path_style]`: per-site path abbreviation.  All `Full` by default,
+    /// which renders every path byte-for-byte as it does today.
+    pub path_style: PathStyleConfig,
 }
 
 impl Default for UiTheme {
@@ -437,6 +487,7 @@ impl Default for UiTheme {
             sidebar_click_focus: false,
             worktree_name: None,
             project_name: None,
+            path_style: PathStyleConfig::default(),
         }
     }
 }
@@ -1088,6 +1139,26 @@ struct RawUi {
     focus_outline: RawFocusOutline,
     /// Clicking a sidebar moves keyboard focus to it.  Default false.
     sidebar_click_focus: Option<bool>,
+    path_style: RawPathStyle,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RawPathStyle {
+    /// "full" (default) | "fish" | "zed", per site.
+    diff_title: Option<String>,
+    git_rows: Option<String>,
+    git_header: Option<String>,
+    filename: RawTextEmphasis,
+    parent: RawTextEmphasis,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RawTextEmphasis {
+    color: Option<RgbStr>,
+    bold: Option<bool>,
+    italic: Option<bool>,
 }
 
 /// One `[[ui.profiles]]` entry.  Fields are optional so a malformed entry
@@ -1231,6 +1302,13 @@ impl RawConfig {
             sidebar_click_focus: self.ui.sidebar_click_focus.unwrap_or(false),
             worktree_name: self.ui.worktree_name.clone().filter(|t| !t.trim().is_empty()),
             project_name: self.ui.project_name.clone().filter(|t| !t.trim().is_empty()),
+            path_style: PathStyleConfig {
+                diff_title: parse_path_style(self.ui.path_style.diff_title.as_deref()),
+                git_rows: parse_path_style(self.ui.path_style.git_rows.as_deref()),
+                git_header: parse_path_style(self.ui.path_style.git_header.as_deref()),
+                filename: text_emphasis(&self.ui.path_style.filename),
+                parent: text_emphasis(&self.ui.path_style.parent),
+            },
         };
 
         // ---- Font ----
@@ -1516,6 +1594,49 @@ mod tests {
         // A blank override is treated as unset so discovery still runs.
         let raw: RawConfig = toml::from_str("[ui]\ndelta_path = \"  \"").unwrap();
         assert_eq!(raw.into_config().delta_path, None);
+    }
+
+    #[test]
+    fn path_style_defaults_to_full_everywhere() {
+        let ui = ui_from_toml("");
+        assert_eq!(ui.path_style.diff_title, PathStyle::Full);
+        assert_eq!(ui.path_style.git_rows, PathStyle::Full);
+        assert_eq!(ui.path_style.git_header, PathStyle::Full);
+        assert_eq!(ui.path_style.filename, TextEmphasis::default());
+        assert_eq!(ui.path_style.parent, TextEmphasis::default());
+    }
+
+    #[test]
+    fn path_style_parses_per_site_and_falls_back_on_nonsense() {
+        let ui = ui_from_toml("[ui.path_style]\ndiff_title = \"zed\"\ngit_rows = \"fish\"");
+        assert_eq!(ui.path_style.diff_title, PathStyle::Zed);
+        assert_eq!(ui.path_style.git_rows, PathStyle::Fish);
+        // An omitted key is not an error, it is "full".
+        assert_eq!(ui.path_style.git_header, PathStyle::Full);
+
+        let ui = ui_from_toml("[ui.path_style]\ngit_header = \"zeb\"");
+        assert_eq!(ui.path_style.git_header, PathStyle::Full);
+    }
+
+    #[test]
+    fn path_style_emphasis_parses_and_a_blank_color_is_an_error() {
+        let ui = ui_from_toml(
+            "[ui.path_style.filename]\ncolor = \"#e6e6e6\"\nbold = true\n\
+             [ui.path_style.parent]\nitalic = true\n",
+        );
+        assert_eq!(ui.path_style.filename.color, Some(Color32::from_rgb(0xe6, 0xe6, 0xe6)));
+        assert!(ui.path_style.filename.bold);
+        assert!(!ui.path_style.filename.italic);
+        assert_eq!(ui.path_style.parent.color, None);
+        assert!(ui.path_style.parent.italic);
+
+        // `RgbStr` rejects a blank string and a raw-schema error discards the
+        // whole merged config, so an empty color is a mistake to fix, not a way
+        // to say "absent" — omit the key instead.
+        let value: toml::Value =
+            toml::from_str("[ui.path_style.filename]\ncolor = \"\"").expect("valid toml");
+        let raw: Result<RawConfig, _> = value.try_into();
+        assert!(raw.is_err(), "a blank color must not parse as absent");
     }
 
     #[test]

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -24,6 +24,7 @@ mod mouse;
 mod notify_macos;
 mod panel_filter;
 mod paste;
+mod path_style;
 mod pr_status;
 mod projects;
 mod row_label;

--- a/alacritree/src/path_style.rs
+++ b/alacritree/src/path_style.rs
@@ -1,0 +1,353 @@
+//! Abbreviated path rendering for sidebar rows and pane titles.
+//!
+//! Pure and egui-free so the table below can be unit-tested without a `Ui`,
+//! and so the caller decides what counts as `home` — a WSL path's home lives
+//! inside the distro and cannot be inferred from the path.
+
+/// How a path is spelled to the user.  `Full` is the identity and the
+/// default, so an unmodified config renders exactly what it renders today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PathStyle {
+    #[default]
+    Full,
+    /// Every parent segment collapses to its first character, fish-style.
+    Fish,
+    /// The filename leads, the parent trails it.
+    Zed,
+}
+
+/// A path cut where it may be abbreviated.  `root` is never abbreviated and
+/// never reordered; `parent` keeps its trailing separator, and is empty for a
+/// bare name.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Parts {
+    pub root: String,
+    pub parent: String,
+    pub name: String,
+}
+
+pub fn split(path: &str, style: PathStyle, home: Option<&str>) -> Parts {
+    let (root, rest, sep) = split_root(path);
+    let collapsed = match style {
+        PathStyle::Full => None,
+        _ => home.and_then(|home| strip_home(path, home, sep)),
+    };
+    let (root, segments) = match collapsed {
+        // `~` replaces the root as well as the leading segments, so a
+        // collapsed path carries no root of its own.
+        Some(tail) => {
+            let mut segments = vec!["~".to_string()];
+            segments.extend(segments_of(tail, sep));
+            (String::new(), segments)
+        },
+        None => (root, segments_of(rest, sep)),
+    };
+
+    let name = segments.last().cloned().unwrap_or_default();
+    let mut parent = String::new();
+    for segment in &segments[..segments.len().saturating_sub(1)] {
+        parent.push_str(&abbreviate(segment, style));
+        parent.push(sep);
+    }
+    Parts { root, parent, name }
+}
+
+pub fn render(path: &str, style: PathStyle, home: Option<&str>) -> String {
+    if style == PathStyle::Full {
+        return path.to_string();
+    }
+    let parts = split(path, style, home);
+    match style {
+        PathStyle::Full => unreachable!("returned above"),
+        PathStyle::Fish => format!("{}{}{}", parts.root, parts.parent, parts.name),
+        PathStyle::Zed if parts.parent.is_empty() => format!("{}{}", parts.root, parts.name),
+        PathStyle::Zed => format!("{} {}{}", parts.name, parts.root, parts.parent),
+    }
+}
+
+/// The root token, the remainder, and the separator the root implies.
+///
+/// Matched by prefix and in this order, because `\` and `:` are legal inside
+/// a Unix filename: scanning for separator characters would misread
+/// `dir/name\part.txt` as a Windows path.
+fn split_root(path: &str) -> (String, &str, char) {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        return match segments_len(rest, 2) {
+            Some(len) => (path[..r"\\?\UNC\".len() + len].to_string(), &rest[len..], '\\'),
+            None => (path.to_string(), "", '\\'),
+        };
+    }
+    if let Some(rest) = path.strip_prefix(r"\\?\") {
+        if let Some(len) = drive_root_len(rest) {
+            return (path[..r"\\?\".len() + len].to_string(), &rest[len..], '\\');
+        }
+    }
+    if let Some(rest) = path.strip_prefix(r"\\") {
+        return match segments_len(rest, 2) {
+            Some(len) => (path[..2 + len].to_string(), &rest[len..], '\\'),
+            None => (path.to_string(), "", '\\'),
+        };
+    }
+    if let Some(len) = drive_root_len(path) {
+        // Normalize `C:/` to `C:\`: a drive path is re-joined with backslashes.
+        return (format!("{}:\\", &path[..1]), &path[len..], '\\');
+    }
+    if is_drive_relative(path) {
+        // `C:foo` is relative to the drive's current directory, so no
+        // separator may be inserted after the root.
+        return (path[..2].to_string(), &path[2..], '\\');
+    }
+    if let Some(rest) = path.strip_prefix('/') {
+        return ("/".to_string(), rest, '/');
+    }
+    (String::new(), path, '/')
+}
+
+/// Byte length of `<letter>:<sep>`, or `None` when `s` does not start with one.
+fn drive_root_len(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let is_drive = bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/');
+    is_drive.then_some(3)
+}
+
+fn is_drive_relative(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+/// Byte offset past `n` `\`-separated segments *and* the separator closing the
+/// last one.  `None` when the string runs out first, which means the whole
+/// input is root and there is nothing beneath it.
+fn segments_len(s: &str, n: usize) -> Option<usize> {
+    let mut idx = 0;
+    for _ in 0..n {
+        idx += s[idx..].find('\\')? + 1;
+    }
+    Some(idx)
+}
+
+/// Windows paths are split on either separator; POSIX paths only on `/`, so a
+/// Unix filename containing `\` survives intact.
+fn segments_of(rest: &str, sep: char) -> Vec<String> {
+    let split_on = |c: char| c == sep || (sep == '\\' && c == '/');
+    rest.split(split_on).filter(|s| !s.is_empty()).map(str::to_string).collect()
+}
+
+/// The part of `path` beneath `home`, or `None` when it is not beneath it.
+/// An exact match yields `""` — the path *is* home.
+fn strip_home<'a>(path: &'a str, home: &str, sep: char) -> Option<&'a str> {
+    // A home that is nothing but separators would collapse every absolute
+    // path to `~`, which reads as a bug rather than as a shortening.  `/` is
+    // no one's home directory; root's is `/root`.
+    let home = home.trim_end_matches(['/', '\\']);
+    if home.is_empty() {
+        return None;
+    }
+    // A Windows filesystem is case-insensitive and accepts both separators;
+    // a Unix one is neither, and `/Home` is a different directory.
+    let same = |a: &str, b: &str| {
+        if sep == '\\' { normalize_windows(a) == normalize_windows(b) } else { a == b }
+    };
+    if same(path, home) {
+        return Some("");
+    }
+    let (head, tail) = path.split_at_checked(home.len())?;
+    if !same(head, home) {
+        return None;
+    }
+    let first = tail.chars().next()?;
+    (first == sep || (sep == '\\' && first == '/')).then(|| &tail[first.len_utf8()..])
+}
+
+/// Full Unicode lowering, not `to_ascii_lowercase`: NTFS folds case beyond
+/// ASCII, so a home under `C:\Üsers` must still match `c:\üsers`.
+fn normalize_windows(s: &str) -> String {
+    s.replace('/', "\\").to_lowercase()
+}
+
+/// Fish keeps enough of a segment to still recognize it: the first character,
+/// plus one more when that character is a dot, so `.config` reads `.c`.
+fn abbreviate(segment: &str, style: PathStyle) -> String {
+    if style != PathStyle::Fish || segment == "~" {
+        return segment.to_string();
+    }
+    let mut chars = segment.chars();
+    let mut out = String::new();
+    if let Some(first) = chars.next() {
+        out.push(first);
+        if first == '.' {
+            out.extend(chars.next());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The identity guarantee: an unmodified config renders every path
+    /// byte-for-byte, home directory included.
+    #[test]
+    fn full_is_the_identity() {
+        let home = Some("/home/lev");
+        for path in [
+            "",
+            "/",
+            "src/app.rs",
+            "/home/lev/Git/x/y.rs",
+            r"C:\Program Files\Git",
+            r"C:",
+            r"C:foo\bar",
+            r"\\server\share\x",
+            r"\\wsl.localhost\kali-linux\home\lev",
+            r"\\?\UNC\wsl.localhost\kali-linux\home\lev",
+            r"\\?\C:\Users\Lev",
+            r"dir/name\part.txt",
+            "a/b/",
+        ] {
+            assert_eq!(render(path, PathStyle::Full, home), path, "Full changed {path:?}");
+            assert_eq!(render(path, PathStyle::Full, None), path, "Full changed {path:?}");
+        }
+    }
+
+    #[test]
+    fn split_recognizes_roots_before_separators() {
+        let cases: &[(&str, (&str, &str, &str))] = &[
+            ("", ("", "", "")),
+            ("/", ("/", "", "")),
+            (r"C:\", (r"C:\", "", "")),
+            ("C:", ("C:", "", "")),
+            ("C:foo", ("C:", "", "foo")),
+            (r"C:foo\bar", ("C:", r"f\", "bar")),
+            ("f.txt", ("", "", "f.txt")),
+            ("/f.txt", ("/", "", "f.txt")),
+            ("a/b/", ("", "a/", "b")),
+            (r"C:\Program Files\Git", (r"C:\", r"P\", "Git")),
+            (r"\\server\share\a\b.txt", (r"\\server\share\", r"a\", "b.txt")),
+            (
+                r"\\wsl.localhost\kali-linux\home\lev\x.rs",
+                (r"\\wsl.localhost\kali-linux\", r"h\l\", "x.rs"),
+            ),
+            (r"\\?\C:\Users\Lev\x", (r"\\?\C:\", r"U\L\", "x")),
+            (r"\\?\UNC\server\share\a\b", (r"\\?\UNC\server\share\", r"a\", "b")),
+        ];
+        for (input, (root, parent, name)) in cases {
+            let parts = split(input, PathStyle::Fish, None);
+            assert_eq!(
+                (parts.root.as_str(), parts.parent.as_str(), parts.name.as_str()),
+                (*root, *parent, *name),
+                "split({input:?})"
+            );
+        }
+    }
+
+    /// Backslash and `:` are legal in a Unix filename, so a path that does
+    /// not match a Windows root prefix must split only on `/`.
+    #[test]
+    fn a_unix_filename_may_contain_a_backslash_or_colon() {
+        let parts = split(r"dir/name\part.txt", PathStyle::Fish, None);
+        assert_eq!(parts.root, "");
+        assert_eq!(parts.parent, "d/");
+        assert_eq!(parts.name, r"name\part.txt");
+
+        let parts = split(r"dir/name:\part", PathStyle::Fish, None);
+        assert_eq!(parts.name, r"name:\part");
+    }
+
+    /// Windows paths spelled with forward slashes split on either separator
+    /// and re-join with a backslash.
+    #[test]
+    fn a_drive_path_accepts_forward_slashes() {
+        assert_eq!(render("C:/Users/Lev/x.rs", PathStyle::Fish, None), r"C:\U\L\x.rs");
+    }
+
+    #[test]
+    fn fish_abbreviates_parents_and_keeps_a_leading_dot() {
+        assert_eq!(render("path/to/file.txt", PathStyle::Fish, None), "p/t/file.txt");
+        assert_eq!(render("/a/.config/nvim/init.lua", PathStyle::Fish, None), "/a/.c/n/init.lua");
+        assert_eq!(render("f.txt", PathStyle::Fish, None), "f.txt");
+        assert_eq!(render("/", PathStyle::Fish, None), "/");
+        assert_eq!(render("", PathStyle::Fish, None), "");
+    }
+
+    /// Zed gets the same input classes as Fish — drive-relative, UNC, dotted,
+    /// trailing separator, empty, root-only — because the reorder is where a
+    /// root can most easily be dropped or duplicated.
+    #[test]
+    fn zed_swaps_the_name_ahead_of_the_parent_and_keeps_the_root() {
+        assert_eq!(render("path/to/file.txt", PathStyle::Zed, None), "file.txt path/to/");
+        assert_eq!(render("/a/b/c.txt", PathStyle::Zed, None), "c.txt /a/b/");
+        // No parent: the bare name, no trailing space — but the root stays.
+        assert_eq!(render("f.txt", PathStyle::Zed, None), "f.txt");
+        assert_eq!(render("/f.txt", PathStyle::Zed, None), "/f.txt");
+        assert_eq!(render(r"C:\f.txt", PathStyle::Zed, None), r"C:\f.txt");
+        assert_eq!(render("", PathStyle::Zed, None), "");
+        assert_eq!(render("/", PathStyle::Zed, None), "/");
+        assert_eq!(render("C:", PathStyle::Zed, None), "C:");
+        // Drive-relative: no separator may appear after the root.
+        assert_eq!(render(r"C:foo\bar", PathStyle::Zed, None), r"bar C:foo\");
+        assert_eq!(render("a/b/", PathStyle::Zed, None), "b a/");
+        assert_eq!(render("/a/.config/init.lua", PathStyle::Zed, None), "init.lua /a/.config/");
+        assert_eq!(
+            render(r"\\wsl.localhost\kali-linux\home\lev\x.rs", PathStyle::Zed, None),
+            r"x.rs \\wsl.localhost\kali-linux\home\lev\"
+        );
+    }
+
+    #[test]
+    fn home_collapses_for_fish_and_zed_only() {
+        let home = Some("/home/lev");
+        assert_eq!(render("/home/lev/Git/x/y.rs", PathStyle::Fish, home), "~/G/x/y.rs");
+        assert_eq!(render("/home/lev/Git/x/y.rs", PathStyle::Zed, home), "y.rs ~/Git/x/");
+        assert_eq!(render("/home/lev", PathStyle::Fish, home), "~");
+        assert_eq!(render("/home/lev/Git/x/y.rs", PathStyle::Full, home), "/home/lev/Git/x/y.rs");
+        // A sibling directory whose name merely starts with the home prefix
+        // is not inside it.
+        assert_eq!(render("/home/levi/x.rs", PathStyle::Fish, home), "/h/l/x.rs");
+        // No home, no guess.
+        assert_eq!(render("/home/lev/Git/y.rs", PathStyle::Fish, None), "/h/l/G/y.rs");
+    }
+
+    #[test]
+    fn home_matching_is_case_and_separator_insensitive_on_windows_paths() {
+        let home = Some(r"C:\Users\Lev");
+        assert_eq!(render(r"c:\users\lev\Git\y.rs", PathStyle::Fish, home), r"~\G\y.rs");
+        assert_eq!(render("C:/Users/Lev/Git/y.rs", PathStyle::Fish, home), r"~\G\y.rs");
+        // NTFS folds case past ASCII, so `to_ascii_lowercase` is not enough.
+        assert_eq!(
+            render(r"c:\üsers\lev\Git\y.rs", PathStyle::Fish, Some(r"C:\Üsers\Lev")),
+            r"~\G\y.rs"
+        );
+        // POSIX paths compare exactly — case matters on a Unix filesystem.
+        assert_eq!(render("/HOME/LEV/y.rs", PathStyle::Fish, Some("/home/lev")), "/H/L/y.rs");
+        // A home of nothing but separators would collapse every absolute path.
+        assert_eq!(render("/a/b.rs", PathStyle::Fish, Some("/")), "/a/b.rs");
+    }
+
+    /// The distro is the UNC *share*, so it is part of the root and never
+    /// abbreviates away.
+    #[test]
+    fn a_wsl_unc_root_is_never_abbreviated() {
+        assert_eq!(
+            render(r"\\wsl.localhost\kali-linux\home\lev\x.rs", PathStyle::Fish, None),
+            r"\\wsl.localhost\kali-linux\h\l\x.rs"
+        );
+    }
+
+    /// `split_root` and `strip_home` index by byte, and a slice landing mid
+    /// character panics rather than degrading — so a non-ASCII path is not an
+    /// edge case, it is a crash waiting for a user with an accent in a
+    /// directory name.
+    #[test]
+    fn multibyte_paths_do_not_panic() {
+        for path in ["Ä/Ö/ü.rs", "/日本/語/x.rs", "Ä:foo", "日本語", "/Ä", "C:Ä\\ö"] {
+            let _ = render(path, PathStyle::Fish, Some("/日本"));
+            let _ = render(path, PathStyle::Zed, Some("Ä"));
+            let _ = render(path, PathStyle::Fish, None);
+        }
+    }
+}

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -324,7 +324,7 @@ pub fn normalize_label(label: Option<String>) -> Option<String> {
 fn display_name(root: &std::path::Path) -> String {
     root.file_name()
         .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_else(|| root.display().to_string())
+        .unwrap_or_else(|| wsl::display_path(root))
 }
 
 /// Sections: 0 repo-or-not, 1 `worktree list --porcelain -z`,
@@ -500,6 +500,14 @@ mod tests {
         let wt = project.worktrees.iter().find(|w| w.name == "feature").unwrap();
         assert!(!wt.prunable);
         assert_eq!(wt.branch.as_deref(), Some("feature"));
+    }
+
+    /// A distro root has no `file_name()`, so the name falls back to the whole
+    /// path — which must not be the UNC spelling.
+    #[cfg(windows)]
+    #[test]
+    fn a_rootless_path_names_itself_in_the_distros_spelling() {
+        assert_eq!(display_name(std::path::Path::new(r"\\wsl.localhost\kali-linux")), "/");
     }
 
     #[test]

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -20,6 +20,10 @@ pub struct Project {
     pub worktrees: Vec<Worktree>,
     pub expanded: bool,
     pub shell_override: Option<crate::wsl::ShellChoice>,
+    /// The distro's own `$HOME` for a WSL project, so a path can collapse to
+    /// `~` without guessing the prefix from the path itself.  `None` for a
+    /// native project, whose home comes from `home::home_dir()`.
+    pub home: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -115,6 +119,7 @@ impl Project {
             default_branch: None,
             expanded: true,
             shell_override: None,
+            home: None,
         }
     }
 
@@ -163,6 +168,7 @@ impl Project {
                 label: None,
                 expanded: true,
                 shell_override: None,
+                home: Some(text(5)).filter(|h| !h.is_empty()),
             }),
         }
     }
@@ -209,6 +215,7 @@ impl Project {
             label: None,
             expanded: true,
             shell_override: None,
+            home: None,
         }
     }
 
@@ -224,15 +231,17 @@ impl Project {
     }
 
     /// Adopt a discovery result.  A non-authoritative result leaves the
-    /// worktree list and default branch alone: an unreachable backend must not
-    /// read as deletion.  `expanded`, `shell_override`, and `label` are user
-    /// state and are never touched either way.
+    /// discovered fields alone: an unreachable backend must not read as
+    /// deletion.  `expanded`, `shell_override`, and `label` are user state and
+    /// are never touched either way.  One list, so a field cannot be adopted by
+    /// the synchronous refresh and dropped by the background one.
     pub fn apply(&mut self, found: Discovered) {
         if !found.authoritative {
             return;
         }
         self.worktrees = found.project.worktrees;
         self.default_branch = found.project.default_branch;
+        self.home = found.project.home;
     }
 }
 
@@ -329,7 +338,8 @@ fn display_name(root: &std::path::Path) -> String {
 
 /// Sections: 0 repo-or-not, 1 `worktree list --porcelain -z`,
 /// 2 origin/HEAD symref, 3 which common default-branch names exist,
-/// 4 `init.defaultBranch` only if it names an existing branch.
+/// 4 `init.defaultBranch` only if it names an existing branch,
+/// 5 the distro's `$HOME`.
 const DISCOVER_SCRIPT: &str = r#"
 p="$1"
 sep() { printf '\n@@ALACRITREE@@\n'; }
@@ -343,6 +353,8 @@ git -C "$p" for-each-ref --format='%(refname:short)' refs/heads/main refs/heads/
 sep
 cfg=$(git -C "$p" config init.defaultBranch 2>/dev/null)
 if [ -n "$cfg" ] && git -C "$p" rev-parse --verify --quiet "refs/heads/$cfg" >/dev/null 2>&1; then printf '%s' "$cfg"; fi
+sep
+printf '%s' "$HOME"
 "#;
 
 /// One record from `git worktree list --porcelain -z`.  The main worktree is
@@ -578,6 +590,40 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         let bytes = b"worktree /home/lev/my proj\0HEAD abc\0branch refs/heads/main\0\0";
         let records = parse_worktree_list_z(bytes);
         assert_eq!(records[0].path, "/home/lev/my proj");
+    }
+
+    /// `$HOME` rides the existing discovery batch, so its section index must not
+    /// drift from the script.  A blank section means the distro reported nothing
+    /// and there is no home to collapse to.
+    #[test]
+    fn the_discover_script_ends_with_the_home_section() {
+        assert!(
+            DISCOVER_SCRIPT.trim_end().ends_with(r#"printf '%s' "$HOME""#),
+            "the $HOME section must be last so its index stays 5"
+        );
+        assert_eq!(DISCOVER_SCRIPT.matches("\nsep\n").count(), 5, "one sep per section boundary");
+    }
+
+    /// Discovery is adopted through one method by both refresh paths.  Two paths
+    /// each listing fields by hand is what lets a newly discovered field land in
+    /// one and be dropped by the other — and the folder-picker path, which starts
+    /// from a placeholder, is the one that matters most.
+    #[test]
+    fn adopting_a_discovery_keeps_user_state_and_takes_the_rest() {
+        let mut existing = Project::placeholder(PathBuf::from("/repo"));
+        existing.label = Some("Work".to_string());
+        existing.expanded = false;
+
+        let mut fresh = Project::placeholder(PathBuf::from("/repo"));
+        fresh.default_branch = Some("main".to_string());
+        fresh.home = Some("/home/lev".to_string());
+
+        existing.apply(Discovered::found(fresh));
+
+        assert_eq!(existing.home.as_deref(), Some("/home/lev"));
+        assert_eq!(existing.default_branch.as_deref(), Some("main"));
+        assert_eq!(existing.label.as_deref(), Some("Work"), "a rename is user state");
+        assert!(!existing.expanded, "the expand toggle is user state");
     }
 
     #[test]

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -128,6 +128,7 @@ mod tests {
             worktrees: Vec::new(),
             expanded: false,
             shell_override: None,
+            home: None,
         }
     }
 

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -55,7 +55,7 @@ impl LabelTemplates {
         if let Some(branch) = &wt.branch {
             vars.insert("branch".to_string(), branch.clone());
         }
-        vars.insert("path".to_string(), wt.path.display().to_string());
+        vars.insert("path".to_string(), crate::wsl::display_path(&wt.path));
         if let Some(pr) = pr {
             vars.insert("pr".to_string(), format!("#{}", pr.number));
         }
@@ -74,7 +74,7 @@ impl LabelTemplates {
         };
         let mut vars = HashMap::new();
         vars.insert("name".to_string(), project.name.clone());
-        vars.insert("path".to_string(), project.root.display().to_string());
+        vars.insert("path".to_string(), crate::wsl::display_path(&project.root));
         self.render_or_fallback("project_name", &template, &vars, &project.name)
     }
 
@@ -102,6 +102,7 @@ impl LabelTemplates {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::projects::Worktree;
     use std::path::PathBuf;
 
     fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
@@ -235,5 +236,21 @@ mod tests {
         let mut t = LabelTemplates::new(Some("$pr $name".into()), None);
         assert_eq!(t.worktree_label(&wt("alpha", None), Some(&pr(7))), "#7 alpha");
         assert_eq!(t.worktree_label(&wt("alpha", None), None), "alpha");
+    }
+
+    /// `$path` is the template's window onto the filesystem, so a WSL worktree
+    /// must substitute the path the user would type inside the distro.
+    #[cfg(windows)]
+    #[test]
+    fn the_path_variable_uses_the_distros_spelling() {
+        let wt = Worktree {
+            name: "monorepo".to_string(),
+            path: PathBuf::from(r"\\wsl.localhost\kali-linux\home\lev\Git\monorepo"),
+            branch: Some("main".to_string()),
+            is_main: true,
+            prunable: false,
+        };
+        let mut templates = LabelTemplates::new(Some("$path".to_string()), None);
+        assert_eq!(templates.worktree_label(&wt, None), "/home/lev/Git/monorepo");
     }
 }

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -1061,6 +1061,9 @@ impl Session {
     /// changes, and child-exits from non-visible sessions don't pile up.
     pub fn drain_events(&mut self, palette: &Palette) -> DrainOutcome {
         let mut outcome = DrainOutcome::default();
+        // Derived rather than stored: a `title_pinned` field set at spawn is a
+        // second source of truth that can drift from `kind`.
+        let title_pinned = matches!(self.kind, SessionKind::Diff { .. });
         while let Ok(event) = self.events.try_recv() {
             match event {
                 // OSC 4 / 10 / 11 / 12.  Programs that ask the terminal for its
@@ -1087,9 +1090,13 @@ impl Session {
                     self.write(reply);
                 },
                 event => {
-                    if let Some(bytes) =
-                        apply_term_event(event, &mut self.title, &mut self.exited, &mut outcome)
-                    {
+                    if let Some(bytes) = apply_term_event(
+                        event,
+                        &mut self.title,
+                        title_pinned,
+                        &mut self.exited,
+                        &mut outcome,
+                    ) {
                         self.write(bytes);
                     }
                 },
@@ -1271,12 +1278,13 @@ impl Drop for Session {
 fn apply_term_event(
     event: TermEvent,
     title: &mut String,
+    pinned: bool,
     exited: &mut bool,
     outcome: &mut DrainOutcome,
 ) -> Option<Vec<u8>> {
     match event {
         TermEvent::PtyWrite(s) => return Some(s.into_bytes()),
-        TermEvent::Title(t) => {
+        TermEvent::Title(t) if !pinned => {
             // A spinner-shaped title transitioning to a non-spinner one
             // is how Claude Code (and similar tools that don't ring
             // BEL) signal "done — your turn".  Treat it like a bell.
@@ -1440,9 +1448,114 @@ mod tests {
         let mut outcome = DrainOutcome::default();
         let mut title = String::new();
         let mut exited = false;
-        apply_term_event(event, &mut title, &mut exited, &mut outcome);
+        apply_term_event(event, &mut title, false, &mut exited, &mut outcome);
 
         assert_eq!(outcome.clipboard, vec![(Target::Clipboard, "hello".to_owned())]);
+    }
+
+    /// A session whose child has already exited, so nothing more arrives from
+    /// the PTY and an injected sequence is the only event left to drain.  On
+    /// Windows that also consumes ConPTY's own startup title, so the assertions
+    /// below are about *our* sequence rather than racing that one.
+    fn spawn_exited_probe(kind: SessionKind, title: &str) -> Session {
+        #[cfg(windows)]
+        let (program, args) = ("cmd", vec!["/c", "exit"]);
+        #[cfg(not(windows))]
+        let (program, args) = ("sh", vec!["-c", "true"]);
+
+        let mut session = Session::spawn_command(
+            egui::Context::default(),
+            &Config::default(),
+            std::env::current_dir().ok(),
+            TermSize::new(80, 24),
+            (8.0, 16.0),
+            program.to_string(),
+            args.into_iter().map(str::to_string).collect(),
+            title.to_string(),
+            kind,
+        )
+        .unwrap();
+
+        // Draining until `ChildExit` is seen consumes everything the child sent:
+        // the loop emits `ChildExit` and then stops reading the PTY, because
+        // `spawn_with` passes `drain_on_exit: false` (`session.rs:866`,
+        // `event_loop.rs:263`).  Only a `Wakeup` can follow, and nothing maps it
+        // to a title.
+        let palette = Palette::default();
+        let start = Instant::now();
+        while !session.is_exited() {
+            assert!(start.elapsed() < Duration::from_secs(10), "child never exited");
+            session.drain_events(&palette);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        session
+    }
+
+    /// Drive a real OSC 0 through the real VT parser into the real drain, the
+    /// way ConPTY delivers its startup title.
+    fn title_after_osc(mut session: Session, osc_title: &str) -> String {
+        let sequence = format!("\x1b]0;{osc_title}\x07");
+        {
+            let mut term = session.term.lock();
+            Processor::<StdSyncHandler>::new().advance(&mut *term, sequence.as_bytes());
+        }
+        session.drain_events(&Palette::default());
+        session.title.clone()
+    }
+
+    /// ConPTY defaults a child's console title to its command line and publishes
+    /// it as OSC 0, so a diff pane on Windows renamed itself after git's exe
+    /// path.  A diff pane's title is set by alacritree and never means to change.
+    #[test]
+    fn a_diff_panes_title_survives_a_title_sequence() {
+        let session =
+            spawn_exited_probe(SessionKind::Diff { key: "probe".to_string() }, "diff: src/app.rs");
+        assert_eq!(
+            title_after_osc(session, r"C:\Program Files\Git\cmd\git"),
+            "diff: src/app.rs",
+            "a diff pane must keep the name alacritree gave it"
+        );
+    }
+
+    /// The pin is scoped to diff panes: a shell's title is the child's to set,
+    /// and that is how editors and agents label their tab.
+    #[test]
+    fn a_shell_still_follows_its_childs_title() {
+        let session = spawn_exited_probe(SessionKind::Shell, "shell");
+        assert_eq!(title_after_osc(session, "nvim src/app.rs"), "nvim src/app.rs");
+    }
+
+    /// Pinning suppresses one event arm, not the drain.  A bell in a diff pane
+    /// still raises attention and a child exit still reaps the pane.
+    #[test]
+    fn a_pinned_session_still_reports_bells_and_exit() {
+        #[cfg(windows)]
+        let exit_status = {
+            use std::os::windows::process::ExitStatusExt;
+            std::process::ExitStatus::from_raw(0)
+        };
+        #[cfg(not(windows))]
+        let exit_status = {
+            use std::os::unix::process::ExitStatusExt;
+            std::process::ExitStatus::from_raw(0)
+        };
+
+        let mut outcome = DrainOutcome::default();
+        let mut title = "diff: src/app.rs".to_string();
+        let mut exited = false;
+
+        apply_term_event(TermEvent::Bell, &mut title, true, &mut exited, &mut outcome);
+        apply_term_event(
+            TermEvent::ChildExit(exit_status),
+            &mut title,
+            true,
+            &mut exited,
+            &mut outcome,
+        );
+
+        assert!(outcome.attention);
+        assert!(exited);
+        assert_eq!(title, "diff: src/app.rs");
     }
 
     /// Zero grace is the config default and must keep the pre-debounce

--- a/alacritree/src/sidebar_nav.rs
+++ b/alacritree/src/sidebar_nav.rs
@@ -210,6 +210,7 @@ mod tests {
                 .collect(),
             expanded,
             shell_override: None,
+            home: None,
         }
     }
 

--- a/alacritree/src/wsl.rs
+++ b/alacritree/src/wsl.rs
@@ -130,6 +130,17 @@ pub fn normalize_root(path: PathBuf) -> PathBuf {
     }
 }
 
+/// How a workspace path should read to the user: WSL workspaces in the
+/// distro's own spelling, native paths untouched.  Not `windows_to_linux`,
+/// which also rewrites `C:\…` into `/mnt/c/…` — correct for handing a path to
+/// git inside a distro, wrong for showing a Windows user their own path.
+pub fn display_path(path: &Path) -> String {
+    match classify(path) {
+        Location::Wsl { linux_path, .. } => linux_path,
+        Location::Windows(_) => path.display().to_string(),
+    }
+}
+
 /// Translate a Windows path to what git inside a distro can resolve:
 /// WSL UNC paths strip to their Linux part; drive paths map under the
 /// automount root; anything else (non-WSL UNC shares) is untranslatable.
@@ -418,6 +429,50 @@ mod tests {
     fn classifies_drive_and_non_wsl_unc_as_windows() {
         assert!(matches!(classify(Path::new(r"C:\Users\Lev")), Location::Windows(_)));
         assert!(matches!(classify(Path::new(r"\\server\share\x")), Location::Windows(_)));
+    }
+
+    /// `classify` is documented to accept the verbatim forms, but only the plain
+    /// prefixes were ever exercised.  `display_path` makes that reachable from
+    /// the UI, so pin it.
+    #[cfg(windows)]
+    #[test]
+    fn classifies_verbatim_unc() {
+        let loc = classify(Path::new(r"\\?\UNC\wsl.localhost\kali-linux\home\lev"));
+        assert_eq!(
+            loc,
+            Location::Wsl { distro: "kali-linux".to_string(), linux_path: "/home/lev".to_string() }
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn display_path_shows_wsl_paths_in_the_distros_spelling() {
+        assert_eq!(
+            display_path(Path::new(r"\\wsl.localhost\kali-linux\home\lev\Git\monorepo")),
+            "/home/lev/Git/monorepo"
+        );
+        assert_eq!(display_path(Path::new(r"\\wsl$\Ubuntu\srv")), "/srv");
+        assert_eq!(
+            display_path(Path::new(r"\\?\UNC\wsl.localhost\kali-linux\home\lev")),
+            "/home/lev"
+        );
+        // A distro root has no segments of its own.
+        assert_eq!(display_path(Path::new(r"\\wsl.localhost\kali-linux")), "/");
+    }
+
+    /// Native paths are the user's own spelling and must survive untouched —
+    /// this is not `windows_to_linux`, which would rewrite `C:\` into `/mnt/c`.
+    #[cfg(windows)]
+    #[test]
+    fn display_path_leaves_windows_paths_alone() {
+        assert_eq!(display_path(Path::new(r"C:\Users\Lev\Git")), r"C:\Users\Lev\Git");
+        assert_eq!(display_path(Path::new(r"\\server\share\x")), r"\\server\share\x");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn display_path_leaves_native_paths_alone() {
+        assert_eq!(display_path(Path::new("/home/lev/Git")), "/home/lev/Git");
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Adds an opt-in path abbreviation style for sidebar and git-panel paths, plus two path-display bug fixes that change default output.

> **Stacked on #138.** The first two commits (`ed57ddba`, `b68df290`) belong to that PR — review from `7a9a1fe3` onward. Rebased on current `master`; merges cleanly.

## Bug fixes (these change default output)

**Diff panes no longer take their title from the terminal.** ConPTY emits an OSC 0 carrying the child's command line, so a diff pane's header could flip to `C:\Program Files\Git\cmd\git …`. Diff panes now pin `diff: <path>` and ignore title sequences; shell sessions still follow their child's title as before.

**WSL workspaces render in Linux spelling.** A worktree under `\\wsl.localhost\<distro>\home\…` now shows as `/home/…` in the sidebar, the git panel header, the command palette and the base-branch picker, instead of the UNC path.

## Feature (opt-in, default inert)

`[ui.path_style]` picks how each site abbreviates a path:

```toml
[ui.path_style]
diff_title = "full"   # default
git_rows   = "fish"   # ~/G/monorepo
git_header = "zed"    # filename first, parent trailing

[ui.path_style.filename]
color = "#e6e6e6"
bold = true

[ui.path_style.parent]
italic = true
```

- `full` — current behavior, the default at every site
- `fish` — fish-shell style, parents shortened to one character (`~/G/monorepo`)
- `zed` — filename first with the parent path after it, each with its own configurable color/bold/italic

Every site defaults to `full` and both emphases default to unset, so an unmodified config renders identically to today. Unknown values log a warning and fall back to `full`.

## Testing

`cargo test -p alacritree` — 507 passed, 2 ignored.

One failure, `session::tests::a_pane_runs_its_child_without_a_console_host_handshake`, is pre-existing and unrelated: it asserts a wall-clock ConPTY spawn budget of ~3s and trips at ~3.1s under full-suite parallel load. It passes in isolation at 0.04s and fails the same way on `master`.

## Not covered by CI

No PTY harness, so these want a manual pass on Windows before merge:

- A diff opened from the git panel reads `diff: <path>` in the pane header, tab tooltip, sidebar session row and command-palette entry — never the `git` command line.
- A WSL worktree's git panel header, command palette and base-branch picker all agree on `/home/…`.
- An unmodified config renders every path exactly as it did before.

## Known gap

Hover tooltips on elided sidebar paths are unreliable on Windows. egui adds a tooltip whenever a galley elides, so this should already work; the leading hypothesis (the clickable row shadowing the label's hover) was refuted in a headless repro. Diagnosing it needs a live GUI session and is not part of this PR.
