### PR TITLE
perf(terminal): cut input latency and output stalls [7]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-user-notifications 0.3.2",
  "png 0.17.16",
+ "polling",
  "rfd",
  "serde",
  "serde_json",

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -70,6 +70,10 @@ tempfile = "3"
 fontconfig = "0.8"
 
 [target.'cfg(windows)'.dependencies]
+# Re-posts the console-pipe readiness that the emulated level mode drops
+# mid-burst (`pty_rearm`).  Must resolve to the same version alacritty_terminal
+# links, or the `Poller` handed to the registration is a different type.
+polling = "3.11"
 # Restricts the DLL search path at startup (`harden_dll_search_path`) and
 # borrows the launching shell's console so the CLI can print
 # (`attach_parent_console`).

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -365,6 +365,7 @@ pub struct AlacritreeApp {
     grid_snapshot: crate::terminal_view::GridSnapshot,
     /// Present only under `ALACRITREE_FRAME_LOG`; `None` is the normal run.
     frame_log: Option<crate::frame_log::FrameLog>,
+    phases: crate::frame_log::Phases,
     /// How much of the frame in progress went to painting the terminal grid,
     /// as opposed to the sidebars and everything else sharing it.
     grid_paint: std::time::Duration,
@@ -689,6 +690,7 @@ impl AlacritreeApp {
             glyph_cache: crate::glyph_cache::GlyphCache::new(),
             grid_snapshot: crate::terminal_view::GridSnapshot::new(),
             frame_log: crate::frame_log::FrameLog::from_env(),
+            phases: crate::frame_log::Phases::new(),
             grid_paint: std::time::Duration::ZERO,
             pending_project_refresh: HashMap::new(),
             wsl_delta_paths: HashMap::new(),
@@ -7100,9 +7102,11 @@ impl eframe::App for AlacritreeApp {
             .as_ref()
             .map(|_| (std::time::Instant::now(), crate::frame_log::output_wait()));
         self.grid_paint = std::time::Duration::ZERO;
+        self.phases.restart();
         self.poll_project_refreshes();
         self.poll_pending_deletes(ctx);
         self.poll_pending_creates(ctx);
+        self.phases.mark("polls");
         let modal_open = self.is_modal_open();
         // Keys pressed mid-composition drive the IME's candidate window,
         // not the app — alacritty's key_input returns early the same way,
@@ -7121,10 +7125,14 @@ impl eframe::App for AlacritreeApp {
                 self.handle_shortcuts(ctx);
             }
         }
+        self.phases.mark("input");
         self.process_notification_actions(ctx);
         self.process_ipc_calls(ctx);
+        self.phases.mark("ipc");
         self.process_session_events(ctx);
+        self.phases.mark("session-events");
         self.reconcile_sidebar_focus(ctx);
+        self.phases.mark("focus");
         let theme = self.theme;
         // GL clear is the sole source of the bg when opacity < 1; painting any
         // panel fill on top would compound the alpha through egui's blend.
@@ -7145,6 +7153,8 @@ impl eframe::App for AlacritreeApp {
             }
         }
 
+        self.phases.mark("projects-sidebar");
+
         if self.show_right_sidebar {
             let r = self.show_git_sidebar(ctx, panel_frame);
             paint_panel_border(ctx, r.left(), r.y_range(), theme.sidebar_border);
@@ -7152,6 +7162,7 @@ impl eframe::App for AlacritreeApp {
                 paint_focus_outline(ctx, r, &theme);
             }
         }
+        self.phases.mark("git-sidebar");
 
         let central = egui::CentralPanel::default()
             .frame(Frame::default().fill(central_fill).inner_margin(Margin::same(0)))
@@ -7230,6 +7241,7 @@ impl eframe::App for AlacritreeApp {
         if theme.focus_outline.terminal && !modal_open && self.focus == PaneFocus::Terminal {
             paint_focus_outline(ctx, central.response.rect, &theme);
         }
+        self.phases.mark("central");
 
         if self.pending_create.is_some() {
             self.show_create_dialog(ctx);
@@ -7258,6 +7270,7 @@ impl eframe::App for AlacritreeApp {
         if self.palette.is_open() && !modal_open {
             self.show_command_palette(ctx);
         }
+        self.phases.mark("dialogs");
 
         self.reap_exited_sessions(ctx);
         // A shell that exited on its own is only removed here, after paint.
@@ -7265,6 +7278,8 @@ impl eframe::App for AlacritreeApp {
         // input; with it, the repair is queued for the frame the repaint
         // request has already scheduled.
         self.reconcile_sidebar_focus(ctx);
+        self.phases.mark("reap");
+        self.phases.report_if_slow();
 
         if let (Some(log), Some((started, waited))) = (self.frame_log.as_mut(), frame_started) {
             log.record(crate::frame_log::Timings {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -982,7 +982,7 @@ impl AlacritreeApp {
             if let Some(idx) =
                 self.projects.iter().position(|p| p.worktrees.iter().any(|w| w.path == path))
             {
-                self.projects[idx].refresh();
+                self.refresh_project(ctx, idx);
             }
             return;
         }
@@ -6920,8 +6920,8 @@ impl AlacritreeApp {
         reply_tx: mpsc::Sender<ipc::IpcResult>,
     ) {
         let Some(idx) = self.projects.iter().position(|p| p.root == root) else {
-            let _ = reply_tx
-                .send(Err(format!("{} is not a project in the sidebar", root.display())));
+            let _ =
+                reply_tx.send(Err(format!("{} is not a project in the sidebar", root.display())));
             return;
         };
         self.refresh_project(ctx, idx);

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -7094,8 +7094,11 @@ impl eframe::App for AlacritreeApp {
         [n(bg.r()), n(bg.g()), n(bg.b()), self.config.window.opacity]
     }
 
-    fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
-        let frame_started = self.frame_log.as_ref().map(|_| std::time::Instant::now());
+    fn update(&mut self, ctx: &Context, frame: &mut eframe::Frame) {
+        let frame_started = self
+            .frame_log
+            .as_ref()
+            .map(|_| (std::time::Instant::now(), crate::frame_log::output_wait()));
         self.grid_paint = std::time::Duration::ZERO;
         self.poll_project_refreshes();
         self.poll_pending_deletes(ctx);
@@ -7263,8 +7266,13 @@ impl eframe::App for AlacritreeApp {
         // request has already scheduled.
         self.reconcile_sidebar_focus(ctx);
 
-        if let (Some(log), Some(started)) = (self.frame_log.as_mut(), frame_started) {
-            log.record(started.elapsed(), self.grid_paint);
+        if let (Some(log), Some((started, waited))) = (self.frame_log.as_mut(), frame_started) {
+            log.record(crate::frame_log::Timings {
+                started,
+                grid: self.grid_paint,
+                cpu: frame.info().cpu_usage.map(std::time::Duration::from_secs_f32),
+                waited,
+            });
         }
     }
 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -7294,6 +7294,7 @@ impl eframe::App for AlacritreeApp {
                 grid: self.grid_paint,
                 cpu: frame.info().cpu_usage.map(std::time::Duration::from_secs_f32),
                 waited,
+                echo: crate::frame_log::echo(),
             });
         }
     }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -363,6 +363,11 @@ pub struct AlacritreeApp {
     /// Scratch buffers the painter copies the visible grid into, so the
     /// terminal lock is released before any shape is built.
     grid_snapshot: crate::terminal_view::GridSnapshot,
+    /// Present only under `ALACRITREE_FRAME_LOG`; `None` is the normal run.
+    frame_log: Option<crate::frame_log::FrameLog>,
+    /// How much of the frame in progress went to painting the terminal grid,
+    /// as opposed to the sidebars and everything else sharing it.
+    grid_paint: std::time::Duration,
     /// In-flight background re-discoveries, keyed by project root.  WSL
     /// discovery shells out to wsl.exe and must never block paint; results
     /// are adopted in `poll_project_refreshes`.
@@ -683,6 +688,8 @@ impl AlacritreeApp {
             ),
             glyph_cache: crate::glyph_cache::GlyphCache::new(),
             grid_snapshot: crate::terminal_view::GridSnapshot::new(),
+            frame_log: crate::frame_log::FrameLog::from_env(),
+            grid_paint: std::time::Duration::ZERO,
             pending_project_refresh: HashMap::new(),
             wsl_delta_paths: HashMap::new(),
             pending_delta: HashMap::new(),
@@ -7088,6 +7095,8 @@ impl eframe::App for AlacritreeApp {
     }
 
     fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
+        let frame_started = self.frame_log.as_ref().map(|_| std::time::Instant::now());
+        self.grid_paint = std::time::Duration::ZERO;
         self.poll_project_refreshes();
         self.poll_pending_deletes(ctx);
         self.poll_pending_creates(ctx);
@@ -7191,7 +7200,8 @@ impl eframe::App for AlacritreeApp {
                         editor_error,
                     )
                 } else {
-                    terminal_view::show(
+                    let started = std::time::Instant::now();
+                    let response = terminal_view::show(
                         ui,
                         session,
                         &self.config,
@@ -7201,7 +7211,9 @@ impl eframe::App for AlacritreeApp {
                         &mut self.color_glyphs,
                         &mut self.glyph_cache,
                         &mut self.grid_snapshot,
-                    )
+                    );
+                    self.grid_paint += started.elapsed();
+                    response
                 };
                 // egui fake-clicks the natively focused widget on Space/Enter,
                 // and the terminal keeps native focus while the sidebar owns
@@ -7250,6 +7262,10 @@ impl eframe::App for AlacritreeApp {
         // input; with it, the repair is queued for the frame the repaint
         // request has already scheduled.
         self.reconcile_sidebar_focus(ctx);
+
+        if let (Some(log), Some(started)) = (self.frame_log.as_mut(), frame_started) {
+            log.record(started.elapsed(), self.grid_paint);
+        }
     }
 }
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -5697,6 +5697,9 @@ impl AlacritreeApp {
 
         let grace = self.config.ui.attention_grace;
         for idx in 0..self.sessions.len() {
+            // Window focus is deliberately not part of this: an unfocused
+            // window still shows its grid, so its output still has to repaint.
+            self.sessions[idx].set_visible(Some(idx) == visible_idx);
             let outcome = self.sessions[idx].drain_events(&self.config.palette);
             // Ahead of the attention early-out: a background session copying
             // with OSC 52 still owns the clipboard.

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -359,6 +359,7 @@ pub struct AlacritreeApp {
     builtin_glyphs: crate::builtin_font::BuiltinGlyphCache,
     ime: crate::ime::Ime,
     color_glyphs: crate::color_glyph::ColorGlyphCache,
+    glyph_cache: crate::glyph_cache::GlyphCache,
     /// In-flight background re-discoveries, keyed by project root.  WSL
     /// discovery shells out to wsl.exe and must never block paint; results
     /// are adopted in `poll_project_refreshes`.
@@ -677,6 +678,7 @@ impl AlacritreeApp {
                 font_chain,
                 color_glyph_budget_mb,
             ),
+            glyph_cache: crate::glyph_cache::GlyphCache::new(),
             pending_project_refresh: HashMap::new(),
             wsl_delta_paths: HashMap::new(),
             pending_delta: HashMap::new(),
@@ -7193,6 +7195,7 @@ impl eframe::App for AlacritreeApp {
                         &mut self.builtin_glyphs,
                         &mut self.ime,
                         &mut self.color_glyphs,
+                        &mut self.glyph_cache,
                     )
                 };
                 // egui fake-clicks the natively focused widget on Space/Enter,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1514,7 +1514,10 @@ impl AlacritreeApp {
             actions
         });
         for action in actions {
+            let name = action.label();
+            let started = std::time::Instant::now();
             self.dispatch_action(ctx, action, ActionOrigin::Keyboard);
+            crate::frame_log::note_if_slow("action", name, started.elapsed());
         }
     }
 
@@ -6897,7 +6900,10 @@ impl AlacritreeApp {
         let Some(rx) = &self.ipc_rx else { return };
         let calls: Vec<ipc::AppCall> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         for call in calls {
+            let name = call.request.name();
+            let started = std::time::Instant::now();
             let result = self.handle_ipc_request(ctx, call.request);
+            crate::frame_log::note_if_slow("ipc request", name, started.elapsed());
             // A send error means the client gave up waiting — nothing to do.
             let _ = call.reply_tx.send(result);
         }
@@ -7122,10 +7128,11 @@ impl eframe::App for AlacritreeApp {
                     PaneFocus::GitSidebar => self.handle_git_sidebar_nav(ctx),
                     PaneFocus::Terminal => {},
                 }
+                self.phases.mark("sidebar-nav");
                 self.handle_shortcuts(ctx);
             }
         }
-        self.phases.mark("input");
+        self.phases.mark("shortcuts");
         self.process_notification_actions(ctx);
         self.process_ipc_calls(ctx);
         self.phases.mark("ipc");

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -27,7 +27,7 @@ use crate::paste;
 use crate::path_style;
 use crate::path_style::PathStyle;
 use crate::pr_status::{PrCache, PrInfo, PrState};
-use crate::projects::{Discovered, Project, Worktree, project_json};
+use crate::projects::{Project, Worktree, project_json};
 use crate::scratchpad;
 use crate::session::{
     AttentionVerdict, Session, SessionId, SessionKind, TermSize, poll_attention_debounce,
@@ -369,10 +369,11 @@ pub struct AlacritreeApp {
     /// How much of the frame in progress went to painting the terminal grid,
     /// as opposed to the sidebars and everything else sharing it.
     grid_paint: std::time::Duration,
-    /// In-flight background re-discoveries, keyed by project root.  WSL
-    /// discovery shells out to wsl.exe and must never block paint; results
-    /// are adopted in `poll_project_refreshes`.
-    pending_project_refresh: HashMap<PathBuf, Receiver<Discovered>>,
+    /// In-flight background re-discoveries, keyed by project root.  Neither
+    /// backend may block paint: wsl.exe takes seconds while the distro VM
+    /// boots, and git2 takes tens of milliseconds on a project with many
+    /// worktrees.  Results are adopted in `poll_project_refreshes`.
+    project_refreshes: crate::project_refresh::ProjectRefreshes,
     /// Resolved absolute path of `delta` inside each WSL distro, so diff panes
     /// stop re-sourcing a login profile on every open.  Successes only: a miss
     /// is never stored, so installing delta mid-session is picked up later.
@@ -692,7 +693,7 @@ impl AlacritreeApp {
             frame_log: crate::frame_log::FrameLog::from_env(),
             phases: crate::frame_log::Phases::new(),
             grid_paint: std::time::Duration::ZERO,
-            pending_project_refresh: HashMap::new(),
+            project_refreshes: Default::default(),
             wsl_delta_paths: HashMap::new(),
             pending_delta: HashMap::new(),
             sidebar_rows_cache: None,
@@ -774,16 +775,12 @@ impl AlacritreeApp {
         Ok(idx)
     }
 
-    /// Windows projects re-discover synchronously (git2, fast).  WSL
-    /// projects re-discover on a worker thread: wsl.exe takes ~400 ms warm
-    /// and seconds while the distro VM boots.
+    /// Re-discovery always runs on a worker thread: wsl.exe takes ~400 ms warm
+    /// and seconds while the distro VM boots, and git2 discovery costs tens of
+    /// milliseconds on a project with many worktrees.
     fn refresh_project(&mut self, ctx: &Context, idx: usize) {
         let root = self.projects[idx].root.clone();
-        if matches!(wsl::classify(&root), wsl::Location::Windows(_)) {
-            self.projects[idx].refresh();
-            return;
-        }
-        if self.pending_project_refresh.contains_key(&root) {
+        if self.project_refreshes.is_running(&root) {
             return;
         }
         let (tx, rx) = mpsc::channel();
@@ -793,7 +790,7 @@ impl AlacritreeApp {
             let _ = tx.send(Project::discover(worker_root));
             ctx.request_repaint();
         });
-        self.pending_project_refresh.insert(root, rx);
+        self.project_refreshes.start(root, rx);
     }
 
     /// Re-run worktree discovery for every project — the keyboard/IPC
@@ -809,15 +806,14 @@ impl AlacritreeApp {
     /// the shell override, and the label either way.
     fn poll_project_refreshes(&mut self) {
         let projects = &mut self.projects;
-        self.pending_project_refresh.retain(|root, rx| match rx.try_recv() {
-            Ok(found) => {
-                if let Some(project) = projects.iter_mut().find(|p| p.root == *root) {
+        self.project_refreshes.poll(|root, found| {
+            match projects.iter_mut().find(|p| p.root == *root) {
+                Some(project) => {
                     project.apply(found);
-                }
-                false
-            },
-            Err(mpsc::TryRecvError::Empty) => true,
-            Err(mpsc::TryRecvError::Disconnected) => false,
+                    Ok(project_json(project))
+                },
+                None => Err(format!("{} is not a project in the sidebar", root.display())),
+            }
         });
     }
 
@@ -6900,12 +6896,37 @@ impl AlacritreeApp {
         let Some(rx) = &self.ipc_rx else { return };
         let calls: Vec<ipc::AppCall> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         for call in calls {
-            let name = call.request.name();
+            let ipc::AppCall { request, reply_tx } = call;
+            // Discovery is far too slow to run here, and the caller still has
+            // to be answered from the refreshed list rather than the stale
+            // one, so this request owns its reply channel until then.
+            if let ipc::IpcRequest::RefreshProject { root } = request {
+                self.defer_project_refresh(ctx, root, reply_tx);
+                continue;
+            }
+            let name = request.name();
             let started = std::time::Instant::now();
-            let result = self.handle_ipc_request(ctx, call.request);
+            let result = self.handle_ipc_request(ctx, request);
             crate::frame_log::note_if_slow("ipc request", name, started.elapsed());
             // A send error means the client gave up waiting — nothing to do.
-            let _ = call.reply_tx.send(result);
+            let _ = reply_tx.send(result);
+        }
+    }
+
+    fn defer_project_refresh(
+        &mut self,
+        ctx: &Context,
+        root: PathBuf,
+        reply_tx: mpsc::Sender<ipc::IpcResult>,
+    ) {
+        let Some(idx) = self.projects.iter().position(|p| p.root == root) else {
+            let _ = reply_tx
+                .send(Err(format!("{} is not a project in the sidebar", root.display())));
+            return;
+        };
+        self.refresh_project(ctx, idx);
+        if let Some(reply_tx) = self.project_refreshes.watch(&root, reply_tx) {
+            let _ = reply_tx.send(Ok(project_json(&self.projects[idx])));
         }
     }
 
@@ -7008,14 +7029,10 @@ impl AlacritreeApp {
                 };
                 scratchpad::read_json(&workspace)
             },
-            Req::RefreshProject { root } => {
-                let project =
-                    self.projects.iter_mut().find(|p| p.root == root).ok_or_else(|| {
-                        format!("{} is not a project in the sidebar", root.display())
-                    })?;
-                project.refresh();
-                Ok(project_json(project))
-            },
+            // Claimed by `process_ipc_calls` before dispatch: the reply is
+            // held until the background discovery lands, which needs the
+            // reply channel this method does not have.
+            Req::RefreshProject { .. } => Err("refresh was not deferred".to_string()),
             Req::AddProject { path } => Ok(project_json(self.add_project(path))),
             Req::RemoveProject { root } => {
                 let idx =

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -7126,6 +7126,7 @@ impl eframe::App for AlacritreeApp {
             .map(|_| (std::time::Instant::now(), crate::frame_log::output_wait()));
         self.grid_paint = std::time::Duration::ZERO;
         self.phases.restart();
+        self.glyph_cache.begin_frame(ctx);
         self.poll_project_refreshes();
         self.poll_pending_deletes(ctx);
         self.poll_pending_creates(ctx);

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -360,6 +360,9 @@ pub struct AlacritreeApp {
     ime: crate::ime::Ime,
     color_glyphs: crate::color_glyph::ColorGlyphCache,
     glyph_cache: crate::glyph_cache::GlyphCache,
+    /// Scratch buffers the painter copies the visible grid into, so the
+    /// terminal lock is released before any shape is built.
+    grid_snapshot: crate::terminal_view::GridSnapshot,
     /// In-flight background re-discoveries, keyed by project root.  WSL
     /// discovery shells out to wsl.exe and must never block paint; results
     /// are adopted in `poll_project_refreshes`.
@@ -679,6 +682,7 @@ impl AlacritreeApp {
                 color_glyph_budget_mb,
             ),
             glyph_cache: crate::glyph_cache::GlyphCache::new(),
+            grid_snapshot: crate::terminal_view::GridSnapshot::new(),
             pending_project_refresh: HashMap::new(),
             wsl_delta_paths: HashMap::new(),
             pending_delta: HashMap::new(),
@@ -7196,6 +7200,7 @@ impl eframe::App for AlacritreeApp {
                         &mut self.ime,
                         &mut self.color_glyphs,
                         &mut self.glyph_cache,
+                        &mut self.grid_snapshot,
                     )
                 };
                 // egui fake-clicks the natively focused widget on Space/Enter,

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -18,6 +18,36 @@ pub enum BindingAction {
     Unsupported(String),
 }
 
+/// A `Copy` stand-in for an action's identity, for logs that outlive the
+/// action itself.  The payloads are dropped: they are the user's keystrokes
+/// and config text, and naming the action is what a timing log needs.
+#[derive(Clone, Copy)]
+pub enum ActionLabel {
+    Chars,
+    Named(NamedAction),
+    Unsupported,
+}
+
+impl std::fmt::Debug for ActionLabel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Chars => f.write_str("Chars"),
+            Self::Named(action) => write!(f, "{action:?}"),
+            Self::Unsupported => f.write_str("Unsupported"),
+        }
+    }
+}
+
+impl BindingAction {
+    pub fn label(&self) -> ActionLabel {
+        match self {
+            Self::Chars(_) => ActionLabel::Chars,
+            Self::Named(n) => ActionLabel::Named(*n),
+            Self::Unsupported(_) => ActionLabel::Unsupported,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NamedAction {
     Paste,

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -489,6 +489,11 @@ pub struct UiTheme {
     /// it (so filter typing works without the focus shortcut).  Off by default
     /// so unmodified configs keep click-through-to-terminal behavior.
     pub sidebar_click_focus: bool,
+    /// `[ui] vsync`: block each present until the display's next refresh.  On
+    /// by default, as upstream eframe has it.  Turning it off presents a
+    /// finished frame immediately, trading tearing for the queueing delay
+    /// between a keystroke's frame and the screen.
+    pub vsync: bool,
     /// `[ui] worktree_name`: template for worktree row labels (subst syntax:
     /// `$name`, `$branch`, `$path`, `${var:fallback}`; `$pr` is the branch's
     /// PR number as `#123`, absent when none is known — it needs
@@ -521,6 +526,7 @@ impl Default for UiTheme {
             focus_outline: FocusOutline::default(),
             scrollbar: ScrollbarStyle::Floating,
             sidebar_click_focus: false,
+            vsync: true,
             worktree_name: None,
             project_name: None,
             path_style: PathStyleConfig::default(),
@@ -1178,6 +1184,9 @@ struct RawUi {
     focus_outline: RawFocusOutline,
     /// Clicking a sidebar moves keyboard focus to it.  Default false.
     sidebar_click_focus: Option<bool>,
+    /// Wait for the display's refresh before showing a finished frame.
+    /// Default true.
+    vsync: Option<bool>,
     path_style: RawPathStyle,
 }
 
@@ -1340,6 +1349,7 @@ impl RawConfig {
             },
             scrollbar: parse_scrollbar(self.ui.scrollbar.as_deref()),
             sidebar_click_focus: self.ui.sidebar_click_focus.unwrap_or(false),
+            vsync: self.ui.vsync.unwrap_or(true),
             worktree_name: self.ui.worktree_name.clone().filter(|t| !t.trim().is_empty()),
             project_name: self.ui.project_name.clone().filter(|t| !t.trim().is_empty()),
             path_style: PathStyleConfig {
@@ -2131,6 +2141,16 @@ program = "second"
     #[test]
     fn sidebar_click_focus_defaults_off() {
         assert!(!ui_from_toml("").sidebar_click_focus);
+    }
+
+    #[test]
+    fn vsync_defaults_on() {
+        assert!(ui_from_toml("").vsync);
+    }
+
+    #[test]
+    fn vsync_parses() {
+        assert!(!ui_from_toml("[ui]\nvsync = false").vsync);
     }
 
     #[test]

--- a/alacritree/src/frame_log.rs
+++ b/alacritree/src/frame_log.rs
@@ -81,6 +81,11 @@ fn take_pending(slot: &AtomicU64, painted: u64) -> Option<Duration> {
 /// it is worth a line of its own naming what consumed it.
 const SLOW_FRAME: Duration = Duration::from_millis(15);
 
+/// One piece of work worth naming inside a slow frame.  Below the frame
+/// threshold, so the thing that caused a hitch is named even when it shared
+/// the frame with something bigger.
+const SLOW_PHASE: Duration = Duration::from_millis(10);
+
 /// Phases that fit in one frame's breakdown.  Marks past this are dropped:
 /// the breakdown is a debugging aid, not a reason to allocate mid-frame.
 const MAX_PHASES: usize = 16;
@@ -135,6 +140,16 @@ impl Phases {
         let breakdown =
             ranked.iter().map(|(name, d)| format!("{name} {d:?}")).collect::<Vec<_>>().join(", ");
         log::info!("slow frame: {total:?} | {breakdown}");
+    }
+}
+
+/// Name the individual piece of work that made a phase slow.
+///
+/// A phase is only as useful as its narrowest name: "ipc 101 ms" says the
+/// stall is on the socket path, not which request sat on the UI thread.
+pub fn note_if_slow(kind: &str, what: impl std::fmt::Debug, took: Duration) {
+    if enabled() && took >= SLOW_PHASE {
+        log::info!("slow {kind}: {what:?} {took:?}");
     }
 }
 

--- a/alacritree/src/frame_log.rs
+++ b/alacritree/src/frame_log.rs
@@ -41,12 +41,59 @@ fn epoch() -> Instant {
     *EPOCH.get_or_init(Instant::now)
 }
 
+/// When the visible session last had a keystroke written to its PTY, as
+/// nanoseconds since `epoch()`; zero when nothing is awaiting an echo.
+static KEYSTROKE_AT: AtomicU64 = AtomicU64::new(0);
+
+/// The round trip of the most recent keystroke, waiting to be sampled.
+static ECHO: AtomicU64 = AtomicU64::new(0);
+
+/// Note that a keystroke went to the visible session's PTY.
+///
+/// The newest keystroke replaces the last, so a burst measures the round trip
+/// of the character still outstanding rather than of the one that started it.
+pub fn keystroke_sent() {
+    if enabled() {
+        KEYSTROKE_AT.store(now().max(1), Ordering::Relaxed);
+    }
+}
+
 /// Note that a session produced output that no frame has shown yet.
 ///
 /// Called from the PTY threads.
 pub fn output_arrived() {
-    if enabled() {
-        mark_pending(&OUTPUT_PENDING, now());
+    if !enabled() {
+        return;
+    }
+    let now = now();
+    mark_pending(&OUTPUT_PENDING, now);
+
+    close_echo(&KEYSTROKE_AT, &ECHO, now);
+}
+
+/// The round trip of the last keystroke to be echoed, once.
+pub fn echo() -> Option<Duration> {
+    take_echo(&ECHO)
+}
+
+/// Close the round trip of the keystroke still outstanding, if any.
+///
+/// Everything between the write and here is outside this process: the ConPTY
+/// round trip, the child's own redraw, and alacritty's parse.  It is the one
+/// segment of a keystroke's journey the frame timings cannot see.  Output the
+/// keystroke did not cause closes the trip early, so this bounds the segment
+/// from below.
+fn close_echo(sent_at: &AtomicU64, echo: &AtomicU64, arrived: u64) {
+    let sent = sent_at.swap(0, Ordering::Relaxed);
+    if sent != 0 {
+        echo.store(arrived.saturating_sub(sent).max(1), Ordering::Relaxed);
+    }
+}
+
+fn take_echo(echo: &AtomicU64) -> Option<Duration> {
+    match echo.swap(0, Ordering::Relaxed) {
+        0 => None,
+        nanos => Some(Duration::from_nanos(nanos)),
     }
 }
 
@@ -160,6 +207,7 @@ struct Samples {
     periods: Vec<Duration>,
     cpus: Vec<Duration>,
     waits: Vec<Duration>,
+    echoes: Vec<Duration>,
 }
 
 /// One frame's readings, gathered across `update` and handed over at the end.
@@ -170,6 +218,7 @@ pub struct Timings {
     /// not survive into a percentile over thousands of frames.
     pub cpu: Option<Duration>,
     pub waited: Option<Duration>,
+    pub echo: Option<Duration>,
 }
 
 pub struct FrameLog {
@@ -190,11 +239,12 @@ impl FrameLog {
     }
 
     pub fn record(&mut self, frame: Timings) {
-        let Timings { started, grid, cpu, waited } = frame;
+        let Timings { started, grid, cpu, waited, echo } = frame;
         self.samples.totals.push(started.elapsed());
         self.samples.grids.push(grid);
         self.samples.cpus.extend(cpu);
         self.samples.waits.extend(waited);
+        self.samples.echoes.extend(echo);
         if let Some(previous) = self.started_previous.replace(started) {
             self.samples.periods.push(started.saturating_duration_since(previous));
         }
@@ -207,7 +257,7 @@ impl FrameLog {
     fn report(&mut self) {
         let elapsed = self.reported_at.elapsed();
         self.reported_at = Instant::now();
-        let Samples { mut totals, mut grids, mut periods, mut cpus, mut waits } =
+        let Samples { mut totals, mut grids, mut periods, mut cpus, mut waits, mut echoes } =
             std::mem::take(&mut self.samples);
         if totals.is_empty() {
             return;
@@ -218,12 +268,14 @@ impl FrameLog {
         periods.sort_unstable();
         cpus.sort_unstable();
         waits.sort_unstable();
+        echoes.sort_unstable();
         let spent: Duration = totals.iter().sum();
 
         log::info!(
             "frames: {} in {:.1}s ({:.0}/s, {:.0}% of the thread) | total p50 {:?} p95 {:?} p99 \
              {:?} max {:?} | grid p50 {:?} p95 {:?} | period p50 {:?} p95 {:?} | render+update \
-             p50 {:?} p95 {:?} | output waited p50 {:?} p95 {:?} max {:?}",
+             p50 {:?} p95 {:?} | output waited p50 {:?} p95 {:?} max {:?} | echo n={} p50 {:?} \
+             p95 {:?} p99 {:?}",
             totals.len(),
             elapsed.as_secs_f64(),
             totals.len() as f64 / elapsed.as_secs_f64(),
@@ -241,6 +293,10 @@ impl FrameLog {
             Reading(quantile(&waits, 0.50)),
             Reading(quantile(&waits, 0.95)),
             Reading(waits.last().copied()),
+            echoes.len(),
+            Reading(quantile(&echoes, 0.50)),
+            Reading(quantile(&echoes, 0.95)),
+            Reading(quantile(&echoes, 0.99)),
         );
     }
 }
@@ -276,7 +332,7 @@ mod tests {
     }
 
     fn frame(started: Instant) -> Timings {
-        Timings { started, grid: Duration::ZERO, cpu: None, waited: None }
+        Timings { started, grid: Duration::ZERO, cpu: None, waited: None, echo: None }
     }
 
     #[test]
@@ -371,6 +427,40 @@ mod tests {
         mark_pending(&slot, 0);
 
         assert!(take_pending(&slot, 5_000).is_some());
+    }
+
+    /// The round trip runs from the keystroke's write to the output that
+    /// answered it.
+    #[test]
+    fn output_after_a_keystroke_closes_its_round_trip() {
+        let (sent_at, echo) = (AtomicU64::new(2_000), AtomicU64::new(0));
+
+        close_echo(&sent_at, &echo, 9_000);
+
+        assert_eq!(take_echo(&echo), Some(Duration::from_nanos(7_000)));
+    }
+
+    /// Output nobody typed for is most of what a terminal produces, and it
+    /// must not enter the sample as a round trip of its own.
+    #[test]
+    fn output_with_no_keystroke_outstanding_reports_nothing() {
+        let (sent_at, echo) = (AtomicU64::new(0), AtomicU64::new(0));
+
+        close_echo(&sent_at, &echo, 9_000);
+
+        assert_eq!(take_echo(&echo), None);
+    }
+
+    /// One keystroke is one round trip: the output that keeps coming after it
+    /// is the child still redrawing, not further keystrokes being answered.
+    #[test]
+    fn only_the_first_output_after_a_keystroke_counts() {
+        let (sent_at, echo) = (AtomicU64::new(2_000), AtomicU64::new(0));
+
+        close_echo(&sent_at, &echo, 9_000);
+        close_echo(&sent_at, &echo, 40_000);
+
+        assert_eq!(take_echo(&echo), Some(Duration::from_nanos(7_000)));
     }
 
     /// Each mark closes the phase that ran since the previous one, so the

--- a/alacritree/src/frame_log.rs
+++ b/alacritree/src/frame_log.rs
@@ -5,15 +5,100 @@
 //! same frame.  This measures whole frames in the app that is actually
 //! lagging, and splits off the grid so the two can be compared.
 //!
-//! Disabled it costs one `Option` check per frame and never allocates.
+//! `update` is only part of a frame: eframe tessellates, uploads and presents
+//! after it returns.  So the period between two frame starts is recorded
+//! alongside eframe's own `cpu_usage`, which covers rendering but stops short
+//! of the vsync wait.  A period far above the CPU time, while frames are being
+//! produced at the display's cap, is time blocked on present rather than time
+//! spent working.
+//!
+//! Disabled it costs one `Option` check per frame, one flag read per PTY
+//! wakeup, and never allocates.
 
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// How often the accumulated frames are summarized.
 const REPORT_EVERY: Duration = Duration::from_secs(5);
 
+/// Whether `ALACRITREE_FRAME_LOG` asked for measurements.  Read by the PTY
+/// threads, which have no handle on the `FrameLog` the UI thread owns.
+fn enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var_os("ALACRITREE_FRAME_LOG")
+            .is_some_and(|v| !matches!(v.to_str(), Some("0") | Some("")))
+    })
+}
+
+/// Terminal output waiting to reach the screen, as nanoseconds since
+/// `epoch()`; zero when the last frame already painted everything.
+static OUTPUT_PENDING: AtomicU64 = AtomicU64::new(0);
+
+fn epoch() -> Instant {
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    *EPOCH.get_or_init(Instant::now)
+}
+
+/// Note that a session produced output that no frame has shown yet.
+///
+/// Called from the PTY threads.
+pub fn output_arrived() {
+    if enabled() {
+        mark_pending(&OUTPUT_PENDING, now());
+    }
+}
+
+/// How long the output this frame is about to paint has been waiting.
+///
+/// Read before the frame builds anything, so output that arrives mid-frame
+/// stays pending rather than being credited to a paint that may have missed
+/// it.
+pub fn output_wait() -> Option<Duration> {
+    take_pending(&OUTPUT_PENDING, now())
+}
+
+fn now() -> u64 {
+    epoch().elapsed().as_nanos() as u64
+}
+
+/// Only the oldest pending output is kept, so what a frame reports is the
+/// longest any of it waited, not the shortest.  Zero means nothing is pending,
+/// so an arrival at that exact nanosecond is nudged forward by one.
+fn mark_pending(slot: &AtomicU64, arrived: u64) {
+    let _ = slot.compare_exchange(0, arrived.max(1), Ordering::Relaxed, Ordering::Relaxed);
+}
+
+fn take_pending(slot: &AtomicU64, painted: u64) -> Option<Duration> {
+    match slot.swap(0, Ordering::Relaxed) {
+        0 => None,
+        arrived => Some(Duration::from_nanos(painted.saturating_sub(arrived))),
+    }
+}
+
+#[derive(Default)]
+struct Samples {
+    totals: Vec<Duration>,
+    grids: Vec<Duration>,
+    periods: Vec<Duration>,
+    cpus: Vec<Duration>,
+    waits: Vec<Duration>,
+}
+
+/// One frame's readings, gathered across `update` and handed over at the end.
+pub struct Timings {
+    pub started: Instant,
+    pub grid: Duration,
+    /// eframe's reading for the frame *before* this one; the off-by-one does
+    /// not survive into a percentile over thousands of frames.
+    pub cpu: Option<Duration>,
+    pub waited: Option<Duration>,
+}
+
 pub struct FrameLog {
-    frames: Vec<(Duration, Duration)>,
+    samples: Samples,
+    started_previous: Option<Instant>,
     reported_at: Instant,
 }
 
@@ -21,13 +106,23 @@ impl FrameLog {
     /// A log if `ALACRITREE_FRAME_LOG` is set to anything but `0`, otherwise
     /// nothing — the caller keeps an `Option` so a normal run pays nothing.
     pub fn from_env() -> Option<Self> {
-        let enabled = std::env::var_os("ALACRITREE_FRAME_LOG")
-            .is_some_and(|v| !matches!(v.to_str(), Some("0") | Some("")));
-        enabled.then(|| Self { frames: Vec::new(), reported_at: Instant::now() })
+        enabled().then(|| Self {
+            samples: Samples::default(),
+            started_previous: None,
+            reported_at: Instant::now(),
+        })
     }
 
-    pub fn record(&mut self, total: Duration, grid: Duration) {
-        self.frames.push((total, grid));
+    pub fn record(&mut self, frame: Timings) {
+        let Timings { started, grid, cpu, waited } = frame;
+        self.samples.totals.push(started.elapsed());
+        self.samples.grids.push(grid);
+        self.samples.cpus.extend(cpu);
+        self.samples.waits.extend(waited);
+        if let Some(previous) = self.started_previous.replace(started) {
+            self.samples.periods.push(started.saturating_duration_since(previous));
+        }
+
         if self.reported_at.elapsed() >= REPORT_EVERY {
             self.report();
         }
@@ -36,49 +131,85 @@ impl FrameLog {
     fn report(&mut self) {
         let elapsed = self.reported_at.elapsed();
         self.reported_at = Instant::now();
-        let frames = std::mem::take(&mut self.frames);
-        if frames.is_empty() {
+        let Samples { mut totals, mut grids, mut periods, mut cpus, mut waits } =
+            std::mem::take(&mut self.samples);
+        if totals.is_empty() {
             return;
         }
 
-        let mut totals: Vec<Duration> = frames.iter().map(|(t, _)| *t).collect();
-        let mut grids: Vec<Duration> = frames.iter().map(|(_, g)| *g).collect();
         totals.sort_unstable();
         grids.sort_unstable();
+        periods.sort_unstable();
+        cpus.sort_unstable();
+        waits.sort_unstable();
         let spent: Duration = totals.iter().sum();
 
         log::info!(
             "frames: {} in {:.1}s ({:.0}/s, {:.0}% of the thread) | total p50 {:?} p95 {:?} p99 \
-             {:?} max {:?} | grid p50 {:?} p95 {:?}",
-            frames.len(),
+             {:?} max {:?} | grid p50 {:?} p95 {:?} | period p50 {:?} p95 {:?} | render+update \
+             p50 {:?} p95 {:?} | output waited p50 {:?} p95 {:?} max {:?}",
+            totals.len(),
             elapsed.as_secs_f64(),
-            frames.len() as f64 / elapsed.as_secs_f64(),
+            totals.len() as f64 / elapsed.as_secs_f64(),
             100.0 * spent.as_secs_f64() / elapsed.as_secs_f64(),
-            quantile(&totals, 0.50),
-            quantile(&totals, 0.95),
-            quantile(&totals, 0.99),
+            Reading(quantile(&totals, 0.50)),
+            Reading(quantile(&totals, 0.95)),
+            Reading(quantile(&totals, 0.99)),
             totals[totals.len() - 1],
-            quantile(&grids, 0.50),
-            quantile(&grids, 0.95),
+            Reading(quantile(&grids, 0.50)),
+            Reading(quantile(&grids, 0.95)),
+            Reading(quantile(&periods, 0.50)),
+            Reading(quantile(&periods, 0.95)),
+            Reading(quantile(&cpus, 0.50)),
+            Reading(quantile(&cpus, 0.95)),
+            Reading(quantile(&waits, 0.50)),
+            Reading(quantile(&waits, 0.95)),
+            Reading(waits.last().copied()),
         );
     }
 }
 
-fn quantile(sorted: &[Duration], q: f64) -> Duration {
-    sorted[((sorted.len() as f64 * q) as usize).min(sorted.len() - 1)]
+/// A percentile of an empty sample has no value; `-` says so without the
+/// `Some(..)` wrapper `Option`'s own `Debug` would print.
+struct Reading(Option<Duration>);
+
+impl std::fmt::Debug for Reading {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(value) => write!(f, "{value:?}"),
+            None => f.write_str("-"),
+        }
+    }
+}
+
+fn quantile(sorted: &[Duration], q: f64) -> Option<Duration> {
+    let last = sorted.len().checked_sub(1)?;
+    Some(sorted[((sorted.len() as f64 * q) as usize).min(last)])
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn log() -> FrameLog {
+        FrameLog {
+            samples: Samples::default(),
+            started_previous: None,
+            reported_at: Instant::now(),
+        }
+    }
+
+    fn frame(started: Instant) -> Timings {
+        Timings { started, grid: Duration::ZERO, cpu: None, waited: None }
+    }
+
     #[test]
     fn quantiles_index_within_the_sample() {
         let sorted: Vec<Duration> = (0..100).map(Duration::from_millis).collect();
 
-        assert_eq!(quantile(&sorted, 0.0), Duration::from_millis(0));
-        assert_eq!(quantile(&sorted, 0.5), Duration::from_millis(50));
-        assert_eq!(quantile(&sorted, 1.0), Duration::from_millis(99));
+        assert_eq!(quantile(&sorted, 0.0), Some(Duration::from_millis(0)));
+        assert_eq!(quantile(&sorted, 0.5), Some(Duration::from_millis(50)));
+        assert_eq!(quantile(&sorted, 1.0), Some(Duration::from_millis(99)));
     }
 
     /// A single frame is the whole distribution, and the percentile maths must
@@ -87,6 +218,82 @@ mod tests {
     fn a_single_frame_reports_without_panicking() {
         let sorted = [Duration::from_millis(7)];
 
-        assert_eq!(quantile(&sorted, 0.99), Duration::from_millis(7));
+        assert_eq!(quantile(&sorted, 0.99), Some(Duration::from_millis(7)));
+    }
+
+    #[test]
+    fn a_percentile_of_nothing_has_no_value() {
+        assert_eq!(quantile(&[], 0.5), None);
+    }
+
+    /// The point of the period is the gap the frame did *not* spend in
+    /// `update`, so it runs start-to-start, not end-to-start.
+    #[test]
+    fn a_frames_period_spans_from_the_previous_frames_start() {
+        let mut log = log();
+        let first = Instant::now();
+
+        log.record(frame(first));
+        log.record(frame(first + Duration::from_millis(9)));
+
+        assert_eq!(log.samples.periods, [Duration::from_millis(9)]);
+    }
+
+    /// Nothing preceded the first frame, so it contributes a total but no gap.
+    #[test]
+    fn the_first_frame_contributes_no_period() {
+        let mut log = log();
+
+        log.record(frame(Instant::now()));
+
+        assert_eq!(log.samples.totals.len(), 1);
+        assert!(log.samples.periods.is_empty());
+    }
+
+    /// eframe has no reading for its first frame, and a missing one must not
+    /// shift the others by taking a slot in the sample.
+    #[test]
+    fn a_missing_cpu_reading_is_left_out_of_the_sample() {
+        let mut log = log();
+        let started = Instant::now();
+
+        log.record(frame(started));
+        log.record(Timings { cpu: Some(Duration::from_millis(3)), ..frame(started) });
+
+        assert_eq!(log.samples.cpus, [Duration::from_millis(3)]);
+    }
+
+    /// Output that piles up between frames is reported at the age of the
+    /// oldest piece: that is how long the screen was actually behind.
+    #[test]
+    fn the_oldest_pending_output_sets_the_wait() {
+        let slot = AtomicU64::new(0);
+
+        mark_pending(&slot, 1_000);
+        mark_pending(&slot, 4_000);
+
+        assert_eq!(take_pending(&slot, 9_000), Some(Duration::from_nanos(8_000)));
+    }
+
+    /// The wait belongs to output that was already pending when the frame
+    /// began, so a second frame with nothing new to show reports no wait.
+    #[test]
+    fn output_that_reaches_a_frame_stops_being_pending() {
+        let slot = AtomicU64::new(0);
+        mark_pending(&slot, 1_000);
+
+        assert!(take_pending(&slot, 2_000).is_some());
+        assert_eq!(take_pending(&slot, 3_000), None);
+    }
+
+    /// Zero is the "nothing pending" marker, so output arriving on that exact
+    /// nanosecond must still register.
+    #[test]
+    fn output_arriving_at_the_epoch_still_counts_as_pending() {
+        let slot = AtomicU64::new(0);
+
+        mark_pending(&slot, 0);
+
+        assert!(take_pending(&slot, 5_000).is_some());
     }
 }

--- a/alacritree/src/frame_log.rs
+++ b/alacritree/src/frame_log.rs
@@ -1,0 +1,92 @@
+//! Opt-in frame timing, enabled with `ALACRITREE_FRAME_LOG=1`.
+//!
+//! The paint harnesses time the grid alone in a headless context, which says
+//! nothing about the sidebars, event draining, or git status that share the
+//! same frame.  This measures whole frames in the app that is actually
+//! lagging, and splits off the grid so the two can be compared.
+//!
+//! Disabled it costs one `Option` check per frame and never allocates.
+
+use std::time::{Duration, Instant};
+
+/// How often the accumulated frames are summarized.
+const REPORT_EVERY: Duration = Duration::from_secs(5);
+
+pub struct FrameLog {
+    frames: Vec<(Duration, Duration)>,
+    reported_at: Instant,
+}
+
+impl FrameLog {
+    /// A log if `ALACRITREE_FRAME_LOG` is set to anything but `0`, otherwise
+    /// nothing — the caller keeps an `Option` so a normal run pays nothing.
+    pub fn from_env() -> Option<Self> {
+        let enabled = std::env::var_os("ALACRITREE_FRAME_LOG")
+            .is_some_and(|v| !matches!(v.to_str(), Some("0") | Some("")));
+        enabled.then(|| Self { frames: Vec::new(), reported_at: Instant::now() })
+    }
+
+    pub fn record(&mut self, total: Duration, grid: Duration) {
+        self.frames.push((total, grid));
+        if self.reported_at.elapsed() >= REPORT_EVERY {
+            self.report();
+        }
+    }
+
+    fn report(&mut self) {
+        let elapsed = self.reported_at.elapsed();
+        self.reported_at = Instant::now();
+        let frames = std::mem::take(&mut self.frames);
+        if frames.is_empty() {
+            return;
+        }
+
+        let mut totals: Vec<Duration> = frames.iter().map(|(t, _)| *t).collect();
+        let mut grids: Vec<Duration> = frames.iter().map(|(_, g)| *g).collect();
+        totals.sort_unstable();
+        grids.sort_unstable();
+        let spent: Duration = totals.iter().sum();
+
+        log::info!(
+            "frames: {} in {:.1}s ({:.0}/s, {:.0}% of the thread) | total p50 {:?} p95 {:?} p99 \
+             {:?} max {:?} | grid p50 {:?} p95 {:?}",
+            frames.len(),
+            elapsed.as_secs_f64(),
+            frames.len() as f64 / elapsed.as_secs_f64(),
+            100.0 * spent.as_secs_f64() / elapsed.as_secs_f64(),
+            quantile(&totals, 0.50),
+            quantile(&totals, 0.95),
+            quantile(&totals, 0.99),
+            totals[totals.len() - 1],
+            quantile(&grids, 0.50),
+            quantile(&grids, 0.95),
+        );
+    }
+}
+
+fn quantile(sorted: &[Duration], q: f64) -> Duration {
+    sorted[((sorted.len() as f64 * q) as usize).min(sorted.len() - 1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantiles_index_within_the_sample() {
+        let sorted: Vec<Duration> = (0..100).map(Duration::from_millis).collect();
+
+        assert_eq!(quantile(&sorted, 0.0), Duration::from_millis(0));
+        assert_eq!(quantile(&sorted, 0.5), Duration::from_millis(50));
+        assert_eq!(quantile(&sorted, 1.0), Duration::from_millis(99));
+    }
+
+    /// A single frame is the whole distribution, and the percentile maths must
+    /// not index past it.
+    #[test]
+    fn a_single_frame_reports_without_panicking() {
+        let sorted = [Duration::from_millis(7)];
+
+        assert_eq!(quantile(&sorted, 0.99), Duration::from_millis(7));
+    }
+}

--- a/alacritree/src/frame_log.rs
+++ b/alacritree/src/frame_log.rs
@@ -77,6 +77,67 @@ fn take_pending(slot: &AtomicU64, painted: u64) -> Option<Duration> {
     }
 }
 
+/// A frame this slow is felt as a hitch rather than seen as a frame rate, so
+/// it is worth a line of its own naming what consumed it.
+const SLOW_FRAME: Duration = Duration::from_millis(15);
+
+/// Phases that fit in one frame's breakdown.  Marks past this are dropped:
+/// the breakdown is a debugging aid, not a reason to allocate mid-frame.
+const MAX_PHASES: usize = 16;
+
+/// Where one frame's time went.
+///
+/// A stall that strikes once every few seconds does not move any percentile,
+/// so the summary cannot find it.  This names the phase it happened in.
+pub struct Phases {
+    marks: [(&'static str, Duration); MAX_PHASES],
+    len: usize,
+    since: Instant,
+    on: bool,
+}
+
+impl Phases {
+    pub fn new() -> Self {
+        Self {
+            marks: [("", Duration::ZERO); MAX_PHASES],
+            len: 0,
+            since: Instant::now(),
+            on: enabled(),
+        }
+    }
+
+    pub fn restart(&mut self) {
+        self.len = 0;
+        self.since = Instant::now();
+    }
+
+    /// Close the phase that ended here, naming it.
+    pub fn mark(&mut self, name: &'static str) {
+        if !self.on || self.len == MAX_PHASES {
+            return;
+        }
+        let now = Instant::now();
+        self.marks[self.len] = (name, now.saturating_duration_since(self.since));
+        self.since = now;
+        self.len += 1;
+    }
+
+    pub fn report_if_slow(&self) {
+        let marks = &self.marks[..self.len];
+        let total: Duration = marks.iter().map(|(_, d)| *d).sum();
+        if total < SLOW_FRAME {
+            return;
+        }
+
+        let mut ranked: Vec<_> =
+            marks.iter().filter(|(_, d)| *d >= Duration::from_millis(1)).collect();
+        ranked.sort_unstable_by_key(|(_, d)| std::cmp::Reverse(*d));
+        let breakdown =
+            ranked.iter().map(|(name, d)| format!("{name} {d:?}")).collect::<Vec<_>>().join(", ");
+        log::info!("slow frame: {total:?} | {breakdown}");
+    }
+}
+
 #[derive(Default)]
 struct Samples {
     totals: Vec<Duration>,
@@ -295,5 +356,45 @@ mod tests {
         mark_pending(&slot, 0);
 
         assert!(take_pending(&slot, 5_000).is_some());
+    }
+
+    /// Each mark closes the phase that ran since the previous one, so the
+    /// phases partition the frame instead of all dating from its start.
+    #[test]
+    fn each_phase_measures_only_its_own_span() {
+        let mut phases = Phases { on: true, ..Phases::new() };
+
+        phases.restart();
+        std::thread::sleep(Duration::from_millis(20));
+        phases.mark("first");
+        phases.mark("second");
+
+        let [(_, first), (_, second)] = phases.marks[..2] else { unreachable!() };
+        assert!(first >= Duration::from_millis(20), "{first:?}");
+        assert!(second < Duration::from_millis(10), "{second:?}");
+    }
+
+    /// A frame with more phases than the breakdown holds must drop the extras
+    /// rather than run off the end of the array.
+    #[test]
+    fn marks_past_the_last_slot_are_dropped() {
+        let mut phases = Phases { on: true, ..Phases::new() };
+
+        for _ in 0..MAX_PHASES + 5 {
+            phases.mark("phase");
+        }
+
+        assert_eq!(phases.len, MAX_PHASES);
+    }
+
+    /// Disabled, a mark must not even read the clock.
+    #[test]
+    fn a_disabled_breakdown_records_nothing() {
+        let mut phases = Phases::new();
+        phases.on = false;
+
+        phases.mark("phase");
+
+        assert_eq!(phases.len, 0);
     }
 }

--- a/alacritree/src/glyph_cache.rs
+++ b/alacritree/src/glyph_cache.rs
@@ -1,0 +1,161 @@
+//! Laid-out single-character galleys, reused across frames.
+//!
+//! The grid paints one glyph per cell so every character lands on the cursor's
+//! `col * cell_w` boundary — egui's own run layout drifts off it.  Going
+//! through `Painter::text` for each one costs a `String`, a `LayoutJob`, and a
+//! galley-cache probe per glyph *per frame*, which at a maximized window is
+//! tens of thousands of allocations to redraw glyphs that mostly did not
+//! change.  A galley is immutable and its colour can be replaced at paint time
+//! with `TextShape::override_text_color`, so one galley per character and
+//! style serves every cell that ever shows it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use egui::text::LayoutJob;
+use egui::{Color32, Context, FontFamily, FontId, Galley};
+
+use crate::fonts::{BOLD_FAMILY, BOLD_ITALIC_FAMILY, ITALIC_FAMILY};
+
+/// Which of the four terminal faces a glyph is drawn with.  Cheaper to hash
+/// than a `FontId`, whose `f32` size is not `Hash` anyway.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum Face {
+    Normal,
+    Bold,
+    Italic,
+    BoldItalic,
+}
+
+impl Face {
+    pub fn new(bold: bool, italic: bool) -> Self {
+        match (bold, italic) {
+            (true, true) => Self::BoldItalic,
+            (true, false) => Self::Bold,
+            (false, true) => Self::Italic,
+            (false, false) => Self::Normal,
+        }
+    }
+
+    fn font_id(self, size: f32) -> FontId {
+        match self {
+            Self::Normal => FontId::monospace(size),
+            Self::Bold => FontId::new(size, FontFamily::Name(BOLD_FAMILY.into())),
+            Self::Italic => FontId::new(size, FontFamily::Name(ITALIC_FAMILY.into())),
+            Self::BoldItalic => FontId::new(size, FontFamily::Name(BOLD_ITALIC_FAMILY.into())),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct GlyphCache {
+    /// Point size the cached galleys were laid out at.  A font-size change
+    /// (zoom, config reload) invalidates every one of them.
+    size: f32,
+    entries: HashMap<(char, Face), Arc<Galley>>,
+}
+
+impl GlyphCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The galley for `ch` in `face`, laid out once and reused.  Colour is not
+    /// baked in: callers override it per cell.
+    pub fn get(&mut self, ctx: &Context, ch: char, face: Face, size: f32) -> Arc<Galley> {
+        if self.size != size {
+            self.entries.clear();
+            self.size = size;
+        }
+        if let Some(galley) = self.entries.get(&(ch, face)) {
+            return galley.clone();
+        }
+        // `layout_job` rather than `layout_no_wrap` so the character is laid
+        // out with `PLACEHOLDER`, which `override_text_color` is defined
+        // against; a concrete colour here would be the one egui reuses if the
+        // override is ever dropped.
+        let mut job = LayoutJob::single_section(
+            ch.to_string(),
+            egui::TextFormat::simple(face.font_id(size), Color32::PLACEHOLDER),
+        );
+        job.wrap.max_width = f32::INFINITY;
+        let galley = ctx.fonts(|f| f.layout_job(job));
+        self.entries.insert((ch, face), galley.clone());
+        galley
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A context with fonts available and the three named terminal families
+    /// bound, as `fonts::install_terminal_fonts` leaves it in the app.  egui
+    /// has no fonts at all until a frame has run, and panics on a family it
+    /// was never given.
+    fn ctx() -> Context {
+        let ctx = Context::default();
+        let mut fonts = egui::FontDefinitions::default();
+        let mono = fonts.families[&FontFamily::Monospace].clone();
+        for name in [BOLD_FAMILY, ITALIC_FAMILY, BOLD_ITALIC_FAMILY] {
+            fonts.families.insert(FontFamily::Name(name.into()), mono.clone());
+        }
+        ctx.set_fonts(fonts);
+        let _ = ctx.run(egui::RawInput::default(), |_| {});
+        ctx
+    }
+
+    /// The whole point: painting the same character again must not lay it out
+    /// again, however many cells show it.
+    #[test]
+    fn a_repeated_character_is_laid_out_once() {
+        let ctx = ctx();
+        let mut cache = GlyphCache::new();
+
+        for _ in 0..100 {
+            cache.get(&ctx, 'a', Face::Normal, 14.0);
+        }
+
+        assert_eq!(cache.len(), 1);
+    }
+
+    /// Bold and italic are separate faces, so they cannot share a galley —
+    /// reusing one would paint every bold cell in the regular face.
+    #[test]
+    fn each_face_gets_its_own_galley() {
+        let ctx = ctx();
+        let mut cache = GlyphCache::new();
+
+        for face in [Face::Normal, Face::Bold, Face::Italic, Face::BoldItalic] {
+            cache.get(&ctx, 'a', face, 14.0);
+        }
+
+        assert_eq!(cache.len(), 4);
+    }
+
+    /// Galleys carry their laid-out size, so a zoom step has to discard them —
+    /// keeping them would paint the old size until the cache happened to miss.
+    #[test]
+    fn a_font_size_change_discards_the_cached_galleys() {
+        let ctx = ctx();
+        let mut cache = GlyphCache::new();
+        cache.get(&ctx, 'a', Face::Normal, 14.0);
+
+        cache.get(&ctx, 'b', Face::Normal, 20.0);
+
+        assert_eq!(cache.len(), 1, "galleys laid out at the old size survived a size change");
+    }
+
+    #[test]
+    fn face_maps_bold_and_italic_flags() {
+        assert_eq!(Face::new(false, false), Face::Normal);
+        assert_eq!(Face::new(true, false), Face::Bold);
+        assert_eq!(Face::new(false, true), Face::Italic);
+        assert_eq!(Face::new(true, true), Face::BoldItalic);
+    }
+}

--- a/alacritree/src/glyph_cache.rs
+++ b/alacritree/src/glyph_cache.rs
@@ -47,17 +47,83 @@ impl Face {
     }
 }
 
+/// `layout_job` rather than `layout_no_wrap` so the character is laid out with
+/// `PLACEHOLDER`, which `override_text_color` is defined against; a concrete
+/// colour here would be the one egui reuses if the override is ever dropped.
+fn glyph_job(ch: char, face: Face, size: f32) -> LayoutJob {
+    let mut job = LayoutJob::single_section(
+        ch.to_string(),
+        egui::TextFormat::simple(face.font_id(size), Color32::PLACEHOLDER),
+    );
+    job.wrap.max_width = f32::INFINITY;
+    job
+}
+
+/// The font atlas a set of galleys was laid out against.  A galley's mesh
+/// stores atlas positions, so it only means anything while that atlas is the
+/// one being sampled.
+#[derive(Clone, Copy, PartialEq)]
+struct AtlasState {
+    pixels_per_point: f32,
+    max_texture_side: usize,
+    image_size: [usize; 2],
+    fill_ratio: f32,
+}
+
+impl AtlasState {
+    fn read(ctx: &Context) -> Self {
+        ctx.fonts(|f| Self {
+            pixels_per_point: f.pixels_per_point(),
+            max_texture_side: f.max_texture_side(),
+            image_size: f.font_image_size(),
+            fill_ratio: f.font_atlas_fill_ratio(),
+        })
+    }
+
+    /// Whether galleys laid out against `self` can still be painted now that
+    /// the atlas looks like `now`.  Repacking is the case that matters, but
+    /// growth moves nothing and is folded in anyway: it costs one relayout of
+    /// the visible glyphs on a frame the atlas changed shape, and keeping the
+    /// rule to "anything moved" leaves no repack unnoticed.
+    fn outlived_by(self, now: Self) -> bool {
+        self.pixels_per_point != now.pixels_per_point
+            || self.max_texture_side != now.max_texture_side
+            || self.image_size != now.image_size
+            || now.fill_ratio < self.fill_ratio
+    }
+}
+
 #[derive(Default)]
 pub struct GlyphCache {
     /// Point size the cached galleys were laid out at.  A font-size change
     /// (zoom, config reload) invalidates every one of them.
     size: f32,
+    /// The atlas the entries were laid out against, once a frame has observed
+    /// one.  `None` before the first `begin_frame`, when there is nothing
+    /// cached to invalidate.
+    atlas: Option<AtlasState>,
     entries: HashMap<(char, Face), Arc<Galley>>,
 }
 
 impl GlyphCache {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Drop every galley egui's font atlas has outlived.  Call once per frame
+    /// before any `get`.
+    ///
+    /// `epaint::Fonts::begin_pass` replaces the whole atlas — and drops egui's
+    /// own galley cache with it — when the scale changes, the texture limit
+    /// changes, or the atlas passes 80% full.  Glyphs are repacked into
+    /// different positions, so a galley held across that boundary addresses
+    /// whatever landed in its old slot and paints some other character.
+    pub fn begin_frame(&mut self, ctx: &Context) {
+        let now = AtlasState::read(ctx);
+        if self.atlas.is_some_and(|prev| prev.outlived_by(now)) {
+            self.entries.clear();
+        }
+        self.atlas = Some(now);
     }
 
     /// The galley for `ch` in `face`, laid out once and reused.  Colour is not
@@ -70,16 +136,7 @@ impl GlyphCache {
         if let Some(galley) = self.entries.get(&(ch, face)) {
             return galley.clone();
         }
-        // `layout_job` rather than `layout_no_wrap` so the character is laid
-        // out with `PLACEHOLDER`, which `override_text_color` is defined
-        // against; a concrete colour here would be the one egui reuses if the
-        // override is ever dropped.
-        let mut job = LayoutJob::single_section(
-            ch.to_string(),
-            egui::TextFormat::simple(face.font_id(size), Color32::PLACEHOLDER),
-        );
-        job.wrap.max_width = f32::INFINITY;
-        let galley = ctx.fonts(|f| f.layout_job(job));
+        let galley = ctx.fonts(|f| f.layout_job(glyph_job(ch, face, size)));
         self.entries.insert((ch, face), galley.clone());
         galley
     }
@@ -149,6 +206,41 @@ mod tests {
         cache.get(&ctx, 'b', Face::Normal, 20.0);
 
         assert_eq!(cache.len(), 1, "galleys laid out at the old size survived a size change");
+    }
+
+    /// The atlas position of the first vertex of a galley's mesh — where in
+    /// the font texture painting this galley actually samples from.
+    fn atlas_pos(galley: &Galley) -> egui::Pos2 {
+        galley.rows[0].visuals.mesh.vertices[0].uv
+    }
+
+    /// egui repacks the whole font atlas when the scale changes, and drops its
+    /// own galley cache doing it.  A galley kept across that boundary still
+    /// addresses the slot it had in the discarded atlas, so it paints whatever
+    /// character was repacked into that slot instead of its own.
+    #[test]
+    fn a_repacked_atlas_discards_the_cached_galleys() {
+        let ctx = ctx();
+        let mut cache = GlyphCache::new();
+        cache.begin_frame(&ctx);
+        let before = atlas_pos(&cache.get(&ctx, 'a', Face::Normal, 14.0));
+
+        ctx.set_pixels_per_point(2.0);
+        let _ = ctx.run(egui::RawInput::default(), |_| {});
+        cache.begin_frame(&ctx);
+        let served = atlas_pos(&cache.get(&ctx, 'a', Face::Normal, 14.0));
+
+        let repacked = ctx.fonts(|f| f.layout_job(glyph_job('a', Face::Normal, 14.0)));
+        assert_ne!(
+            before,
+            atlas_pos(&repacked),
+            "the scale change did not move 'a' in the atlas, so this cannot detect a stale galley"
+        );
+        assert_eq!(
+            served,
+            atlas_pos(&repacked),
+            "cache served a galley addressing the discarded atlas"
+        );
     }
 
     #[test]

--- a/alacritree/src/ipc.rs
+++ b/alacritree/src/ipc.rs
@@ -116,6 +116,31 @@ pub enum IpcRequest {
     },
 }
 
+impl IpcRequest {
+    /// The variant's name, for logs that must not print the payload: paths and
+    /// `SendText` bodies are the caller's data, not ours to write to a file.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::ListProjects => "ListProjects",
+            Self::ListSessions => "ListSessions",
+            Self::SelectWorkspace { .. } => "SelectWorkspace",
+            Self::CreateSession { .. } => "CreateSession",
+            Self::CloseSession { .. } => "CloseSession",
+            Self::SendText { .. } => "SendText",
+            Self::MoveSession { .. } => "MoveSession",
+            Self::ReadScreen { .. } => "ReadScreen",
+            Self::ReadScratchpad { .. } => "ReadScratchpad",
+            Self::RefreshProject { .. } => "RefreshProject",
+            Self::AddProject { .. } => "AddProject",
+            Self::RemoveProject { .. } => "RemoveProject",
+            Self::RenameProject { .. } => "RenameProject",
+            Self::GitStatus { .. } => "GitStatus",
+            Self::CreateWorktree { .. } => "CreateWorktree",
+            Self::RunAction { .. } => "RunAction",
+        }
+    }
+}
+
 pub type IpcResult = Result<Value, String>;
 
 /// One request en route to the UI thread, with the channel the connection

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -30,6 +30,8 @@ mod path_style;
 mod pr_status;
 mod project_refresh;
 mod projects;
+#[cfg(windows)]
+mod pty_rearm;
 mod row_label;
 mod scratchpad;
 mod session;

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -108,7 +108,8 @@ fn main() -> eframe::Result<()> {
         viewport = viewport.with_icon(icon);
     }
 
-    let native_options = eframe::NativeOptions { viewport, ..Default::default() };
+    let native_options =
+        eframe::NativeOptions { viewport, vsync: config.ui.vsync, ..Default::default() };
 
     eframe::run_native(
         "Alacritree",

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -14,6 +14,7 @@ mod doppler;
 mod fonts;
 mod git_nav;
 mod git_status;
+mod glyph_cache;
 mod ime;
 mod input;
 mod ipc;

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -28,6 +28,7 @@ mod panel_filter;
 mod paste;
 mod path_style;
 mod pr_status;
+mod project_refresh;
 mod projects;
 mod row_label;
 mod scratchpad;

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -12,6 +12,7 @@ mod command_palette;
 mod config;
 mod doppler;
 mod fonts;
+mod frame_log;
 mod git_nav;
 mod git_status;
 mod glyph_cache;

--- a/alacritree/src/project_refresh.rs
+++ b/alacritree/src/project_refresh.rs
@@ -1,0 +1,158 @@
+//! Bookkeeping for worktree re-discovery, which always runs on a worker.
+//!
+//! Discovery opens the repository with git2, enumerates worktrees and resolves
+//! the default branch — tens of milliseconds on a project with many worktrees,
+//! far too much for the UI thread.
+//!
+//! IPC callers still block until the result is live rather than being answered
+//! the moment the worker starts: a client that refreshes a project in order to
+//! act on the new worktree list would otherwise race its own request.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+
+use crate::ipc::IpcResult;
+use crate::projects::Discovered;
+
+struct Pending {
+    rx: Receiver<Discovered>,
+    waiters: Vec<Sender<IpcResult>>,
+}
+
+#[derive(Default)]
+pub struct ProjectRefreshes {
+    pending: HashMap<PathBuf, Pending>,
+}
+
+impl ProjectRefreshes {
+    pub fn is_running(&self, root: &Path) -> bool {
+        self.pending.contains_key(root)
+    }
+
+    pub fn start(&mut self, root: PathBuf, rx: Receiver<Discovered>) {
+        self.pending.insert(root, Pending { rx, waiters: Vec::new() });
+    }
+
+    /// Park `reply_tx` until the refresh running for `root` has been applied.
+    /// Hands the channel back when nothing is running, leaving the caller to
+    /// answer it however it sees fit.
+    pub fn watch(&mut self, root: &Path, reply_tx: Sender<IpcResult>) -> Option<Sender<IpcResult>> {
+        match self.pending.get_mut(root) {
+            Some(pending) => {
+                pending.waiters.push(reply_tx);
+                None
+            },
+            None => Some(reply_tx),
+        }
+    }
+
+    /// Adopt every finished discovery through `apply`, then answer whoever was
+    /// waiting on it with the reply `apply` produced.
+    pub fn poll(&mut self, mut apply: impl FnMut(&Path, Discovered) -> IpcResult) {
+        self.pending.retain(|root, pending| match pending.rx.try_recv() {
+            Ok(found) => {
+                let reply = apply(root, found);
+                for waiter in pending.waiters.drain(..) {
+                    let _ = waiter.send(reply.clone());
+                }
+                false
+            },
+            Err(TryRecvError::Empty) => true,
+            Err(TryRecvError::Disconnected) => {
+                for waiter in pending.waiters.drain(..) {
+                    let _ = waiter.send(Err("project refresh worker stopped".to_string()));
+                }
+                false
+            },
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::projects::Project;
+    use serde_json::json;
+    use std::sync::mpsc;
+
+    fn discovered(root: &str) -> Discovered {
+        Discovered { project: Project::placeholder(PathBuf::from(root)), authoritative: true }
+    }
+
+    #[test]
+    fn a_waiter_is_answered_only_once_the_discovery_has_been_applied() {
+        let root = PathBuf::from("/a");
+        let (found_tx, found_rx) = mpsc::channel();
+        let (reply_tx, reply_rx) = mpsc::channel();
+
+        let mut refreshes = ProjectRefreshes::default();
+        refreshes.start(root.clone(), found_rx);
+        assert!(refreshes.watch(&root, reply_tx).is_none(), "a running refresh takes the waiter");
+
+        let mut applied = Vec::new();
+        refreshes.poll(|root, _| {
+            applied.push(root.to_path_buf());
+            Ok(json!({}))
+        });
+        assert!(applied.is_empty(), "nothing to apply until the worker reports");
+        assert!(
+            matches!(reply_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "replying before the worktree list is live would let the caller act on stale data"
+        );
+
+        found_tx.send(discovered("/a")).unwrap();
+        refreshes.poll(|root, _| {
+            applied.push(root.to_path_buf());
+            Ok(json!({ "root": root }))
+        });
+
+        assert_eq!(applied, vec![root.clone()]);
+        assert_eq!(reply_rx.try_recv().unwrap(), Ok(json!({ "root": root })));
+        assert!(!refreshes.is_running(&root), "a finished refresh is forgotten");
+    }
+
+    #[test]
+    fn a_second_request_joins_the_refresh_already_running() {
+        let root = PathBuf::from("/a");
+        let (found_tx, found_rx) = mpsc::channel();
+        let (first_tx, first_rx) = mpsc::channel();
+        let (second_tx, second_rx) = mpsc::channel();
+
+        let mut refreshes = ProjectRefreshes::default();
+        refreshes.start(root.clone(), found_rx);
+        assert!(refreshes.watch(&root, first_tx).is_none());
+        assert!(refreshes.watch(&root, second_tx).is_none());
+
+        found_tx.send(discovered("/a")).unwrap();
+        refreshes.poll(|_, _| Ok(json!({ "ok": true })));
+
+        assert_eq!(first_rx.try_recv().unwrap(), Ok(json!({ "ok": true })));
+        assert_eq!(second_rx.try_recv().unwrap(), Ok(json!({ "ok": true })));
+    }
+
+    #[test]
+    fn watching_a_project_with_no_refresh_running_hands_the_channel_back() {
+        let (reply_tx, _reply_rx) = mpsc::channel();
+        let mut refreshes = ProjectRefreshes::default();
+
+        assert!(refreshes.watch(Path::new("/a"), reply_tx).is_some());
+    }
+
+    #[test]
+    fn a_worker_that_dies_still_answers_its_waiters() {
+        let root = PathBuf::from("/a");
+        let (found_tx, found_rx) = mpsc::channel::<Discovered>();
+        let (reply_tx, reply_rx) = mpsc::channel();
+
+        let mut refreshes = ProjectRefreshes::default();
+        refreshes.start(root.clone(), found_rx);
+        refreshes.watch(&root, reply_tx);
+        drop(found_tx);
+
+        refreshes.poll(|_, _| Ok(json!({})));
+
+        assert!(reply_rx.try_recv().unwrap().is_err(), "a caller must never block forever");
+        assert!(!refreshes.is_running(&root));
+    }
+}

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -225,11 +225,6 @@ impl Project {
         self.label.as_deref().unwrap_or(&self.name)
     }
 
-    pub fn refresh(&mut self) {
-        let found = Project::discover(self.root.clone());
-        self.apply(found);
-    }
-
     /// Adopt a discovery result.  A non-authoritative result leaves the
     /// discovered fields alone: an unreachable backend must not read as
     /// deletion.  `expanded`, `shell_override`, and `label` are user state and

--- a/alacritree/src/pty_rearm.rs
+++ b/alacritree/src/pty_rearm.rs
@@ -29,6 +29,18 @@ use alacritty_terminal::tty::{
 use polling::os::iocp::{CompletionPacket, PollerIocpExt};
 use polling::{Event, PollMode, Poller};
 
+/// How much one read may hand back.
+///
+/// The read loop reserves the terminal for as long as it runs and stops once
+/// it has parsed its own cap, but it checks that cap only after parsing
+/// whatever the last read returned — so a single drain the size of its buffer
+/// becomes a single parse of the same size, and the pane holds the grid for as
+/// long as that takes.  A console delivers hundreds of kilobytes at a time
+/// under load, which is tens of milliseconds the UI thread spends queued for a
+/// lock it needs every frame.  Handing back a slice instead splits that into
+/// batches the loop can be interrupted between.
+const READ_CHUNK: usize = 32 * 1024;
+
 /// Owns the PTY because `EventedReadWrite` hands out `&mut Self::Reader`, and
 /// only the type holding the reader can supply that.
 pub struct RearmingReader {
@@ -38,7 +50,8 @@ pub struct RearmingReader {
 
 impl Read for RearmingReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let read = self.pty.reader().read(buf)?;
+        let chunk = buf.len().min(READ_CHUNK);
+        let read = self.pty.reader().read(&mut buf[..chunk])?;
         if read > 0 {
             if let Some(poller) = &self.poller {
                 let _ = poller.post(CompletionPacket::new(Event::readable(PTY_READ_WRITE_TOKEN)));

--- a/alacritree/src/pty_rearm.rs
+++ b/alacritree/src/pty_rearm.rs
@@ -1,0 +1,109 @@
+//! Supplies the level-triggered console readiness that the PTY reader accepts
+//! but never sends.
+//!
+//! Windows has no readiness to report for a console pipe, so the reader
+//! emulates it: a completion packet reaches the poller through the waker
+//! `piper` holds for its pipe.  `piper` installs that waker only when a drain
+//! comes up empty, which is the ordinary contract — poll until pending.  The
+//! reader takes `PollMode::Level` and then never posts a packet of its own
+//! after a drain returns data, so a drain that leaves bytes behind ends with
+//! the pipe holding data and nothing able to announce it.  The loop sleeps
+//! until something unrelated arrives — a keystroke, a resize, the child
+//! exiting — which is why a pane streaming megabytes only advances while the
+//! user types.
+//!
+//! Wrapping the reader posts that packet.  Every read carrying data announces
+//! the pipe again, so the loop keeps coming back until a drain finally comes
+//! up empty and `piper` takes over.  Announcing after the read that empties
+//! the pipe costs one wakeup that finds nothing; skipping it would restore the
+//! stall, because then no drain ever reaches the pending path that installs
+//! the waker.
+
+use std::io::{self, Read};
+use std::sync::Arc;
+
+use alacritty_terminal::event::{OnResize, WindowSize};
+use alacritty_terminal::tty::{
+    ChildEvent, EventedPty, EventedReadWrite, PTY_READ_WRITE_TOKEN, Pty,
+};
+use polling::os::iocp::{CompletionPacket, PollerIocpExt};
+use polling::{Event, PollMode, Poller};
+
+/// Owns the PTY because `EventedReadWrite` hands out `&mut Self::Reader`, and
+/// only the type holding the reader can supply that.
+pub struct RearmingReader {
+    pty: Pty,
+    poller: Option<Arc<Poller>>,
+}
+
+impl Read for RearmingReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let read = self.pty.reader().read(buf)?;
+        if read > 0 {
+            if let Some(poller) = &self.poller {
+                let _ = poller.post(CompletionPacket::new(Event::readable(PTY_READ_WRITE_TOKEN)));
+            }
+        }
+        Ok(read)
+    }
+}
+
+pub struct RearmingPty {
+    reader: RearmingReader,
+}
+
+impl RearmingPty {
+    pub fn new(pty: Pty) -> Self {
+        Self { reader: RearmingReader { pty, poller: None } }
+    }
+}
+
+impl EventedReadWrite for RearmingPty {
+    type Reader = RearmingReader;
+    type Writer = <Pty as EventedReadWrite>::Writer;
+
+    unsafe fn register(
+        &mut self,
+        poll: &Arc<Poller>,
+        interest: Event,
+        poll_opts: PollMode,
+    ) -> io::Result<()> {
+        self.reader.poller = Some(poll.clone());
+        unsafe { self.reader.pty.register(poll, interest, poll_opts) }
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &Arc<Poller>,
+        interest: Event,
+        poll_opts: PollMode,
+    ) -> io::Result<()> {
+        self.reader.poller = Some(poll.clone());
+        self.reader.pty.reregister(poll, interest, poll_opts)
+    }
+
+    fn deregister(&mut self, poll: &Arc<Poller>) -> io::Result<()> {
+        self.reader.poller = None;
+        self.reader.pty.deregister(poll)
+    }
+
+    fn reader(&mut self) -> &mut Self::Reader {
+        &mut self.reader
+    }
+
+    fn writer(&mut self) -> &mut Self::Writer {
+        self.reader.pty.writer()
+    }
+}
+
+impl EventedPty for RearmingPty {
+    fn next_child_event(&mut self) -> Option<ChildEvent> {
+        self.reader.pty.next_child_event()
+    }
+}
+
+impl OnResize for RearmingPty {
+    fn on_resize(&mut self, window_size: WindowSize) {
+        self.reader.pty.on_resize(window_size);
+    }
+}

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -42,25 +42,33 @@ impl EventProxy {
     }
 }
 
-/// Whether an event has to wake the egui loop even though this session's grid
-/// is off screen.  `Wakeup` and `MouseCursorDirty` report only that grid
-/// content changed, which nothing on screen shows until the session is
-/// displayed again — a frame drawn for them repaints the *visible* session to
-/// the same pixels it already had.  Every other event has an effect the user
-/// can observe while looking elsewhere: titles and bells reach the sidebar,
-/// exits close a tab, and PTY replies are what the asking program is blocked
-/// on until a frame drains them.
-fn wakes_hidden_ui(event: &TermEvent) -> bool {
+/// Whether an event carries something a frame has to act on, rather than just
+/// reporting that the grid changed.  `Wakeup` and `MouseCursorDirty` carry no
+/// payload: the grid they announce was already updated under the terminal
+/// lock, and the mouse icon is recomputed from hover state every frame, so a
+/// repaint is the whole of their effect.  Every other event has one a frame
+/// must observe: titles and bells reach the sidebar, exits close a tab, and
+/// PTY replies are what the asking program is blocked on until a frame drains
+/// them.
+fn carries_payload(event: &TermEvent) -> bool {
     !matches!(event, TermEvent::Wakeup | TermEvent::MouseCursorDirty)
 }
 
 impl EventListener for EventProxy {
     fn send_event(&self, event: TermEvent) {
-        let wake = self.visible.load(Ordering::Relaxed) || wakes_hidden_ui(&event);
-        let _ = self.sender.send(event);
-        if wake {
-            self.ctx.request_repaint();
+        // A hidden session's grid is not on screen, so a repaint for it would
+        // redraw the *visible* session to the same pixels.  Nothing then
+        // drains the channel either, which is why the payload-free events must
+        // not enter it: a background agent streaming output would grow it for
+        // as long as the window stayed idle.
+        if !carries_payload(&event) {
+            if self.visible.load(Ordering::Relaxed) {
+                self.ctx.request_repaint();
+            }
+            return;
         }
+        let _ = self.sender.send(event);
+        self.ctx.request_repaint();
     }
 }
 
@@ -1443,9 +1451,26 @@ mod tests {
         let (proxy, events) = EventProxy::new(ctx);
         proxy.set_visible(false);
 
-        proxy.send_event(TermEvent::Wakeup);
+        proxy.send_event(TermEvent::Title("claude: thinking".into()));
 
-        assert!(matches!(events.try_recv(), Ok(TermEvent::Wakeup)));
+        assert!(matches!(events.try_recv(), Ok(TermEvent::Title(_))));
+    }
+
+    /// Nothing drains a hidden session's channel, because nothing wakes the
+    /// loop for it.  Payload-free wakeups therefore cannot go in: a background
+    /// agent streaming output would grow the channel for as long as the window
+    /// stays idle, and the next frame would have to pop all of it.
+    #[test]
+    fn a_hidden_sessions_wakeups_do_not_accumulate() {
+        let (proxy, events) = EventProxy::new(egui::Context::default());
+        proxy.set_visible(false);
+
+        for _ in 0..10_000 {
+            proxy.send_event(TermEvent::Wakeup);
+            proxy.send_event(TermEvent::MouseCursorDirty);
+        }
+
+        assert_eq!(events.try_iter().count(), 0);
     }
 
     #[cfg(target_os = "macos")]

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -1185,6 +1185,9 @@ impl Session {
         let pty = tty::new(&pty_options, window_size, window_id)?;
         let shell_pid = pty_shell_pid(&pty);
 
+        #[cfg(windows)]
+        let pty = crate::pty_rearm::RearmingPty::new(pty);
+
         let event_loop = EventLoop::new(term.clone(), proxy.clone(), pty, false, false)?;
         let sender = event_loop.channel();
         event_loop.spawn();
@@ -2025,6 +2028,84 @@ mod tests {
         // Paired with ALT_SCREEN this is what `apply_scroll` keys off; it is on by
         // default, so a pager resetting it would silently break the wheel too.
         assert!(session.term.lock().mode().contains(TermMode::ALTERNATE_SCROLL));
+    }
+
+    /// A burst bigger than one read must keep flowing with nothing typed.
+    ///
+    /// Windows has no real readiness for the console pipe, so the reader
+    /// emulates it: a completion packet is posted from the waker `piper`
+    /// holds, and `piper` installs that waker only when a drain comes up
+    /// empty.  A read burst that stops at `MAX_LOCKED_READ` with more still
+    /// buffered therefore leaves nothing able to announce the rest, and the
+    /// loop sleeps until an unrelated event arrives.  A keystroke is one; a
+    /// benchmark writing megabytes is not, so its output stalls until the
+    /// user types.
+    #[cfg(windows)]
+    #[test]
+    fn a_burst_bigger_than_one_read_keeps_flowing_without_input() {
+        crate::harden_dll_search_path();
+
+        const MARKER: &str = "BURST-COMPLETE";
+
+        // Writing to the standard output handle rather than `Console.Out`,
+        // because the stall needs one drain to come back holding more than
+        // `MAX_LOCKED_READ`.  `Console.Out` is a `StreamWriter` and hands the
+        // console a few hundred bytes at a time however large the string is,
+        // which the reader keeps up with; the handle takes the whole buffer in
+        // one write.  This is also why a program printing line by line never
+        // stalls and an ordinary shell session looks fine.
+        let script =
+            std::env::temp_dir().join(format!("alacritree-burst-{}.ps1", std::process::id()));
+        std::fs::write(
+            &script,
+            format!(
+                "$out = [Console]::OpenStandardOutput()\n\
+                 $block = [Text.Encoding]::ASCII.GetBytes([string]::new('x', 262144))\n\
+                 for ($i = 0; $i -lt 32; $i++) {{\n\
+                 $out.Write($block, 0, $block.Length)\n\
+                 }}\n\
+                 $tail = [Text.Encoding]::ASCII.GetBytes(\"`n{MARKER}`n\")\n\
+                 $out.Write($tail, 0, $tail.Length)\n\
+                 $out.Flush()\n\
+                 Start-Sleep -Seconds 600\n"
+            ),
+        )
+        .unwrap();
+
+        // The producer sleeps rather than exits: a child that exits would end
+        // the read loop through its own watcher, which is exactly the
+        // unrelated event this has to do without.
+        let session = Session::spawn_command(
+            egui::Context::default(),
+            &Config::default(),
+            std::env::current_dir().ok(),
+            TermSize::new(80, 24),
+            (8.0, 16.0),
+            "powershell".to_string(),
+            vec!["-NoProfile".to_string(), "-File".to_string(), script.display().to_string()],
+            "probe".to_string(),
+            SessionKind::Shell,
+        )
+        .unwrap();
+
+        let start = Instant::now();
+        let arrived = loop {
+            if session.screen_snapshot(0).lines.iter().any(|line| line.contains(MARKER)) {
+                break Some(start.elapsed());
+            }
+            if start.elapsed() > Duration::from_secs(60) {
+                break None;
+            }
+            std::thread::sleep(Duration::from_millis(250));
+        };
+        let _ = std::fs::remove_file(&script);
+
+        let screen = session.screen_snapshot(0).lines.join("\n");
+        assert!(
+            arrived.is_some(),
+            "the pane was written 8 MiB back to back and the last line never arrived: the read \
+             loop is waiting for input it should not need.\nScreen was:\n{screen}"
+        );
     }
 
     /// A pane must not wait on the console host's startup handshake.

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -54,6 +54,16 @@ fn carries_payload(event: &TermEvent) -> bool {
     !matches!(event, TermEvent::Wakeup | TermEvent::MouseCursorDirty)
 }
 
+/// How long a background session's spinner frame may wait for the loop.
+///
+/// Agents animate a Braille spinner in the terminal title, so a busy one emits
+/// a title change several times a second.  Off screen that moves a sidebar
+/// glyph, and waking the loop for each one repaints the entire visible grid to
+/// do it — with a few agents running, enough to saturate the UI thread.
+/// Coalescing to this interval keeps the glyph turning without letting the
+/// animation set the frame rate.
+const SPINNER_COALESCE: Duration = Duration::from_millis(120);
+
 impl EventListener for EventProxy {
     fn send_event(&self, event: TermEvent) {
         // A hidden session's grid is not on screen, so a repaint for it would
@@ -67,8 +77,17 @@ impl EventListener for EventProxy {
             }
             return;
         }
+        // The frame that ends the animation is the one that matters — a
+        // spinner title giving way to a plain one is how an agent says it is
+        // done — so only the animation frames themselves are held back.
+        let spinner_frame = !self.visible.load(Ordering::Relaxed)
+            && matches!(&event, TermEvent::Title(title) if is_spinner_title(title));
         let _ = self.sender.send(event);
-        self.ctx.request_repaint();
+        if spinner_frame {
+            self.ctx.request_repaint_after(SPINNER_COALESCE);
+        } else {
+            self.ctx.request_repaint();
+        }
     }
 }
 
@@ -1524,9 +1543,44 @@ mod tests {
         assert!(ctx.has_requested_repaint(), "the on-screen grid must repaint when it changes");
     }
 
+    /// An agent animating a Braille spinner in its title emits one of these
+    /// several times a second.  Off screen it moves a sidebar glyph, and
+    /// waking the loop for each repaints the whole visible grid to do it —
+    /// with a few agents running, that alone saturates the UI thread.
+    #[test]
+    fn a_hidden_sessions_spinner_frame_does_not_force_a_repaint() {
+        let ctx = egui::Context::default();
+        let (proxy, events) = EventProxy::new(ctx.clone());
+        proxy.set_visible(false);
+
+        // The delay egui hands its repaint callback is what winit schedules
+        // the wakeup on, so it is the difference between "draw now" and "draw
+        // when convenient".  `has_requested_repaint` reports both alike.
+        let delays = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen = Arc::clone(&delays);
+        ctx.set_request_repaint_callback(move |info| {
+            seen.lock().expect("delays").push(info.delay);
+        });
+
+        proxy.send_event(TermEvent::Title("⠋ claude".into()));
+
+        let delays = delays.lock().expect("delays");
+        assert_eq!(delays.len(), 1, "a spinner frame asked for more than one repaint");
+        assert!(
+            delays[0] > Duration::ZERO,
+            "a background spinner frame repainted the visible grid immediately"
+        );
+        assert!(
+            matches!(events.try_recv(), Ok(TermEvent::Title(_))),
+            "the title still has to reach the sidebar, just not this instant"
+        );
+    }
+
     /// Only grid content is invisible while a session is off-screen.  Titles
     /// and bells drive the sidebar, and PTY replies block the program that
     /// asked until a frame drains them, so those still have to wake the loop.
+    /// A spinner giving way to a plain title is how an agent signals it is
+    /// done, so that transition is exactly the one that must not be held back.
     #[test]
     fn a_hidden_sessions_title_still_wakes_the_ui() {
         let ctx = egui::Context::default();

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -2,6 +2,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
@@ -25,19 +26,41 @@ use crate::wsl_helper::{self, WslProbe};
 pub struct EventProxy {
     ctx: egui::Context,
     sender: mpsc::Sender<TermEvent>,
+    /// Whether this session's grid is the one on screen.  Read from the PTY
+    /// thread on every event, written by the UI thread once per frame.
+    visible: Arc<AtomicBool>,
 }
 
 impl EventProxy {
     pub fn new(ctx: egui::Context) -> (Self, mpsc::Receiver<TermEvent>) {
         let (sender, receiver) = mpsc::channel();
-        (Self { ctx, sender }, receiver)
+        (Self { ctx, sender, visible: Arc::new(AtomicBool::new(true)) }, receiver)
     }
+
+    pub fn set_visible(&self, visible: bool) {
+        self.visible.store(visible, Ordering::Relaxed);
+    }
+}
+
+/// Whether an event has to wake the egui loop even though this session's grid
+/// is off screen.  `Wakeup` and `MouseCursorDirty` report only that grid
+/// content changed, which nothing on screen shows until the session is
+/// displayed again — a frame drawn for them repaints the *visible* session to
+/// the same pixels it already had.  Every other event has an effect the user
+/// can observe while looking elsewhere: titles and bells reach the sidebar,
+/// exits close a tab, and PTY replies are what the asking program is blocked
+/// on until a frame drains them.
+fn wakes_hidden_ui(event: &TermEvent) -> bool {
+    !matches!(event, TermEvent::Wakeup | TermEvent::MouseCursorDirty)
 }
 
 impl EventListener for EventProxy {
     fn send_event(&self, event: TermEvent) {
+        let wake = self.visible.load(Ordering::Relaxed) || wakes_hidden_ui(&event);
         let _ = self.sender.send(event);
-        self.ctx.request_repaint();
+        if wake {
+            self.ctx.request_repaint();
+        }
     }
 }
 
@@ -123,6 +146,9 @@ pub struct Session {
     wsl_probe: Option<WslProbe>,
     notifier: Option<Notifier>,
     sender: Option<EventLoopSender>,
+    /// Shares this session's on-screen flag with the `EventProxy` its PTY
+    /// thread posts events through.
+    proxy: EventProxy,
     exited: bool,
 }
 
@@ -921,7 +947,7 @@ impl Session {
     ) -> std::io::Result<Self> {
         let editor = scratchpad::Editor::open(path.clone())?;
         let (proxy, events) = EventProxy::new(ctx);
-        let term = Arc::new(FairMutex::new(Term::new(term_config(config), &size, proxy)));
+        let term = Arc::new(FairMutex::new(Term::new(term_config(config), &size, proxy.clone())));
         Ok(Self {
             id: next_session_id(),
             title: "scratchpad".to_string(),
@@ -941,6 +967,7 @@ impl Session {
             wsl_probe: None,
             notifier: None,
             sender: None,
+            proxy,
             exited: false,
         })
     }
@@ -1020,7 +1047,7 @@ impl Session {
         let pty = tty::new(&pty_options, window_size, window_id)?;
         let shell_pid = pty_shell_pid(&pty);
 
-        let event_loop = EventLoop::new(term.clone(), proxy, pty, false, false)?;
+        let event_loop = EventLoop::new(term.clone(), proxy.clone(), pty, false, false)?;
         let sender = event_loop.channel();
         event_loop.spawn();
 
@@ -1046,8 +1073,16 @@ impl Session {
             wsl_probe,
             notifier: Some(Notifier(sender.clone())),
             sender: Some(sender),
+            proxy,
             exited: false,
         })
+    }
+
+    /// Mark whether this session's grid is the one being painted.  Output from
+    /// a session that isn't stops waking the egui loop, so a busy agent in a
+    /// background tab no longer costs a full repaint per chunk of output.
+    pub fn set_visible(&self, visible: bool) {
+        self.proxy.set_visible(visible);
     }
 
     pub fn write(&self, bytes: Vec<u8>) {
@@ -1340,6 +1375,78 @@ mod tests {
     use alacritty_terminal::vte::ansi::{Processor, StdSyncHandler};
 
     use super::*;
+
+    /// A repainted frame costs a full grid paint of whatever session is on
+    /// screen — milliseconds, at a maximized window.  Output from a session
+    /// the user cannot see changes nothing about that frame, so waking the UI
+    /// for it spends that cost to draw the same pixels again.  Several busy
+    /// agents in background tabs is enough to keep the loop saturated, which
+    /// is what typing then queues behind.
+    #[test]
+    fn a_hidden_sessions_output_does_not_wake_the_ui() {
+        let ctx = egui::Context::default();
+        let (proxy, _events) = EventProxy::new(ctx.clone());
+        proxy.set_visible(false);
+
+        proxy.send_event(TermEvent::Wakeup);
+
+        assert!(
+            !ctx.has_requested_repaint(),
+            "output from an off-screen session repainted the visible grid"
+        );
+    }
+
+    #[test]
+    fn a_visible_sessions_output_wakes_the_ui() {
+        let ctx = egui::Context::default();
+        let (proxy, _events) = EventProxy::new(ctx.clone());
+
+        proxy.send_event(TermEvent::Wakeup);
+
+        assert!(ctx.has_requested_repaint(), "the on-screen grid must repaint when it changes");
+    }
+
+    /// Only grid content is invisible while a session is off-screen.  Titles
+    /// and bells drive the sidebar, and PTY replies block the program that
+    /// asked until a frame drains them, so those still have to wake the loop.
+    #[test]
+    fn a_hidden_sessions_title_still_wakes_the_ui() {
+        let ctx = egui::Context::default();
+        let (proxy, _events) = EventProxy::new(ctx.clone());
+        proxy.set_visible(false);
+
+        proxy.send_event(TermEvent::Title("claude: thinking".into()));
+
+        assert!(ctx.has_requested_repaint(), "a background title change must reach the sidebar");
+    }
+
+    #[test]
+    fn a_hidden_sessions_pty_reply_still_wakes_the_ui() {
+        let ctx = egui::Context::default();
+        let (proxy, _events) = EventProxy::new(ctx.clone());
+        proxy.set_visible(false);
+
+        proxy.send_event(TermEvent::TextAreaSizeRequest(Arc::new(|_| String::new())));
+
+        assert!(
+            ctx.has_requested_repaint(),
+            "a program blocked on a terminal reply must not wait for unrelated input"
+        );
+    }
+
+    /// Events are queued whether or not they wake the loop, so a session that
+    /// was hidden while it produced output has all of it waiting the moment
+    /// something else draws a frame.
+    #[test]
+    fn a_hidden_sessions_events_are_still_queued() {
+        let ctx = egui::Context::default();
+        let (proxy, events) = EventProxy::new(ctx);
+        proxy.set_visible(false);
+
+        proxy.send_event(TermEvent::Wakeup);
+
+        assert!(matches!(events.try_recv(), Ok(TermEvent::Wakeup)));
+    }
 
     #[cfg(target_os = "macos")]
     #[test]

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -815,71 +815,136 @@ fn pty_working_directory(explicit: Option<PathBuf>, config: &Config) -> Option<P
 
 #[cfg(windows)]
 mod windows_process_probe {
-    //! Shared, throttled process-table snapshot.  Every session probes at
-    //! its own `AGENT_CACHE_TTL` cadence; keeping one global `System` means
-    //! N sessions cost one enumeration per tick, not N.  Two-phase refresh:
-    //! names + parent pids for the whole table (one cheap system call
-    //! class), command lines only for the shell's descendants and only when
-    //! no name matched.
-    use std::collections::BTreeMap;
-    use std::sync::{Mutex, PoisonError};
-    use std::time::{Duration, Instant};
+    //! Background process-table scan behind the sidebar's agent signals.
+    //!
+    //! Enumerating the process table costs ~12 ms and fetching command lines
+    //! another ~15 ms, both far too much for the UI thread that asks for them.
+    //! A single refresher thread does the work for every shell the UI has
+    //! asked about and publishes the results; `probe` only reads what was last
+    //! published.  Sessions already tolerate an answer up to `AGENT_CACHE_TTL`
+    //! old, so nothing about the displayed result changes.
+    //!
+    //! The scan is two-phase: names and parent pids for the whole table (one
+    //! cheap system call class), command lines only for a shell's descendants
+    //! and only when no name matched.
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::{Condvar, Mutex, PoisonError};
+    use std::time::Duration;
 
     use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
     use super::{agent_glyph_by_cmdline, agent_glyph_by_name, is_nav_tui_name, process_tree_pids};
 
-    /// Slightly under `AGENT_CACHE_TTL` so the first session to tick
-    /// refreshes and the rest reuse the same table.
-    pub(super) const SNAPSHOT_TTL: Duration = Duration::from_millis(900);
+    /// Slightly under `AGENT_CACHE_TTL`, so a session polling on its own clock
+    /// finds a result no older than one of its own cache windows.
+    pub(super) const REFRESH_INTERVAL: Duration = Duration::from_millis(900);
 
-    static SNAPSHOT: Mutex<Option<(Instant, System)>> = Mutex::new(None);
-
-    /// The command-line scan the name scan falls back to, remembered per shell
-    /// against the descendant tree it ran on.
-    ///
-    /// Fetching command lines costs ~15 ms against ~10 µs for the rest of the
-    /// probe, and a shell running nothing recognizable by name reaches it on
-    /// every poll — three times a second per session, on the UI thread.  Its
-    /// answer can only change when the tree does, so an idle shell pays it
-    /// once instead.
-    static CMDLINE_GLYPH: Mutex<ScannedTrees> = Mutex::new(BTreeMap::new());
+    /// Agent glyph found in the shell's descendant tree, whether the shell has
+    /// any descendants at all, and whether one of them is a nav TUI.
+    pub(super) type Signals = (Option<char>, bool, bool);
 
     /// Per shell: the descendant tree the last command-line scan ran on, and
     /// the glyph it found there.
     pub(super) type ScannedTrees = BTreeMap<u32, (Vec<u32>, Option<char>)>;
 
-    /// The glyph remembered for `shell_pid`, or `None` when the tree has
-    /// changed since it was taken and the scan has to run again.
-    pub(super) fn remembered_glyph(
-        cache: &ScannedTrees,
-        shell_pid: u32,
-        tree: &[u32],
-    ) -> Option<Option<char>> {
-        cache.get(&shell_pid).filter(|(scanned, _)| scanned == tree).map(|(_, glyph)| *glyph)
+    #[derive(Default)]
+    struct Shared {
+        /// Shells asked about since the last pass.  Taken rather than kept, so
+        /// a window nobody is drawing costs nothing: with no frames there are
+        /// no probes, and the refresher blocks instead of enumerating.
+        wanted: BTreeSet<u32>,
+        published: BTreeMap<u32, Signals>,
+        refresher_running: bool,
     }
 
-    /// Agent glyph found in the shell's descendant tree, whether the shell
-    /// has any descendants at all, and whether one of them is a nav TUI.
-    pub(super) fn probe(shell_pid: u32) -> (Option<char>, bool, bool) {
-        let mut guard = SNAPSHOT.lock().unwrap_or_else(PoisonError::into_inner);
-        if guard.as_ref().is_none_or(|(at, _)| at.elapsed() >= SNAPSHOT_TTL) {
-            let mut sys = guard.take().map(|(_, sys)| sys).unwrap_or_default();
+    static SHARED: Mutex<Shared> = Mutex::new(Shared {
+        wanted: BTreeSet::new(),
+        published: BTreeMap::new(),
+        refresher_running: false,
+    });
+    /// Wakes the refresher when it is idling with nothing to scan.
+    static WANTED: Condvar = Condvar::new();
+
+    /// The last published signals for `shell_pid`, defaulting to "nothing
+    /// running" until the refresher has seen it.  Registers the shell so the
+    /// next pass covers it.
+    pub(super) fn probe(shell_pid: u32) -> Signals {
+        let mut shared = SHARED.lock().unwrap_or_else(PoisonError::into_inner);
+        if !shared.refresher_running {
+            shared.refresher_running = true;
+            std::thread::Builder::new()
+                .name("alacritree-process-probe".into())
+                .spawn(refresh_loop)
+                .expect("spawn process probe thread");
+        }
+        let signals = shared.published.get(&shell_pid).copied();
+        if shared.wanted.insert(shell_pid) {
+            WANTED.notify_one();
+        }
+        signals.unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub(super) fn published(shell_pid: u32) -> Option<Signals> {
+        SHARED.lock().unwrap_or_else(PoisonError::into_inner).published.get(&shell_pid).copied()
+    }
+
+    #[cfg(test)]
+    pub(super) fn nothing_wanted() -> bool {
+        SHARED.lock().unwrap_or_else(PoisonError::into_inner).wanted.is_empty()
+    }
+
+    fn refresh_loop() {
+        let mut sys = System::new();
+        let mut scanned = ScannedTrees::new();
+        loop {
+            let wanted = {
+                let mut shared = SHARED.lock().unwrap_or_else(PoisonError::into_inner);
+                while shared.wanted.is_empty() {
+                    shared = WANTED.wait(shared).unwrap_or_else(PoisonError::into_inner);
+                }
+                std::mem::take(&mut shared.wanted)
+            };
+
+            // Everything below runs with no lock held: the UI thread must
+            // never wait on an enumeration.
             sys.refresh_processes_specifics(
                 ProcessesToUpdate::All,
                 true,
                 ProcessRefreshKind::nothing(),
             );
-            *guard = Some((Instant::now(), sys));
-        }
-        let (_, sys) = guard.as_mut().expect("snapshot populated above");
+            let table: Vec<(u32, Option<u32>)> = sys
+                .processes()
+                .iter()
+                .map(|(pid, p)| (pid.as_u32(), p.parent().map(|pp| pp.as_u32())))
+                .collect();
+            let alive: BTreeSet<u32> = table.iter().map(|(pid, _)| *pid).collect();
+            let published: BTreeMap<u32, Signals> = wanted
+                .iter()
+                .filter(|pid| alive.contains(pid))
+                .map(|&pid| (pid, scan(&mut sys, &table, pid, &mut scanned)))
+                .collect();
+            scanned.retain(|pid, _| alive.contains(pid));
 
-        let table: Vec<(u32, Option<u32>)> = sys
-            .processes()
-            .iter()
-            .map(|(pid, p)| (pid.as_u32(), p.parent().map(|pp| pp.as_u32())))
-            .collect();
-        let mut tree = process_tree_pids(&table, shell_pid);
+            {
+                // Merged, not replaced: a shell that happened not to be asked
+                // about this pass keeps its last answer instead of blinking
+                // back to "nothing running".
+                let mut shared = SHARED.lock().unwrap_or_else(PoisonError::into_inner);
+                shared.published.retain(|pid, _| alive.contains(pid));
+                shared.published.extend(published);
+            }
+            std::thread::sleep(REFRESH_INTERVAL);
+        }
+    }
+
+    fn scan(
+        sys: &mut System,
+        table: &[(u32, Option<u32>)],
+        shell_pid: u32,
+        scanned: &mut ScannedTrees,
+    ) -> Signals {
+        let mut tree = process_tree_pids(table, shell_pid);
         let has_children = tree.len() > 1;
         // The table comes out of a hash map, so the tree has to be ordered
         // before it can be compared against the one the last scan ran on.
@@ -895,9 +960,7 @@ mod windows_process_probe {
         if let Some(glyph) = agent_glyph_by_name(&names) {
             return (Some(glyph), has_children, nav_tui);
         }
-
-        let mut cache = CMDLINE_GLYPH.lock().unwrap_or_else(PoisonError::into_inner);
-        if let Some(glyph) = remembered_glyph(&cache, shell_pid, &tree) {
+        if let Some(glyph) = remembered_glyph(scanned, shell_pid, &tree) {
             return (glyph, has_children, nav_tui);
         }
 
@@ -913,8 +976,20 @@ mod windows_process_probe {
             .filter_map(|pid| sys.process(*pid))
             .map(|p| p.cmd().iter().map(|a| a.to_string_lossy()).collect::<Vec<_>>().join(" "));
         let glyph = agent_glyph_by_cmdline(cmds);
-        cache.insert(shell_pid, (tree, glyph));
+        scanned.insert(shell_pid, (tree, glyph));
         (glyph, has_children, nav_tui)
+    }
+
+    /// The glyph remembered for `shell_pid`, or `None` when the tree has
+    /// changed since it was taken and the scan has to run again.  Fetching
+    /// command lines is the expensive half of a pass, and its answer can only
+    /// change when the descendant set does.
+    pub(super) fn remembered_glyph(
+        cache: &ScannedTrees,
+        shell_pid: u32,
+        tree: &[u32],
+    ) -> Option<Option<char>> {
+        cache.get(&shell_pid).filter(|(scanned, _)| scanned == tree).map(|(_, glyph)| *glyph)
     }
 }
 
@@ -1491,6 +1566,34 @@ mod tests {
         assert!(matches!(events.try_recv(), Ok(TermEvent::Title(_))));
     }
 
+    /// Refreshing the process table costs ~12 ms — a dropped frame — and
+    /// `process_probe` runs on the UI thread.  The whole round trip: the call
+    /// registers what it wants and returns with whatever was last computed,
+    /// the refresher answers on its own clock, and it then stops scanning for
+    /// a shell nobody has asked about again.
+    #[cfg(windows)]
+    #[test]
+    fn the_probe_hands_the_scan_to_the_refresher() {
+        let pid = std::process::id();
+
+        let started = Instant::now();
+        let first = windows_process_probe::probe(pid);
+        let waited = started.elapsed();
+
+        assert_eq!(first, (None, false, false), "the first probe had an answer to give");
+        assert!(waited < Duration::from_millis(5), "the probe took {waited:?} to return");
+
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while windows_process_probe::published(pid).is_none() {
+            assert!(Instant::now() < deadline, "the background refresh never published a result");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            windows_process_probe::nothing_wanted(),
+            "the refresher would keep enumerating for a window nobody is drawing"
+        );
+    }
+
     /// Starting an agent through a shim (`node`, `python`) is only visible in
     /// its command line, and it always adds a process.  A remembered scan that
     /// outlived the tree it ran on would leave the sidebar showing no agent
@@ -1522,25 +1625,20 @@ mod tests {
     fn report_process_probe_cost() {
         let pid = std::process::id();
         windows_process_probe::probe(pid);
+        // Let the refresher publish, so the reported cost is the steady state
+        // rather than the empty-map one.
+        std::thread::sleep(super::windows_process_probe::REFRESH_INTERVAL * 2);
 
-        // A burst well inside the 900 ms snapshot TTL, so every call after the
-        // first reuses the table and measures only the per-call derivation.
-        let iterations = 50;
+        let iterations = 1000;
         let started = std::time::Instant::now();
         for _ in 0..iterations {
             std::hint::black_box(windows_process_probe::probe(pid));
         }
-        let warm = started.elapsed() / iterations;
-
-        std::thread::sleep(super::windows_process_probe::SNAPSHOT_TTL);
-        let started = std::time::Instant::now();
-        std::hint::black_box(windows_process_probe::probe(pid));
-        let refresh = started.elapsed();
+        let each = started.elapsed() / iterations;
 
         let (_, counts) = crate::steady_state::measure(|| windows_process_probe::probe(pid));
         println!(
-            "probe: {warm:?} warm, {refresh:?} when the snapshot has expired, {} allocations \
-             ({} KiB)",
+            "probe on the calling thread: {each:?}, {} allocations ({} KiB)",
             counts.allocs,
             counts.bytes / 1024,
         );

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -821,6 +821,7 @@ mod windows_process_probe {
     //! names + parent pids for the whole table (one cheap system call
     //! class), command lines only for the shell's descendants and only when
     //! no name matched.
+    use std::collections::BTreeMap;
     use std::sync::{Mutex, PoisonError};
     use std::time::{Duration, Instant};
 
@@ -830,9 +831,33 @@ mod windows_process_probe {
 
     /// Slightly under `AGENT_CACHE_TTL` so the first session to tick
     /// refreshes and the rest reuse the same table.
-    const SNAPSHOT_TTL: Duration = Duration::from_millis(900);
+    pub(super) const SNAPSHOT_TTL: Duration = Duration::from_millis(900);
 
     static SNAPSHOT: Mutex<Option<(Instant, System)>> = Mutex::new(None);
+
+    /// The command-line scan the name scan falls back to, remembered per shell
+    /// against the descendant tree it ran on.
+    ///
+    /// Fetching command lines costs ~15 ms against ~10 µs for the rest of the
+    /// probe, and a shell running nothing recognizable by name reaches it on
+    /// every poll — three times a second per session, on the UI thread.  Its
+    /// answer can only change when the tree does, so an idle shell pays it
+    /// once instead.
+    static CMDLINE_GLYPH: Mutex<ScannedTrees> = Mutex::new(BTreeMap::new());
+
+    /// Per shell: the descendant tree the last command-line scan ran on, and
+    /// the glyph it found there.
+    pub(super) type ScannedTrees = BTreeMap<u32, (Vec<u32>, Option<char>)>;
+
+    /// The glyph remembered for `shell_pid`, or `None` when the tree has
+    /// changed since it was taken and the scan has to run again.
+    pub(super) fn remembered_glyph(
+        cache: &ScannedTrees,
+        shell_pid: u32,
+        tree: &[u32],
+    ) -> Option<Option<char>> {
+        cache.get(&shell_pid).filter(|(scanned, _)| scanned == tree).map(|(_, glyph)| *glyph)
+    }
 
     /// Agent glyph found in the shell's descendant tree, whether the shell
     /// has any descendants at all, and whether one of them is a nav TUI.
@@ -854,11 +879,14 @@ mod windows_process_probe {
             .iter()
             .map(|(pid, p)| (pid.as_u32(), p.parent().map(|pp| pp.as_u32())))
             .collect();
-        let tree = process_tree_pids(&table, shell_pid);
+        let mut tree = process_tree_pids(&table, shell_pid);
         let has_children = tree.len() > 1;
-        let tree: Vec<Pid> = tree.into_iter().map(Pid::from_u32).collect();
+        // The table comes out of a hash map, so the tree has to be ordered
+        // before it can be compared against the one the last scan ran on.
+        tree.sort_unstable();
+        let pids: Vec<Pid> = tree.iter().copied().map(Pid::from_u32).collect();
 
-        let names: Vec<String> = tree
+        let names: Vec<String> = pids
             .iter()
             .filter_map(|pid| sys.process(*pid))
             .map(|p| p.name().to_string_lossy().into_owned())
@@ -868,18 +896,25 @@ mod windows_process_probe {
             return (Some(glyph), has_children, nav_tui);
         }
 
+        let mut cache = CMDLINE_GLYPH.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(glyph) = remembered_glyph(&cache, shell_pid, &tree) {
+            return (glyph, has_children, nav_tui);
+        }
+
         // Names missed: fetch command lines for just the tree to catch
         // agents launched through node/python shims.
         sys.refresh_processes_specifics(
-            ProcessesToUpdate::Some(&tree),
+            ProcessesToUpdate::Some(&pids),
             false,
             ProcessRefreshKind::nothing().with_cmd(UpdateKind::Always),
         );
-        let cmds = tree
+        let cmds = pids
             .iter()
             .filter_map(|pid| sys.process(*pid))
             .map(|p| p.cmd().iter().map(|a| a.to_string_lossy()).collect::<Vec<_>>().join(" "));
-        (agent_glyph_by_cmdline(cmds), has_children, nav_tui)
+        let glyph = agent_glyph_by_cmdline(cmds);
+        cache.insert(shell_pid, (tree, glyph));
+        (glyph, has_children, nav_tui)
     }
 }
 
@@ -1454,6 +1489,61 @@ mod tests {
         proxy.send_event(TermEvent::Title("claude: thinking".into()));
 
         assert!(matches!(events.try_recv(), Ok(TermEvent::Title(_))));
+    }
+
+    /// Starting an agent through a shim (`node`, `python`) is only visible in
+    /// its command line, and it always adds a process.  A remembered scan that
+    /// outlived the tree it ran on would leave the sidebar showing no agent
+    /// for as long as that shell lived.
+    #[cfg(windows)]
+    #[test]
+    fn a_remembered_cmdline_scan_expires_when_the_tree_changes() {
+        use std::collections::BTreeMap;
+
+        use super::windows_process_probe::remembered_glyph;
+
+        let mut cache = BTreeMap::new();
+        cache.insert(42, (vec![42, 100], None));
+
+        assert_eq!(remembered_glyph(&cache, 42, &[42, 100]), Some(None));
+        assert_eq!(remembered_glyph(&cache, 42, &[42, 100, 101]), None);
+        assert_eq!(remembered_glyph(&cache, 43, &[42, 100]), None);
+    }
+
+    /// Not a gate — run it by hand:
+    /// `cargo test -p alacritree --release -- --ignored --nocapture report_process_probe_cost`
+    ///
+    /// `process_probe` runs on the UI thread whenever a session's agent cache
+    /// goes stale, and every visible frame asks for the glyph.  What one call
+    /// costs is what a keystroke can queue behind.
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "timing harness, not an assertion"]
+    fn report_process_probe_cost() {
+        let pid = std::process::id();
+        windows_process_probe::probe(pid);
+
+        // A burst well inside the 900 ms snapshot TTL, so every call after the
+        // first reuses the table and measures only the per-call derivation.
+        let iterations = 50;
+        let started = std::time::Instant::now();
+        for _ in 0..iterations {
+            std::hint::black_box(windows_process_probe::probe(pid));
+        }
+        let warm = started.elapsed() / iterations;
+
+        std::thread::sleep(super::windows_process_probe::SNAPSHOT_TTL);
+        let started = std::time::Instant::now();
+        std::hint::black_box(windows_process_probe::probe(pid));
+        let refresh = started.elapsed();
+
+        let (_, counts) = crate::steady_state::measure(|| windows_process_probe::probe(pid));
+        println!(
+            "probe: {warm:?} warm, {refresh:?} when the snapshot has expired, {} allocations \
+             ({} KiB)",
+            counts.allocs,
+            counts.bytes / 1024,
+        );
     }
 
     /// Nothing drains a hidden session's channel, because nothing wakes the

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -73,6 +73,7 @@ impl EventListener for EventProxy {
         // as long as the window stayed idle.
         if !carries_payload(&event) {
             if self.visible.load(Ordering::Relaxed) {
+                crate::frame_log::output_arrived();
                 self.ctx.request_repaint();
             }
             return;

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -1924,6 +1924,62 @@ mod tests {
         }
     }
 
+    /// Not a gate — run it by hand:
+    /// `cargo test -p alacritree --release -- --ignored --nocapture --test-threads=1 report_cost_by_rows`
+    ///
+    /// A full-screen app repaints in place, so its damage is a handful of rows
+    /// rather than the whole grid — the one workload where skipping unchanged
+    /// rows is possible at all.  What that would be worth is how much of a
+    /// frame the rows carry: blank rows emit no glyphs, so painting `filled`
+    /// of `rows` approximates repainting only that many.
+    #[test]
+    #[ignore = "timing harness, not an assertion"]
+    fn report_cost_by_rows() {
+        let config = Config::default();
+        let screen = Vec2::new(2560.0, 1440.0);
+        let ctx = egui::Context::default();
+        let (mut session, _dir) = headless_session(&ctx, &config);
+        let mut caches = Caches::new();
+        paint_one_frame(&ctx, &mut session, &config, &mut caches, screen);
+        let (cols, rows) = (session.size.columns, session.size.screen_lines);
+        session.term.lock().resize(TermSize::new(cols, rows));
+
+        for filled in [rows, rows / 2, 8, 3, 1] {
+            {
+                let mut term = session.term.lock();
+                let mut parser = Processor::<StdSyncHandler>::new();
+                parser.advance(&mut *term, b"\x1b[2J");
+                parser.advance(&mut *term, &dense_screen(cols, filled));
+            }
+
+            let mut cost = FrameCost::default();
+            for _ in 0..10 {
+                cost = paint_one_frame(&ctx, &mut session, &config, &mut caches, screen);
+            }
+            let iterations = 40;
+            let (mut build, mut tessellate) =
+                (std::time::Duration::ZERO, std::time::Duration::ZERO);
+            for _ in 0..iterations {
+                cost = std::hint::black_box(paint_one_frame(
+                    &ctx,
+                    &mut session,
+                    &config,
+                    &mut caches,
+                    screen,
+                ));
+                build += cost.build;
+                tessellate += cost.tessellate;
+            }
+
+            println!(
+                "{filled:>3} of {rows} rows with content: build {:?} + tessellate {:?}, {} vertices",
+                build / iterations,
+                tessellate / iterations,
+                cost.vertices,
+            );
+        }
+    }
+
     /// Dense output that fills every visible cell, with a colour change every
     /// few columns so the run-splitting in `paint_grid` behaves like it does
     /// under real program output rather than collapsing to one run per line.

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -111,6 +111,7 @@ pub fn show(
         );
     }
     handle_wheel_scroll(ui, &response, session, config, rect, cell_w, cell_h, cols, rows);
+    dispatch_input(ui, &response, session, ime, allow_focus);
     // Built-in renderer expects the *unadjusted* pixel cell size so it can
     // re-apply `font.offset` itself — passing `cell_w * ppp` (which already
     // includes the offset) would double-add it.  Descent is zero here: the
@@ -147,6 +148,39 @@ pub fn show(
         .map(|p| p.to_owned())
         .and_then(|p| paint_preedit(&painter, rect, session, config, &font_id, cell_w, cell_h, &p));
 
+    if allow_focus && response.has_focus() {
+        // Setting `PlatformOutput::ime` is what makes egui-winit call
+        // `set_ime_allowed(true)` — without it the OS IME never engages.
+        // The rect drives `set_ime_cursor_area`, so the candidate window
+        // follows the caret like alacritty's `update_ime_position`
+        // (TextEdit passes its whole widget rect there, which for a
+        // fullscreen terminal would pin the popup to the window corner).
+        let caret = preedit_caret
+            .or_else(|| cursor_cell_rect(session, rect, cell_w, cell_h))
+            .unwrap_or(rect);
+        ui.ctx().output_mut(|o| {
+            o.ime = Some(egui::output::IMEOutput { rect: caret, cursor_rect: caret });
+        });
+    }
+
+    response
+}
+
+/// Drain this frame's keyboard and IME events into the terminal.
+///
+/// Runs ahead of the paint so a keystroke reaches the PTY without queueing
+/// behind a full-screen grid walk, and so the selection clear and snap-to-
+/// prompt that typing triggers are visible in the frame the user typed in
+/// rather than the next one.  The preedit is likewise resolved before the grid
+/// is built, so a composition starting or ending this frame is painted this
+/// frame.
+fn dispatch_input(
+    ui: &Ui,
+    response: &Response,
+    session: &mut Session,
+    ime: &mut crate::ime::Ime,
+    allow_focus: bool,
+) {
     if allow_focus && response.has_focus() {
         // Kitty-protocol and mouse modes negotiated by the running app decide
         // how events encode, so the encoder needs the live terminal mode.
@@ -191,18 +225,6 @@ pub fn show(
                 },
             }
         }
-        // Setting `PlatformOutput::ime` is what makes egui-winit call
-        // `set_ime_allowed(true)` — without it the OS IME never engages.
-        // The rect drives `set_ime_cursor_area`, so the candidate window
-        // follows the caret like alacritty's `update_ime_position`
-        // (TextEdit passes its whole widget rect there, which for a
-        // fullscreen terminal would pin the popup to the window corner).
-        let caret = preedit_caret
-            .or_else(|| cursor_cell_rect(session, rect, cell_w, cell_h))
-            .unwrap_or(rect);
-        ui.ctx().output_mut(|o| {
-            o.ime = Some(egui::output::IMEOutput { rect: caret, cursor_rect: caret });
-        });
     } else {
         // IMEs commonly auto-commit an in-progress composition when focus
         // moves away (winit pairs the `Commit` with an immediate
@@ -234,8 +256,6 @@ pub fn show(
         // backstop that drops the painted preedit either way.
         ime.clear();
     }
-
-    response
 }
 
 /// Whether the grid owns the pointer at `pos`: inside `rect` with no floating
@@ -1253,6 +1273,94 @@ mod tests {
             })
             .sum();
         FrameCost { build, tessellate, vertices }
+    }
+
+    /// Every glyph a focused frame painted, in paint order, after feeding it
+    /// `events`.  Reading the frame's own shapes is the only way to tell what
+    /// the user saw *that* frame rather than what the terminal state became by
+    /// the end of it.
+    fn painted_text(
+        ctx: &egui::Context,
+        session: &mut Session,
+        config: &Config,
+        ime: &mut crate::ime::Ime,
+        screen: Vec2,
+        events: Vec<Event>,
+    ) -> String {
+        let raw = egui::RawInput {
+            screen_rect: Some(Rect::from_min_size(Pos2::ZERO, screen)),
+            events,
+            ..Default::default()
+        };
+        let mut builtin = BuiltinGlyphCache::new();
+        let mut colors = ColorGlyphCache::new(Vec::new(), 0);
+        let mut glyphs = GlyphCache::new();
+        let out = ctx.run(raw, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                show(ui, session, config, true, &mut builtin, ime, &mut colors, &mut glyphs);
+            });
+        });
+        let mut text = String::new();
+        for clipped in &out.shapes {
+            collect_text(&clipped.shape, &mut text);
+        }
+        text
+    }
+
+    fn collect_text(shape: &egui::Shape, out: &mut String) {
+        match shape {
+            egui::Shape::Text(text) => out.push_str(text.galley.text()),
+            egui::Shape::Vec(shapes) => shapes.iter().for_each(|s| collect_text(s, out)),
+            _ => {},
+        }
+    }
+
+    /// Typing snaps the view back to the prompt (`on_terminal_input_start`), so
+    /// the frame carrying the keystroke has to paint the bottom of the buffer.
+    /// Consuming input only after the grid is built paints the stale
+    /// scrolled-back view for one more frame, and delays the bytes reaching the
+    /// PTY by a whole paint.
+    #[test]
+    fn a_keystroke_reaches_the_terminal_before_the_grid_is_painted() {
+        let config = Config::default();
+        let ctx = egui::Context::default();
+        let (mut session, _dir) = headless_session(&ctx, &config);
+        let mut ime = crate::ime::Ime::default();
+        let screen = Vec2::new(640.0, 480.0);
+
+        // The first frame is what tells the session how big the grid is, and
+        // `Session::resize` forwards to the `Term` only when a PTY sender
+        // exists, so a headless session needs the grid resized by hand.
+        painted_text(&ctx, &mut session, &config, &mut ime, screen, Vec::new());
+        let (cols, rows) = (session.size.columns, session.size.screen_lines);
+        {
+            let mut term = session.term.lock();
+            term.resize(TermSize::new(cols, rows));
+            let mut output = Vec::new();
+            for line in 0..rows * 4 {
+                output.extend_from_slice(format!("L{line}\r\n").as_bytes());
+            }
+            Processor::<StdSyncHandler>::new().advance(&mut *term, &output);
+            term.scroll_display(Scroll::Delta(rows as i32));
+        }
+        let last = format!("L{}", rows * 4 - 1);
+
+        let scrolled_back = painted_text(&ctx, &mut session, &config, &mut ime, screen, Vec::new());
+        assert!(!scrolled_back.contains(&last), "the grid is not scrolled back to begin with");
+
+        let typed = painted_text(
+            &ctx,
+            &mut session,
+            &config,
+            &mut ime,
+            screen,
+            vec![Event::Text("a".to_owned())],
+        );
+
+        assert!(
+            typed.contains(&last),
+            "the frame carrying the keystroke painted the stale scrolled-back view"
+        );
     }
 
     /// Where a frame's time goes.  `build` is the grid walk that turns cells

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -1432,6 +1432,132 @@ mod tests {
         }
     }
 
+    /// A context with the three named terminal families bound, as
+    /// `fonts::install_terminal_fonts` leaves it in the app.  egui panics on a
+    /// family it was never given, so any fixture with a bold or italic cell
+    /// needs them.
+    fn ctx_with_terminal_faces() -> egui::Context {
+        let ctx = egui::Context::default();
+        let mut fonts = egui::FontDefinitions::default();
+        let mono = fonts.families[&FontFamily::Monospace].clone();
+        for name in [BOLD_FAMILY, ITALIC_FAMILY, BOLD_ITALIC_FAMILY] {
+            fonts.families.insert(FontFamily::Name(name.into()), mono.clone());
+        }
+        ctx.set_fonts(fonts);
+        ctx
+    }
+
+    /// A glyph as it was painted: which character, in what colour, and from
+    /// which font family.
+    #[derive(Debug, PartialEq)]
+    struct PaintedGlyph {
+        ch: String,
+        color: Color32,
+        family: FontFamily,
+    }
+
+    /// Every glyph and every filled rectangle a focused frame painted.  The
+    /// snapshot resolves colours and faces before the painter ever runs, so
+    /// this is where a mistake in that resolution becomes visible.
+    fn painted_cells(
+        ctx: &egui::Context,
+        session: &mut Session,
+        config: &Config,
+        caches: &mut Caches,
+        screen: Vec2,
+    ) -> (Vec<PaintedGlyph>, Vec<Color32>) {
+        let raw = egui::RawInput {
+            screen_rect: Some(Rect::from_min_size(Pos2::ZERO, screen)),
+            ..Default::default()
+        };
+        let out = ctx.run(raw, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                show(
+                    ui,
+                    session,
+                    config,
+                    true,
+                    &mut caches.builtin,
+                    &mut caches.ime,
+                    &mut caches.colors,
+                    &mut caches.glyphs,
+                    &mut caches.snapshot,
+                );
+            });
+        });
+        let (mut glyphs, mut fills) = (Vec::new(), Vec::new());
+        for clipped in &out.shapes {
+            collect_cells(&clipped.shape, &mut glyphs, &mut fills);
+        }
+        (glyphs, fills)
+    }
+
+    fn collect_cells(
+        shape: &egui::Shape,
+        glyphs: &mut Vec<PaintedGlyph>,
+        fills: &mut Vec<Color32>,
+    ) {
+        match shape {
+            egui::Shape::Text(text) => glyphs.push(PaintedGlyph {
+                ch: text.galley.text().to_owned(),
+                color: text.override_text_color.unwrap_or(text.fallback_color),
+                family: text.galley.job.sections[0].format.font_id.family.clone(),
+            }),
+            egui::Shape::Rect(rect) => fills.push(rect.fill),
+            egui::Shape::Vec(shapes) => shapes.iter().for_each(|s| collect_cells(s, glyphs, fills)),
+            _ => {},
+        }
+    }
+
+    /// The snapshot resolves every cell's foreground, background and face
+    /// before the terminal lock is released, so a cell that reverses video,
+    /// picks a palette colour, or asks for bold has to come out of that copy
+    /// looking the way the terminal asked.
+    #[test]
+    fn styled_cells_keep_their_colours_and_faces_through_the_snapshot() {
+        let config = Config::default();
+        let ctx = ctx_with_terminal_faces();
+        let (mut session, _dir) = headless_session(&ctx, &config);
+        let mut caches = Caches::new();
+        let screen = Vec2::new(640.0, 480.0);
+
+        painted_cells(&ctx, &mut session, &config, &mut caches, screen);
+        let (cols, rows) = (session.size.columns, session.size.screen_lines);
+        {
+            let mut term = session.term.lock();
+            term.resize(TermSize::new(cols, rows));
+            Processor::<StdSyncHandler>::new().advance(
+                &mut *term,
+                b"\x1b[0mP\x1b[7mR\x1b[0m\x1b[1mB\x1b[0m\x1b[3mI\x1b[0m\x1b[31mC",
+            );
+        }
+
+        let (glyphs, fills) = painted_cells(&ctx, &mut session, &config, &mut caches, screen);
+        let at = |ch: &str| glyphs.iter().find(|g| g.ch == ch).expect("glyph was not painted");
+
+        let fg = rgb_to_color32(resolve(
+            AnsiColor::Named(alacritty_terminal::vte::ansi::NamedColor::Foreground),
+            Flags::empty(),
+            session.term.lock().colors(),
+            &config.palette,
+            true,
+        ));
+        let bg = background(&config.palette);
+
+        assert_eq!(at("P").color, fg, "a plain cell");
+        assert_eq!(at("P").family, FontFamily::Monospace);
+
+        // Reverse video swaps the pair, so the glyph takes the default
+        // background and the run paints the default foreground behind it.
+        assert_eq!(at("R").color, bg, "a reverse-video cell");
+        assert!(fills.contains(&fg), "reverse video painted no background behind the glyph");
+
+        assert_eq!(at("B").family, FontFamily::Name(BOLD_FAMILY.into()), "a bold cell");
+        assert_eq!(at("I").family, FontFamily::Name(ITALIC_FAMILY.into()), "an italic cell");
+
+        assert_ne!(at("C").color, fg, "SGR 31 painted in the default foreground");
+    }
+
     /// Typing snaps the view back to the prompt (`on_terminal_input_start`), so
     /// the frame carrying the keystroke has to paint the bottom of the buffer.
     /// Consuming input only after the grid is built paints the stale

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -228,6 +228,7 @@ fn dispatch_input(
                     // so the user sees their input — matches alacritty's
                     // on_terminal_input_start.
                     paste::on_terminal_input_start(session);
+                    crate::frame_log::keystroke_sent();
                     session.write(bytes);
                 },
             }

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -1229,24 +1229,91 @@ mod tests {
         glyphs: &mut GlyphCache,
         ime: &mut crate::ime::Ime,
         screen: Vec2,
-    ) -> usize {
+    ) -> FrameCost {
         let raw = egui::RawInput {
             screen_rect: Some(Rect::from_min_size(Pos2::ZERO, screen)),
             ..Default::default()
         };
+        let started = std::time::Instant::now();
         let out = ctx.run(raw, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 show(ui, session, config, false, builtin, ime, colors, glyphs);
             });
         });
+        let build = started.elapsed();
         let ppp = out.pixels_per_point;
-        ctx.tessellate(out.shapes, ppp)
+        let started = std::time::Instant::now();
+        let primitives = ctx.tessellate(out.shapes, ppp);
+        let tessellate = started.elapsed();
+        let vertices = primitives
             .iter()
             .map(|p| match &p.primitive {
                 egui::epaint::Primitive::Mesh(mesh) => mesh.vertices.len(),
                 _ => 0,
             })
-            .sum()
+            .sum();
+        FrameCost { build, tessellate, vertices }
+    }
+
+    /// Where a frame's time goes.  `build` is the grid walk that turns cells
+    /// into shapes — the part damage tracking can skip; `tessellate` turns
+    /// those shapes into vertices and runs whether or not anything changed.
+    #[derive(Default, Clone, Copy)]
+    struct FrameCost {
+        build: std::time::Duration,
+        tessellate: std::time::Duration,
+        vertices: usize,
+    }
+
+    /// How much of the grid `Term` reports as damaged, as a renderer that
+    /// wanted to repaint only what changed would see it.
+    fn damage_extent(term: &mut Term<EventProxy>) -> String {
+        let extent = match term.damage() {
+            alacritty_terminal::term::TermDamage::Full => "FULL".to_string(),
+            alacritty_terminal::term::TermDamage::Partial(lines) => {
+                format!("{} lines", lines.count())
+            },
+        };
+        term.reset_damage();
+        extent
+    }
+
+    /// Not a gate — run it by hand:
+    /// `cargo test -p alacritree --release -- --ignored --nocapture report_damage`
+    ///
+    /// Decides whether damage can drive a partial repaint at all.  Scrolling
+    /// the screen marks the whole terminal damaged (`Term::scroll_up_relative`
+    /// calls `mark_fully_damaged`), and a program appending output to a full
+    /// screen scrolls on every line.
+    #[test]
+    #[ignore = "reporting harness, not an assertion"]
+    fn report_damage_under_output() {
+        let (proxy, _events) = EventProxy::new(egui::Context::default());
+        let mut term = Term::new(TermConfig::default(), &TermSize::new(80, 24), proxy);
+        let mut parser = Processor::<StdSyncHandler>::new();
+
+        parser.advance(&mut term, &dense_screen(80, 24));
+        term.reset_damage();
+
+        parser.advance(&mut term, b"\x1b[5;1Hin-place edit");
+        println!("write inside the screen, no scroll: {}", damage_extent(&mut term));
+
+        // The cursor is parked on the last row by the fill, so a newline here
+        // scrolls — the steady state for any program streaming output.
+        parser.advance(&mut term, b"\x1b[24;1H");
+        term.reset_damage();
+        parser.advance(&mut term, b"one appended line\r\n");
+        println!("append one line at the bottom: {}", damage_extent(&mut term));
+
+        parser.advance(&mut term, b"another line\r\n");
+        term.reset_damage();
+        parser.advance(&mut term, b"and another\r\n");
+        println!("append again: {}", damage_extent(&mut term));
+
+        term.scroll_display(Scroll::Delta(5));
+        term.reset_damage();
+        parser.advance(&mut term, b"output while scrolled back\r\n");
+        println!("append while scrolled back: {}", damage_extent(&mut term));
     }
 
     /// Dense output that fills every visible cell, with a colour change every
@@ -1307,9 +1374,9 @@ mod tests {
                 Processor::<StdSyncHandler>::new().advance(&mut *term, &dense_screen(cols, rows));
             }
 
-            let mut verts = 0;
+            let mut cost = FrameCost::default();
             for _ in 0..10 {
-                verts = paint_one_frame(
+                cost = paint_one_frame(
                     &ctx,
                     &mut session,
                     &config,
@@ -1323,8 +1390,10 @@ mod tests {
 
             let iterations = 60;
             let start = std::time::Instant::now();
+            let (mut build, mut tessellate) =
+                (std::time::Duration::ZERO, std::time::Duration::ZERO);
             for _ in 0..iterations {
-                std::hint::black_box(paint_one_frame(
+                cost = std::hint::black_box(paint_one_frame(
                     &ctx,
                     &mut session,
                     &config,
@@ -1334,8 +1403,11 @@ mod tests {
                     &mut ime,
                     screen,
                 ));
+                build += cost.build;
+                tessellate += cost.tessellate;
             }
             let each = start.elapsed() / iterations;
+            let (build, tessellate) = (build / iterations, tessellate / iterations);
 
             let (_, counts) = crate::steady_state::measure(|| {
                 paint_one_frame(
@@ -1351,12 +1423,13 @@ mod tests {
             });
 
             println!(
-                "{}x{} logical px = {cols}x{rows} cells: {each:?} per frame, {} allocations \
-                 ({} KiB), {verts} vertices",
+                "{}x{} logical px = {cols}x{rows} cells: {each:?} per frame (build {build:?} + \
+                 tessellate {tessellate:?}), {} allocations ({} KiB), {} vertices",
                 screen.x,
                 screen.y,
                 counts.allocs,
                 counts.bytes / 1024,
+                cost.vertices,
             );
         }
     }

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -1421,6 +1421,10 @@ mod tests {
         for clipped in &out.shapes {
             collect_text(&clipped.shape, &mut text);
         }
+        // Tessellate as the real loop does: nothing is on screen until the
+        // shapes have become vertices, so a caller timing a frame that skipped
+        // this would be timing half of one.
+        ctx.tessellate(out.shapes, out.pixels_per_point);
         text
     }
 
@@ -1759,6 +1763,163 @@ mod tests {
                 elapsed / iterations,
                 total / waits.max(1),
                 100.0 * total.as_secs_f64() / elapsed.as_secs_f64(),
+            );
+        }
+    }
+
+    /// Not a gate — run it by hand:
+    /// `cargo test -p alacritree --release -- --ignored --nocapture --test-threads=1 report_echo_latency`
+    ///
+    /// What the user actually waits for: output reaching the terminal, and
+    /// that output reaching the screen.  The frame loop is modelled the way
+    /// eframe drives it — a frame runs only when something asked for a repaint
+    /// — and the sample is written from another thread so it lands mid-frame
+    /// the way real PTY output does.  The paint harnesses time one frame in
+    /// isolation; this times the wait a frame is only part of.
+    #[test]
+    #[ignore = "timing harness, not an assertion"]
+    fn report_echo_latency() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        use alacritty_terminal::event::{Event as TermEvent, EventListener};
+
+        /// Written to a fixed cell, so each sample overwrites the last and a
+        /// stale marker can never be mistaken for the pending one.
+        const MARKERS: [char; 2] = ['§', '¶'];
+        const SAMPLES: usize = 150;
+
+        let config = Config::default();
+        let screen = Vec2::new(2560.0, 1440.0);
+
+        // The last row is the control: the same background load with the
+        // sessions left marked visible, which is what every session looked
+        // like before off-screen output stopped waking the loop.
+        for (load, background, mark_hidden, stream_visible) in [
+            ("idle", 0, true, false),
+            ("visible session streaming", 0, true, true),
+            ("8 background sessions streaming", 8, true, false),
+            ("8 background sessions, none marked hidden", 8, false, false),
+        ] {
+            let ctx = egui::Context::default();
+            let (mut session, _dir) = headless_session(&ctx, &config);
+            let mut caches = Caches::new();
+            painted_text(&ctx, &mut session, &config, &mut caches, screen, Vec::new());
+            let (cols, rows) = (session.size.columns, session.size.screen_lines);
+            {
+                let mut term = session.term.lock();
+                term.resize(TermSize::new(cols, rows));
+                Processor::<StdSyncHandler>::new().advance(&mut *term, &dense_screen(cols, rows));
+            }
+
+            let stop = Arc::new(AtomicBool::new(false));
+            let mut threads = Vec::new();
+
+            // A background session reaches the loop through `send_event` and
+            // nothing else, so its proxy is the whole of what matters here.
+            for _ in 0..background {
+                let (proxy, events) = EventProxy::new(ctx.clone());
+                proxy.set_visible(!mark_hidden);
+                let stop = Arc::clone(&stop);
+                threads.push(std::thread::spawn(move || {
+                    let _events = events;
+                    while !stop.load(Ordering::Relaxed) {
+                        proxy.send_event(TermEvent::Wakeup);
+                        std::thread::sleep(std::time::Duration::from_micros(500));
+                    }
+                }));
+            }
+
+            if stream_visible {
+                let term = Arc::clone(&session.term);
+                let ctx = ctx.clone();
+                let stop = Arc::clone(&stop);
+                threads.push(std::thread::spawn(move || {
+                    let mut parser = Processor::<StdSyncHandler>::new();
+                    while !stop.load(Ordering::Relaxed) {
+                        // In place rather than appending: the load under test
+                        // is repaint pressure and parse work, and scrolling
+                        // would carry the marker cell off screen.
+                        parser.advance(&mut *term.lock(), b"\x1b[20;1Hstreaming output");
+                        ctx.request_repaint();
+                        std::thread::sleep(std::time::Duration::from_micros(500));
+                    }
+                }));
+            }
+
+            // Timestamped before the lock is taken: waiting for the terminal
+            // is part of what the output waits through.
+            let pending: Arc<std::sync::Mutex<Option<(char, std::time::Instant)>>> =
+                Arc::new(std::sync::Mutex::new(None));
+            {
+                let (term, ctx, stop, pending) = (
+                    Arc::clone(&session.term),
+                    ctx.clone(),
+                    Arc::clone(&stop),
+                    Arc::clone(&pending),
+                );
+                threads.push(std::thread::spawn(move || {
+                    let mut parser = Processor::<StdSyncHandler>::new();
+                    let mut next = 0;
+                    while !stop.load(Ordering::Relaxed) {
+                        if pending.lock().expect("pending").is_some() {
+                            std::thread::yield_now();
+                            continue;
+                        }
+                        // Settle first, by an interval that does not divide
+                        // the frame period: injecting the moment the last
+                        // sample landed would phase-lock to the loop and
+                        // measure how fast it can cycle rather than how long
+                        // an arbitrary write waits.  Spun rather than slept
+                        // because Windows rounds a sleep up to the timer tick.
+                        let gap = std::time::Duration::from_micros(2000 + (next as u64 % 7) * 1500);
+                        let until = std::time::Instant::now() + gap;
+                        while std::time::Instant::now() < until {
+                            std::hint::spin_loop();
+                        }
+
+                        let marker = MARKERS[next % MARKERS.len()];
+                        next += 1;
+                        let at = std::time::Instant::now();
+                        parser.advance(&mut *term.lock(), format!("\x1b[1;1H{marker}").as_bytes());
+                        *pending.lock().expect("pending") = Some((marker, at));
+                        ctx.request_repaint();
+                    }
+                }));
+            }
+
+            let mut samples: Vec<std::time::Duration> = Vec::with_capacity(SAMPLES);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+            while samples.len() < SAMPLES && std::time::Instant::now() < deadline {
+                if !ctx.has_requested_repaint() {
+                    std::thread::yield_now();
+                    continue;
+                }
+                let painted =
+                    painted_text(&ctx, &mut session, &config, &mut caches, screen, Vec::new());
+                let mut slot = pending.lock().expect("pending");
+                if let Some((marker, at)) = *slot
+                    && painted.contains(marker)
+                {
+                    samples.push(at.elapsed());
+                    *slot = None;
+                }
+            }
+
+            stop.store(true, Ordering::Relaxed);
+            for thread in threads {
+                let _ = thread.join();
+            }
+
+            samples.sort_unstable();
+            let at = |q: f64| samples[((samples.len() as f64 * q) as usize).min(samples.len() - 1)];
+            println!(
+                "{load}: {} samples, p50 {:?}, p95 {:?}, p99 {:?}, worst {:?}",
+                samples.len(),
+                at(0.50),
+                at(0.95),
+                at(0.99),
+                samples[samples.len() - 1],
             );
         }
     }

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -34,6 +34,7 @@ pub fn show(
     ime: &mut crate::ime::Ime,
     color_glyphs: &mut ColorGlyphCache,
     glyphs: &mut GlyphCache,
+    snapshot: &mut GridSnapshot,
 ) -> Response {
     let font_id = FontId::monospace(config.font.egui_size());
     let (cell_w_pt, cell_h_pt) = ui.ctx().fonts(|f| {
@@ -123,10 +124,20 @@ pub fn show(
         line_height: (cell_h_pt * ppp).floor() as f64,
         descent: 0.0,
     };
+    // The guard is a temporary so it is dropped at the end of this statement:
+    // nothing below may run while the terminal is locked.
+    snapshot.capture(
+        &session.term.lock(),
+        config,
+        hovered_link.as_ref().map(|l| &l.bounds),
+        // The preedit overlay replaces the cursor while composing
+        // (alacritty hides it the same way, display/content.rs).
+        ime.preedit().is_some(),
+    );
     paint_grid(
         &painter,
         rect,
-        session,
+        snapshot,
         config,
         &font_id,
         cell_w,
@@ -137,10 +148,6 @@ pub fn show(
         color_glyphs,
         glyphs,
         ui.ctx(),
-        hovered_link.as_ref().map(|l| &l.bounds),
-        // The preedit overlay replaces the cursor while composing
-        // (alacritty hides it the same way, display/content.rs).
-        ime.preedit().is_some(),
     );
 
     let preedit_caret = ime
@@ -758,11 +765,209 @@ impl Style {
     }
 }
 
+/// The visible grid, copied out from under the terminal lock.
+///
+/// The PTY thread applies output under the same `FairMutex` the painter needs,
+/// so every microsecond a frame holds it is a microsecond the terminal cannot
+/// parse — and the echo of a keystroke waits behind that.  Mirrors alacritty's
+/// `Display::draw`, which collects its renderable cells and drops the terminal
+/// guard before rendering anything.
+///
+/// Both buffers are reused across frames, and colours are resolved during the
+/// copy, so painting from a snapshot needs neither the lock nor the palette.
+#[derive(Default)]
+pub struct GridSnapshot {
+    text: String,
+    runs: Vec<Run>,
+    cursor: Option<CursorSnapshot>,
+}
+
+/// A span of cells sharing one resolved style, indexing into
+/// `GridSnapshot::text`.
+struct Run {
+    text: std::ops::Range<usize>,
+    start_col: usize,
+    row: i32,
+    flags: Flags,
+    fg: Color32,
+    bg: Color32,
+    selected: bool,
+}
+
+struct CursorSnapshot {
+    shape: CursorShape,
+    column: usize,
+    row: i32,
+    color: Color32,
+    /// The glyph a solid block covers, with the colour that keeps it legible.
+    glyph: Option<(char, Flags, Color32)>,
+}
+
+impl GridSnapshot {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn capture(
+        &mut self,
+        term: &Term<EventProxy>,
+        config: &Config,
+        link_bounds: Option<&Match>,
+        cursor_hidden: bool,
+    ) {
+        self.text.clear();
+        self.runs.clear();
+        self.cursor = None;
+
+        let runtime_palette = term.colors();
+        let grid = term.grid();
+        let display_offset = grid.display_offset() as i32;
+        let screen_lines = grid.screen_lines() as i32;
+        let cols = grid.columns();
+
+        // Resolve the active selection once per frame; the per-cell range checks
+        // are cheap and avoid re-deriving it for every run.
+        let selection_range = term.selection.as_ref().and_then(|s| s.to_range(term));
+        let in_link = |line: Line, column: Column| {
+            link_bounds.is_some_and(|b| b.contains(&Point::new(line, column)))
+        };
+
+        for row in 0..screen_lines {
+            let line = Line(row - display_offset);
+            let cells = &grid[line];
+
+            let mut col = 0;
+            while col < cols {
+                let start = col;
+                let style = Style::from_cell(&cells[Column(col)], in_link(line, Column(col)));
+                let selected = is_selected(selection_range.as_ref(), line, Column(col));
+                let text_start = self.text.len();
+                while col < cols {
+                    let cell = &cells[Column(col)];
+                    if Style::from_cell(cell, in_link(line, Column(col))) != style
+                        || is_selected(selection_range.as_ref(), line, Column(col)) != selected
+                    {
+                        break;
+                    }
+                    if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                        col += 1;
+                        continue;
+                    }
+                    let ch = if cell.c == '\0' || cell.flags.contains(Flags::HIDDEN) {
+                        ' '
+                    } else {
+                        cell.c
+                    };
+                    self.text.push(ch);
+                    col += 1;
+                }
+                if self.text.len() == text_start {
+                    continue;
+                }
+                let (fg, bg) = run_colors(style, selected, runtime_palette, config);
+                self.runs.push(Run {
+                    text: text_start..self.text.len(),
+                    start_col: start,
+                    row,
+                    flags: style.flags,
+                    fg,
+                    bg,
+                    selected,
+                });
+            }
+        }
+
+        let cursor_point: Point = grid.cursor.point;
+        let cursor_row = cursor_point.line.0 + display_offset;
+        let shape = cursor_shape(term);
+        if cursor_hidden
+            || matches!(shape, CursorShape::Hidden)
+            || cursor_row < 0
+            || cursor_row >= screen_lines
+        {
+            return;
+        }
+
+        let cell = &grid[Line(cursor_point.line.0)][cursor_point.column];
+        let color = runtime_palette[alacritty_terminal::vte::ansi::NamedColor::Cursor]
+            .map(rgb_to_color32)
+            .or_else(|| config.palette.cursor_bg.map(rgb_to_color32))
+            .unwrap_or_else(|| foreground(&config.palette));
+        // Only the solid block covers the glyph underneath it.
+        let glyph = (matches!(shape, CursorShape::Block)
+            && cell.c != '\0'
+            && !cell.flags.contains(Flags::HIDDEN))
+        .then(|| {
+            let glyph_color = config.palette.cursor_fg.map(rgb_to_color32).unwrap_or_else(|| {
+                rgb_to_color32(resolve(
+                    cell.bg,
+                    cell.flags,
+                    runtime_palette,
+                    &config.palette,
+                    false,
+                ))
+            });
+            let glyph_color =
+                if glyph_color == color { background(&config.palette) } else { glyph_color };
+            (cell.c, cell.flags, glyph_color)
+        });
+
+        self.cursor = Some(CursorSnapshot {
+            shape,
+            column: cursor_point.column.0,
+            row: cursor_row,
+            color,
+            glyph,
+        });
+    }
+}
+
+/// Foreground and background a run is drawn with, after INVERSE and the
+/// selection highlight.
+fn run_colors(
+    style: Style,
+    selected: bool,
+    runtime: &alacritty_terminal::term::color::Colors,
+    config: &Config,
+) -> (Color32, Color32) {
+    let inverse = style.flags.contains(Flags::INVERSE);
+    let cell_fg = resolve(
+        if inverse { style.bg } else { style.fg },
+        style.flags,
+        runtime,
+        &config.palette,
+        true,
+    );
+    let cell_bg = resolve(
+        if inverse { style.fg } else { style.bg },
+        style.flags,
+        runtime,
+        &config.palette,
+        false,
+    );
+    if !selected {
+        return (rgb_to_color32(cell_fg), rgb_to_color32(cell_bg));
+    }
+    // When `colors.selection.background` is set we honor it; otherwise we swap
+    // fg/bg of the underlying cell so the highlight is always visible without
+    // requiring a config entry.
+    let sel_bg =
+        config.palette.selection_bg.map(rgb_to_color32).unwrap_or_else(|| rgb_to_color32(cell_fg));
+    let sel_fg = config.palette.selection_fg.map(rgb_to_color32).unwrap_or_else(|| {
+        if config.palette.selection_bg.is_some() {
+            rgb_to_color32(cell_fg)
+        } else {
+            rgb_to_color32(cell_bg)
+        }
+    });
+    (sel_fg, sel_bg)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn paint_grid(
     painter: &egui::Painter,
     rect: Rect,
-    session: &Session,
+    snapshot: &GridSnapshot,
     config: &Config,
     font_id: &FontId,
     cell_w: f32,
@@ -773,92 +978,32 @@ fn paint_grid(
     color_glyphs: &mut ColorGlyphCache,
     glyphs: &mut GlyphCache,
     ctx: &egui::Context,
-    link_bounds: Option<&Match>,
-    cursor_hidden: bool,
 ) {
-    let term = session.term.lock();
-    let runtime_palette = term.colors();
-    let grid = term.grid();
-    let display_offset = grid.display_offset() as i32;
-    let screen_lines = grid.screen_lines() as i32;
-    let cols = grid.columns();
-
-    let cursor_point: Point = grid.cursor.point;
-    let cursor_visible_line = cursor_point.line.0 + display_offset;
     let bg_color = background(&config.palette);
-
-    // Resolve the active selection once per frame; the per-cell range checks
-    // are cheap and avoid relocking inside paint_run.
-    let selection_range = term.selection.as_ref().and_then(|s| s.to_range(&term));
-    let in_link = |line: Line, column: Column| {
-        link_bounds.is_some_and(|b| b.contains(&Point::new(line, column)))
-    };
-
-    for row_idx in 0..screen_lines {
-        let line = Line(row_idx - display_offset);
-        let row = &grid[line];
-        let y = rect.min.y + row_idx as f32 * cell_h;
-
-        let mut col = 0;
-        while col < cols {
-            let start = col;
-            let style = Style::from_cell(&row[Column(col)], in_link(line, Column(col)));
-            let selected = is_selected(selection_range.as_ref(), line, Column(col));
-            let mut run = String::new();
-            while col < cols {
-                let cell = &row[Column(col)];
-                if Style::from_cell(cell, in_link(line, Column(col))) != style
-                    || is_selected(selection_range.as_ref(), line, Column(col)) != selected
-                {
-                    break;
-                }
-                if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
-                    col += 1;
-                    continue;
-                }
-                let ch =
-                    if cell.c == '\0' || cell.flags.contains(Flags::HIDDEN) { ' ' } else { cell.c };
-                run.push(ch);
-                col += 1;
-            }
-            paint_run(
-                painter,
-                rect,
-                &run,
-                start,
-                y,
-                cell_w,
-                cell_h,
-                style,
-                runtime_palette,
-                config,
-                font_id,
-                bg_color,
-                selected,
-                ppp,
-                metrics,
-                builtin_glyphs,
-                color_glyphs,
-                glyphs,
-                ctx,
-            );
-        }
-    }
-
-    if !cursor_hidden && cursor_visible_line >= 0 && cursor_visible_line < screen_lines {
-        let cursor_shape = cursor_shape(&term);
-        paint_cursor(
+    for run in &snapshot.runs {
+        paint_run(
             painter,
             rect,
-            &term,
-            config,
-            cursor_point,
-            cursor_visible_line,
+            &snapshot.text[run.text.clone()],
+            run.start_col,
+            rect.min.y + run.row as f32 * cell_h,
             cell_w,
             cell_h,
+            run,
+            config,
             font_id,
-            cursor_shape,
+            bg_color,
+            ppp,
+            metrics,
+            builtin_glyphs,
+            color_glyphs,
+            glyphs,
+            ctx,
         );
+    }
+
+    if let Some(cursor) = &snapshot.cursor {
+        paint_cursor(painter, rect, cursor, cell_w, cell_h, font_id);
     }
 }
 
@@ -901,12 +1046,10 @@ fn paint_run(
     y: f32,
     cell_w: f32,
     cell_h: f32,
-    style: Style,
-    runtime: &alacritty_terminal::term::color::Colors,
+    style: &Run,
     config: &Config,
     font_id: &FontId,
     default_bg: Color32,
-    selected: bool,
     ppp: f32,
     metrics: &Metrics,
     builtin_glyphs: &mut BuiltinGlyphCache,
@@ -914,50 +1057,12 @@ fn paint_run(
     glyphs: &mut GlyphCache,
     ctx: &egui::Context,
 ) {
-    if run.is_empty() {
-        return;
-    }
-    let inverse = style.flags.contains(Flags::INVERSE);
-    let cell_fg = resolve(
-        if inverse { style.bg } else { style.fg },
-        style.flags,
-        runtime,
-        &config.palette,
-        true,
-    );
-    let cell_bg = resolve(
-        if inverse { style.fg } else { style.bg },
-        style.flags,
-        runtime,
-        &config.palette,
-        false,
-    );
-    // When `colors.selection.background` is set we honor it; otherwise we swap
-    // fg/bg of the underlying cell so the highlight is always visible without
-    // requiring a config entry.
-    let (fg, bg) = if selected {
-        let sel_bg = config
-            .palette
-            .selection_bg
-            .map(rgb_to_color32)
-            .unwrap_or_else(|| rgb_to_color32(cell_fg));
-        let sel_fg = config.palette.selection_fg.map(rgb_to_color32).unwrap_or_else(|| {
-            if config.palette.selection_bg.is_some() {
-                rgb_to_color32(cell_fg)
-            } else {
-                rgb_to_color32(cell_bg)
-            }
-        });
-        (sel_fg, sel_bg)
-    } else {
-        (rgb_to_color32(cell_fg), rgb_to_color32(cell_bg))
-    };
-
+    let (fg, bg) = (style.fg, style.bg);
     let width = run.chars().count() as f32 * cell_w;
     let x = rect.min.x + start_col as f32 * cell_w;
     let bg_rect = Rect::from_min_size(Pos2::new(x, y), Vec2::new(width, cell_h));
 
-    if bg != default_bg || selected {
+    if bg != default_bg || style.selected {
         painter.rect_filled(bg_rect, 0.0, bg);
     }
 
@@ -1018,73 +1123,51 @@ fn paint_run(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn paint_cursor(
     painter: &egui::Painter,
     rect: Rect,
-    term: &Term<EventProxy>,
-    config: &Config,
-    cursor_point: Point,
-    cursor_visible_line: i32,
+    cursor: &CursorSnapshot,
     cell_w: f32,
     cell_h: f32,
     font_id: &FontId,
-    shape: alacritty_terminal::vte::ansi::CursorShape,
 ) {
     use alacritty_terminal::vte::ansi::CursorShape::*;
-    if matches!(shape, Hidden) {
-        return;
-    }
 
-    let runtime_palette = term.colors();
-    let grid = term.grid();
-    let cell = &grid[Line(cursor_point.line.0)][cursor_point.column];
-
-    let x = rect.min.x + cursor_point.column.0 as f32 * cell_w;
-    let y = rect.min.y + cursor_visible_line as f32 * cell_h;
+    let x = rect.min.x + cursor.column as f32 * cell_w;
+    let y = rect.min.y + cursor.row as f32 * cell_h;
     let cursor_rect = Rect::from_min_size(Pos2::new(x, y), Vec2::new(cell_w, cell_h));
 
-    let cursor_color = runtime_palette[alacritty_terminal::vte::ansi::NamedColor::Cursor]
-        .map(rgb_to_color32)
-        .or_else(|| config.palette.cursor_bg.map(rgb_to_color32))
-        .unwrap_or_else(|| foreground(&config.palette));
-
-    match shape {
+    match cursor.shape {
         Block => {
-            painter.rect_filled(cursor_rect, 0.0, cursor_color);
+            painter.rect_filled(cursor_rect, 0.0, cursor.color);
         },
         HollowBlock => {
             painter.rect_stroke(
                 cursor_rect,
                 0.0,
-                Stroke::new(1.0_f32, cursor_color),
+                Stroke::new(1.0_f32, cursor.color),
                 egui::StrokeKind::Inside,
             );
         },
         Beam => {
             let bar = Rect::from_min_size(Pos2::new(x, y), Vec2::new(2.0, cell_h));
-            painter.rect_filled(bar, 0.0, cursor_color);
+            painter.rect_filled(bar, 0.0, cursor.color);
         },
         Underline => {
             let bar = Rect::from_min_size(Pos2::new(x, y + cell_h - 2.0), Vec2::new(cell_w, 2.0));
-            painter.rect_filled(bar, 0.0, cursor_color);
+            painter.rect_filled(bar, 0.0, cursor.color);
         },
         Hidden => return,
     }
 
     // The solid block covers the glyph; redraw it in inverted color so it stays legible.
-    if matches!(shape, Block) && cell.c != '\0' && !cell.flags.contains(Flags::HIDDEN) {
-        let glyph_color = config.palette.cursor_fg.map(rgb_to_color32).unwrap_or_else(|| {
-            rgb_to_color32(resolve(cell.bg, cell.flags, runtime_palette, &config.palette, false))
-        });
-        let glyph_color =
-            if glyph_color == cursor_color { background(&config.palette) } else { glyph_color };
+    if let Some((ch, flags, color)) = cursor.glyph {
         painter.text(
             Pos2::new(x, y),
             egui::Align2::LEFT_TOP,
-            cell.c.to_string(),
-            font_for_flags(cell.flags, font_id),
-            glyph_color,
+            ch.to_string(),
+            font_for_flags(flags, font_id),
+            color,
         );
     }
 }
@@ -1237,17 +1320,34 @@ mod tests {
         (session, dir)
     }
 
+    /// Everything the painter reuses between frames, as the app holds it.
+    struct Caches {
+        builtin: BuiltinGlyphCache,
+        colors: ColorGlyphCache,
+        glyphs: GlyphCache,
+        ime: crate::ime::Ime,
+        snapshot: GridSnapshot,
+    }
+
+    impl Caches {
+        fn new() -> Self {
+            Self {
+                builtin: BuiltinGlyphCache::new(),
+                colors: ColorGlyphCache::new(Vec::new(), 0),
+                glyphs: GlyphCache::new(),
+                ime: crate::ime::Ime::default(),
+                snapshot: GridSnapshot::new(),
+            }
+        }
+    }
+
     /// One full paint of the grid: layout, shape building, and tessellation —
     /// everything between a PTY wakeup and the vertex buffer the GPU gets.
-    #[allow(clippy::too_many_arguments)]
     fn paint_one_frame(
         ctx: &egui::Context,
         session: &mut Session,
         config: &Config,
-        builtin: &mut BuiltinGlyphCache,
-        colors: &mut ColorGlyphCache,
-        glyphs: &mut GlyphCache,
-        ime: &mut crate::ime::Ime,
+        caches: &mut Caches,
         screen: Vec2,
     ) -> FrameCost {
         let raw = egui::RawInput {
@@ -1257,7 +1357,17 @@ mod tests {
         let started = std::time::Instant::now();
         let out = ctx.run(raw, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
-                show(ui, session, config, false, builtin, ime, colors, glyphs);
+                show(
+                    ui,
+                    session,
+                    config,
+                    false,
+                    &mut caches.builtin,
+                    &mut caches.ime,
+                    &mut caches.colors,
+                    &mut caches.glyphs,
+                    &mut caches.snapshot,
+                );
             });
         });
         let build = started.elapsed();
@@ -1283,7 +1393,7 @@ mod tests {
         ctx: &egui::Context,
         session: &mut Session,
         config: &Config,
-        ime: &mut crate::ime::Ime,
+        caches: &mut Caches,
         screen: Vec2,
         events: Vec<Event>,
     ) -> String {
@@ -1292,12 +1402,19 @@ mod tests {
             events,
             ..Default::default()
         };
-        let mut builtin = BuiltinGlyphCache::new();
-        let mut colors = ColorGlyphCache::new(Vec::new(), 0);
-        let mut glyphs = GlyphCache::new();
         let out = ctx.run(raw, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
-                show(ui, session, config, true, &mut builtin, ime, &mut colors, &mut glyphs);
+                show(
+                    ui,
+                    session,
+                    config,
+                    true,
+                    &mut caches.builtin,
+                    &mut caches.ime,
+                    &mut caches.colors,
+                    &mut caches.glyphs,
+                    &mut caches.snapshot,
+                );
             });
         });
         let mut text = String::new();
@@ -1325,13 +1442,13 @@ mod tests {
         let config = Config::default();
         let ctx = egui::Context::default();
         let (mut session, _dir) = headless_session(&ctx, &config);
-        let mut ime = crate::ime::Ime::default();
+        let mut caches = Caches::new();
         let screen = Vec2::new(640.0, 480.0);
 
         // The first frame is what tells the session how big the grid is, and
         // `Session::resize` forwards to the `Term` only when a PTY sender
         // exists, so a headless session needs the grid resized by hand.
-        painted_text(&ctx, &mut session, &config, &mut ime, screen, Vec::new());
+        painted_text(&ctx, &mut session, &config, &mut caches, screen, Vec::new());
         let (cols, rows) = (session.size.columns, session.size.screen_lines);
         {
             let mut term = session.term.lock();
@@ -1345,14 +1462,15 @@ mod tests {
         }
         let last = format!("L{}", rows * 4 - 1);
 
-        let scrolled_back = painted_text(&ctx, &mut session, &config, &mut ime, screen, Vec::new());
+        let scrolled_back =
+            painted_text(&ctx, &mut session, &config, &mut caches, screen, Vec::new());
         assert!(!scrolled_back.contains(&last), "the grid is not scrolled back to begin with");
 
         let typed = painted_text(
             &ctx,
             &mut session,
             &config,
-            &mut ime,
+            &mut caches,
             screen,
             vec![Event::Text("a".to_owned())],
         );
@@ -1361,6 +1479,32 @@ mod tests {
             typed.contains(&last),
             "the frame carrying the keystroke painted the stale scrolled-back view"
         );
+    }
+
+    /// The snapshot's run text and run list are reused frame to frame, so an
+    /// unchanged grid has to paint the same thing twice — a missed clear would
+    /// append the second frame's runs to the first's.
+    #[test]
+    fn a_reused_snapshot_paints_an_unchanged_grid_the_same_way() {
+        let config = Config::default();
+        let ctx = egui::Context::default();
+        let (mut session, _dir) = headless_session(&ctx, &config);
+        let mut caches = Caches::new();
+        let screen = Vec2::new(640.0, 480.0);
+
+        painted_text(&ctx, &mut session, &config, &mut caches, screen, Vec::new());
+        let (cols, rows) = (session.size.columns, session.size.screen_lines);
+        {
+            let mut term = session.term.lock();
+            term.resize(TermSize::new(cols, rows));
+            Processor::<StdSyncHandler>::new().advance(&mut *term, &dense_screen(cols, rows));
+        }
+
+        let first = painted_text(&ctx, &mut session, &config, &mut caches, screen, Vec::new());
+        let second = painted_text(&ctx, &mut session, &config, &mut caches, screen, Vec::new());
+
+        assert!(!first.is_empty(), "the fixture painted nothing");
+        assert_eq!(first, second);
     }
 
     /// Where a frame's time goes.  `build` is the grid walk that turns cells
@@ -1424,6 +1568,75 @@ mod tests {
         println!("append while scrolled back: {}", damage_extent(&mut term));
     }
 
+    /// Not a gate — run it by hand:
+    /// `cargo test -p alacritree --release -- --ignored --nocapture report_lock_contention`
+    ///
+    /// The PTY thread applies output under the same `FairMutex` the painter
+    /// holds, so whatever a frame holds it for is time the terminal cannot
+    /// parse — and the echo of a keystroke waits behind it.  Measured from the
+    /// PTY thread's side: how long acquiring the lock takes while frames paint.
+    #[test]
+    #[ignore = "timing harness, not an assertion"]
+    fn report_lock_contention() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let config = Config::default();
+        for screen in [Vec2::new(1280.0, 720.0), Vec2::new(2560.0, 1440.0)] {
+            let ctx = egui::Context::default();
+            let (mut session, _dir) = headless_session(&ctx, &config);
+            let mut caches = Caches::new();
+
+            paint_one_frame(&ctx, &mut session, &config, &mut caches, screen);
+            let (cols, rows) = (session.size.columns, session.size.screen_lines);
+            {
+                let mut term = session.term.lock();
+                term.resize(TermSize::new(cols, rows));
+                Processor::<StdSyncHandler>::new().advance(&mut *term, &dense_screen(cols, rows));
+            }
+
+            let term = Arc::clone(&session.term);
+            let stop = Arc::new(AtomicBool::new(false));
+            let locker = {
+                let stop = Arc::clone(&stop);
+                std::thread::spawn(move || {
+                    let (mut waits, mut total, mut worst) =
+                        (0u32, std::time::Duration::ZERO, std::time::Duration::ZERO);
+                    while !stop.load(Ordering::Relaxed) {
+                        let started = std::time::Instant::now();
+                        let guard = term.lock();
+                        let waited = started.elapsed();
+                        drop(guard);
+                        waits += 1;
+                        total += waited;
+                        worst = worst.max(waited);
+                        std::thread::yield_now();
+                    }
+                    (waits, total, worst)
+                })
+            };
+
+            let iterations = 60;
+            let started = std::time::Instant::now();
+            for _ in 0..iterations {
+                paint_one_frame(&ctx, &mut session, &config, &mut caches, screen);
+            }
+            let elapsed = started.elapsed();
+            stop.store(true, Ordering::Relaxed);
+            let (waits, total, worst) = locker.join().expect("locker thread");
+
+            println!(
+                "{}x{} logical px = {cols}x{rows} cells: {:?} per frame, PTY-side lock waits \
+                 {waits} × {:?} mean (worst {worst:?}), {:.0}% of the run blocked",
+                screen.x,
+                screen.y,
+                elapsed / iterations,
+                total / waits.max(1),
+                100.0 * total.as_secs_f64() / elapsed.as_secs_f64(),
+            );
+        }
+    }
+
     /// Dense output that fills every visible cell, with a colour change every
     /// few columns so the run-splitting in `paint_grid` behaves like it does
     /// under real program output rather than collapsing to one run per line.
@@ -1457,22 +1670,10 @@ mod tests {
         for screen in [Vec2::new(1280.0, 720.0), Vec2::new(2560.0, 1440.0)] {
             let ctx = egui::Context::default();
             let (mut session, _dir) = headless_session(&ctx, &config);
-            let mut builtin = BuiltinGlyphCache::new();
-            let mut colors = ColorGlyphCache::new(Vec::new(), 0);
-            let mut glyphs = GlyphCache::new();
-            let mut ime = crate::ime::Ime::default();
+            let mut caches = Caches::new();
 
             // The first frame is what tells the session how big the grid is.
-            paint_one_frame(
-                &ctx,
-                &mut session,
-                &config,
-                &mut builtin,
-                &mut colors,
-                &mut glyphs,
-                &mut ime,
-                screen,
-            );
+            paint_one_frame(&ctx, &mut session, &config, &mut caches, screen);
             // `Session::resize` forwards to the `Term` only when a PTY sender
             // exists, so a headless session needs the grid resized by hand.
             let (cols, rows) = (session.size.columns, session.size.screen_lines);
@@ -1484,16 +1685,7 @@ mod tests {
 
             let mut cost = FrameCost::default();
             for _ in 0..10 {
-                cost = paint_one_frame(
-                    &ctx,
-                    &mut session,
-                    &config,
-                    &mut builtin,
-                    &mut colors,
-                    &mut glyphs,
-                    &mut ime,
-                    screen,
-                );
+                cost = paint_one_frame(&ctx, &mut session, &config, &mut caches, screen);
             }
 
             let iterations = 60;
@@ -1505,10 +1697,7 @@ mod tests {
                     &ctx,
                     &mut session,
                     &config,
-                    &mut builtin,
-                    &mut colors,
-                    &mut glyphs,
-                    &mut ime,
+                    &mut caches,
                     screen,
                 ));
                 build += cost.build;
@@ -1518,16 +1707,7 @@ mod tests {
             let (build, tessellate) = (build / iterations, tessellate / iterations);
 
             let (_, counts) = crate::steady_state::measure(|| {
-                paint_one_frame(
-                    &ctx,
-                    &mut session,
-                    &config,
-                    &mut builtin,
-                    &mut colors,
-                    &mut glyphs,
-                    &mut ime,
-                    screen,
-                )
+                paint_one_frame(&ctx, &mut session, &config, &mut caches, screen)
             });
 
             println!(

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -17,12 +17,14 @@ use crate::color_glyph::{CachedColorGlyph, ColorGlyphCache};
 use crate::colors::{background, foreground, resolve, rgb_to_color32};
 use crate::config::Config;
 use crate::fonts::{BOLD_FAMILY, BOLD_ITALIC_FAMILY, ITALIC_FAMILY};
+use crate::glyph_cache::{Face, GlyphCache};
 use crate::input::event_to_bytes;
 use crate::links::{self, Link};
 use crate::mouse;
 use crate::paste;
 use crate::session::{EventProxy, Session, SessionKind, TermSize};
 
+#[allow(clippy::too_many_arguments)]
 pub fn show(
     ui: &mut Ui,
     session: &mut Session,
@@ -31,6 +33,7 @@ pub fn show(
     builtin_glyphs: &mut BuiltinGlyphCache,
     ime: &mut crate::ime::Ime,
     color_glyphs: &mut ColorGlyphCache,
+    glyphs: &mut GlyphCache,
 ) -> Response {
     let font_id = FontId::monospace(config.font.egui_size());
     let (cell_w_pt, cell_h_pt) = ui.ctx().fonts(|f| {
@@ -131,6 +134,7 @@ pub fn show(
         &metrics,
         builtin_glyphs,
         color_glyphs,
+        glyphs,
         ui.ctx(),
         hovered_link.as_ref().map(|l| &l.bounds),
         // The preedit overlay replaces the cursor while composing
@@ -747,6 +751,7 @@ fn paint_grid(
     metrics: &Metrics,
     builtin_glyphs: &mut BuiltinGlyphCache,
     color_glyphs: &mut ColorGlyphCache,
+    glyphs: &mut GlyphCache,
     ctx: &egui::Context,
     link_bounds: Option<&Match>,
     cursor_hidden: bool,
@@ -814,6 +819,7 @@ fn paint_grid(
                 metrics,
                 builtin_glyphs,
                 color_glyphs,
+                glyphs,
                 ctx,
             );
         }
@@ -885,6 +891,7 @@ fn paint_run(
     metrics: &Metrics,
     builtin_glyphs: &mut BuiltinGlyphCache,
     color_glyphs: &mut ColorGlyphCache,
+    glyphs: &mut GlyphCache,
     ctx: &egui::Context,
 ) {
     if run.is_empty() {
@@ -936,10 +943,10 @@ fn paint_run(
 
     if !style.flags.contains(Flags::HIDDEN) {
         // Per-glyph paint: egui's run layout drifts off the cursor's `col * cell_w` grid (worse with zoom).
-        let glyph_font = font_for_flags(style.flags, font_id);
+        let face =
+            Face::new(style.flags.contains(Flags::BOLD), style.flags.contains(Flags::ITALIC));
         let glyph_dx = config.font.glyph_offset.x as f32;
         let glyph_dy = config.font.glyph_offset.y as f32;
-        let mut buf = [0u8; 4];
         for (i, ch) in run.chars().enumerate() {
             if ch == ' ' {
                 continue;
@@ -967,12 +974,14 @@ fn paint_run(
                 paint_color_glyph(painter, cached, cell_x, y, ppp);
                 continue;
             }
-            painter.text(
-                Pos2::new(cell_x + glyph_dx, y + glyph_dy),
-                egui::Align2::LEFT_TOP,
-                ch.encode_utf8(&mut buf).to_string(),
-                glyph_font.clone(),
-                fg,
+            let galley = glyphs.get(ctx, ch, face, font_id.size);
+            painter.add(
+                egui::epaint::TextShape::new(
+                    Pos2::new(cell_x + glyph_dx, y + glyph_dy),
+                    galley,
+                    fg,
+                )
+                .with_override_text_color(fg),
             );
         }
     }
@@ -1185,6 +1194,171 @@ mod tests {
         let mut term = Term::new(TermConfig::default(), &TermSize::new(80, 24), proxy);
         Processor::<StdSyncHandler>::new().advance(&mut term, output);
         term
+    }
+
+    /// A PTY-less session whose grid can be driven straight from a byte
+    /// stream.  `spawn_scratchpad` is the only constructor that builds a
+    /// `Session` without a child process; dropping the editor afterwards
+    /// leaves a plain terminal session behind.
+    fn headless_session(ctx: &egui::Context, config: &Config) -> (Session, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("scratch.md");
+        std::fs::write(&path, "").expect("write scratch file");
+        let mut session = Session::spawn_scratchpad(
+            ctx.clone(),
+            config,
+            Some(dir.path().to_path_buf()),
+            TermSize::new(80, 24),
+            (8.0, 16.0),
+            path,
+        )
+        .expect("scratchpad session");
+        session.scratchpad = None;
+        (session, dir)
+    }
+
+    /// One full paint of the grid: layout, shape building, and tessellation —
+    /// everything between a PTY wakeup and the vertex buffer the GPU gets.
+    #[allow(clippy::too_many_arguments)]
+    fn paint_one_frame(
+        ctx: &egui::Context,
+        session: &mut Session,
+        config: &Config,
+        builtin: &mut BuiltinGlyphCache,
+        colors: &mut ColorGlyphCache,
+        glyphs: &mut GlyphCache,
+        ime: &mut crate::ime::Ime,
+        screen: Vec2,
+    ) -> usize {
+        let raw = egui::RawInput {
+            screen_rect: Some(Rect::from_min_size(Pos2::ZERO, screen)),
+            ..Default::default()
+        };
+        let out = ctx.run(raw, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                show(ui, session, config, false, builtin, ime, colors, glyphs);
+            });
+        });
+        let ppp = out.pixels_per_point;
+        ctx.tessellate(out.shapes, ppp)
+            .iter()
+            .map(|p| match &p.primitive {
+                egui::epaint::Primitive::Mesh(mesh) => mesh.vertices.len(),
+                _ => 0,
+            })
+            .sum()
+    }
+
+    /// Dense output that fills every visible cell, with a colour change every
+    /// few columns so the run-splitting in `paint_grid` behaves like it does
+    /// under real program output rather than collapsing to one run per line.
+    fn dense_screen(cols: usize, rows: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        for row in 0..rows {
+            out.extend_from_slice(format!("\x1b[{};1H", row + 1).as_bytes());
+            for col in 0..cols {
+                if col % 7 == 0 {
+                    out.extend_from_slice(format!("\x1b[3{}m", 1 + (col / 7) % 7).as_bytes());
+                }
+                out.push(b'a' + (col % 26) as u8);
+            }
+        }
+        out
+    }
+
+    /// Not a gate — run it by hand:
+    /// `cargo test -p alacritree --release -- --ignored --nocapture paint_cost`
+    ///
+    /// Every PTY wakeup requests a repaint, and a repaint runs this whole path
+    /// for the visible session.  What it costs is what a keystroke queues
+    /// behind while a session is streaming output.
+    #[test]
+    #[ignore = "timing harness, not an assertion"]
+    fn report_paint_cost() {
+        #[cfg(windows)]
+        crate::harden_dll_search_path();
+
+        let config = Config::default();
+        for screen in [Vec2::new(1280.0, 720.0), Vec2::new(2560.0, 1440.0)] {
+            let ctx = egui::Context::default();
+            let (mut session, _dir) = headless_session(&ctx, &config);
+            let mut builtin = BuiltinGlyphCache::new();
+            let mut colors = ColorGlyphCache::new(Vec::new(), 0);
+            let mut glyphs = GlyphCache::new();
+            let mut ime = crate::ime::Ime::default();
+
+            // The first frame is what tells the session how big the grid is.
+            paint_one_frame(
+                &ctx,
+                &mut session,
+                &config,
+                &mut builtin,
+                &mut colors,
+                &mut glyphs,
+                &mut ime,
+                screen,
+            );
+            // `Session::resize` forwards to the `Term` only when a PTY sender
+            // exists, so a headless session needs the grid resized by hand.
+            let (cols, rows) = (session.size.columns, session.size.screen_lines);
+            {
+                let mut term = session.term.lock();
+                term.resize(TermSize::new(cols, rows));
+                Processor::<StdSyncHandler>::new().advance(&mut *term, &dense_screen(cols, rows));
+            }
+
+            let mut verts = 0;
+            for _ in 0..10 {
+                verts = paint_one_frame(
+                    &ctx,
+                    &mut session,
+                    &config,
+                    &mut builtin,
+                    &mut colors,
+                    &mut glyphs,
+                    &mut ime,
+                    screen,
+                );
+            }
+
+            let iterations = 60;
+            let start = std::time::Instant::now();
+            for _ in 0..iterations {
+                std::hint::black_box(paint_one_frame(
+                    &ctx,
+                    &mut session,
+                    &config,
+                    &mut builtin,
+                    &mut colors,
+                    &mut glyphs,
+                    &mut ime,
+                    screen,
+                ));
+            }
+            let each = start.elapsed() / iterations;
+
+            let (_, counts) = crate::steady_state::measure(|| {
+                paint_one_frame(
+                    &ctx,
+                    &mut session,
+                    &config,
+                    &mut builtin,
+                    &mut colors,
+                    &mut glyphs,
+                    &mut ime,
+                    screen,
+                )
+            });
+
+            println!(
+                "{}x{} logical px = {cols}x{rows} cells: {each:?} per frame, {} allocations \
+                 ({} KiB), {verts} vertices",
+                screen.x,
+                screen.y,
+                counts.allocs,
+                counts.bytes / 1024,
+            );
+        }
     }
 
     /// Full-screen apps hide the cursor with DECTCEM while they repaint, then

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -278,6 +278,10 @@ sidebar_focus      = "preserve"  # how far the projects sidebar goes when the
                                   # slides to a sibling bounded by its parent.
                                   # "follow": also moves the terminal to a delete
                                   # landing that has a live session
+vsync              = true   # restart required — wait for the display's refresh
+                            # before showing a finished frame (default true).
+                            # false presents each frame as soon as it is drawn,
+                            # trading tearing for lower keystroke-to-screen delay
 
 [ui.icons]                  # sidebar glyph overrides (e.g. Nerd Font icons)
 search = "⌕"                # glyph prefixing the sidebar search prompt


### PR DESCRIPTION
Cuts input latency and removes two Windows output stalls. The UI thread no longer spends most of its frame budget blocked on the terminal lock, and a pane streaming output no longer advances only while the user types.

## What changed

**Painting.** The grid is captured once per frame and painted from that snapshot instead of under the terminal lock; laid-out glyphs are reused across frames; input is dispatched before the grid is painted so a keystroke is not a frame behind.

**Off the UI thread.** Process-table scans, project discovery over IPC, and the per-descendant command-line scan moved off the UI thread. Payload-free wakeups, off-screen output, and background spinners no longer drive repaints.

**Windows PTY.** Two distinct defects, one commit each:

- `perf(pty): repost console readiness mid-burst` — the console pipe has no readiness to report, so the reader emulates it through a waker `piper` installs only when a drain comes up empty. A drain that stopped with bytes still buffered left nothing able to announce them, so output stalled until an unrelated event arrived — a keystroke, a resize, the child exiting. Covered by a regression test that times out at 60 s without the fix and passes in 0.8 s with it.
- `perf(pty): cap each console read at 32 KiB` — the read loop checks its byte cap only *after* parsing whatever the last read returned, so one 300 KB drain became one 300 KB parse holding the terminal lease. Measured from the UI thread: 15.85 ms median / 40.13 ms p95 waiting for that lock, roughly 94% of the frame, with over a second between repaints. Capping each read drops the median wait to 200 ns.

**Instrumentation.** `ALACRITREE_FRAME_LOG=1` reports frame, phase, output-wait and echo timings. Opt-in, off by default.

## Order

Stacked on #153 `[6]` — merge that first. Followed by `[8]`, which vendors the console host that removes the remaining ConPTY bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcFM3Wbmd5YEGzAdoHqF9H
