### PR TITLE
feat(drop): handle files dragged onto the window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
+ "shlex",
  "subst",
  "swash",
  "sysinfo",

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -25,6 +25,9 @@ git2 = { version = "0.20", default-features = false }
 rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "async-std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# POSIX shell word quoting for dropped file paths, the same crate wezterm
+# uses for its `quote_dropped_files = "Posix"` mode.
+shlex = "1.3"
 # Shell-style $var / ${var} / ${var:fallback} substitution for the sidebar's
 # templated row names.  Chosen over a template engine: the fallback syntax is
 # the whole feature, and its deps are already in the workspace lockfile.

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -77,13 +77,14 @@ fontconfig = "0.8"
 # mid-burst (`pty_rearm`).  Must resolve to the same version alacritty_terminal
 # links, or the `Poller` handed to the registration is a different type.
 polling = "3.11"
-# Restricts the DLL search path at startup (`harden_dll_search_path`) and
-# borrows the launching shell's console so the CLI can print
-# (`attach_parent_console`).
+# Restricts the DLL search path at startup (`harden_dll_search_path`), borrows
+# the launching shell's console so the CLI can print (`attach_parent_console`),
+# and reads the cursor during a file drag, which winit discards.
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_System_Console",
     "Win32_System_LibraryLoader",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 # Foreground-agent detection: walks the shell's descendant process tree.
 # Linux reads /proc directly, so the dependency is Windows-only.

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1325,21 +1325,21 @@ impl AlacritreeApp {
     /// three targets do not become a guessing game.  Silent off Windows: no
     /// cursor position is available there, so the tint would be a lie.
     fn paint_drop_hover(&self, ctx: &Context, regions: &file_drop::Regions) {
-        if !self.config.ui.drop.highlight || ctx.input(|i| i.raw.hovered_files.is_empty()) {
+        let cfg = &self.config.ui.drop;
+        if !cfg.enabled || !cfg.highlight || ctx.input(|i| i.raw.hovered_files.is_empty()) {
             return;
         }
+        let Some(pointer) = file_drop::screen_pointer(ctx) else {
+            return;
+        };
         // winit's `DragOver` handler emits no event, so moving the cursor
         // mid-drag wakes nothing and the polled position would stay frozen at
         // wherever the drag entered.  This is the only place the feature drives
         // the loop, and it stops when the drag leaves or drops.
         ctx.request_repaint();
-        let Some(pointer) = file_drop::screen_pointer(ctx) else {
-            return;
-        };
         let active_is_scratchpad =
             self.active_session_index().is_some_and(|idx| self.sessions[idx].scratchpad.is_some());
-        let Some(target) =
-            file_drop::route(Some(pointer), regions, active_is_scratchpad, &self.config.ui.drop)
+        let Some(target) = file_drop::route(Some(pointer), regions, active_is_scratchpad, cfg)
         else {
             return;
         };

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1321,6 +1321,43 @@ impl AlacritreeApp {
         self.projects.last().expect("just pushed")
     }
 
+    /// Tint whichever region a drop would land on while files are hovering, so
+    /// three targets do not become a guessing game.  Silent off Windows: no
+    /// cursor position is available there, so the tint would be a lie.
+    fn paint_drop_hover(&self, ctx: &Context, regions: &file_drop::Regions) {
+        if !self.config.ui.drop.highlight || ctx.input(|i| i.raw.hovered_files.is_empty()) {
+            return;
+        }
+        // winit's `DragOver` handler emits no event, so moving the cursor
+        // mid-drag wakes nothing and the polled position would stay frozen at
+        // wherever the drag entered.  This is the only place the feature drives
+        // the loop, and it stops when the drag leaves or drops.
+        ctx.request_repaint();
+        let Some(pointer) = file_drop::screen_pointer(ctx) else {
+            return;
+        };
+        let active_is_scratchpad =
+            self.active_session_index().is_some_and(|idx| self.sessions[idx].scratchpad.is_some());
+        let Some(target) =
+            file_drop::route(Some(pointer), regions, active_is_scratchpad, &self.config.ui.drop)
+        else {
+            return;
+        };
+        let rect = match target {
+            file_drop::Target::ProjectsSidebar => match regions.sidebar {
+                Some(rect) => rect,
+                None => return,
+            },
+            file_drop::Target::Terminal | file_drop::Target::Scratchpad => regions.central,
+        };
+        // `Theme::accent` is already resolved (config accent, else ANSI blue);
+        // `UiTheme::sidebar_accent` is the raw `Option` and would paint nothing
+        // on an unconfigured palette.
+        let accent = self.theme.accent;
+        ctx.layer_painter(egui::LayerId::new(egui::Order::Foreground, egui::Id::new("drop_hover")))
+            .rect_filled(rect, 0.0, accent.linear_multiply(0.15));
+    }
+
     /// Send this frame's dropped files wherever they landed.  All of the
     /// deciding happens in `file_drop`; this only reaches the sinks.
     fn handle_dropped_files(&mut self, ctx: &Context, regions: &file_drop::Regions) {
@@ -7328,6 +7365,7 @@ impl eframe::App for AlacritreeApp {
         if !modal_open && !self.palette.is_open() {
             let regions =
                 file_drop::Regions::new(sidebar_rect, central.response.rect, &self.config.ui.drop);
+            self.paint_drop_hover(ctx, &regions);
             self.handle_dropped_files(ctx, &regions);
         }
         self.phases.mark("central");

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1290,7 +1290,14 @@ impl AlacritreeApp {
         let Some(path) = rfd::FileDialog::new().pick_folder() else {
             return;
         };
-        let path = wsl::normalize_root(path);
+        self.add_project_off_thread(ctx, wsl::normalize_root(path));
+    }
+
+    /// Put a project in the sidebar without stalling the frame: `wsl.exe` takes
+    /// hundreds of milliseconds warm and seconds while the distro VM boots, so
+    /// a WSL root goes in as a placeholder and discovers on a worker.  Native
+    /// roots spawn nothing and are cheap enough to discover in place.
+    fn add_project_off_thread(&mut self, ctx: &Context, path: PathBuf) {
         if self.projects.iter().any(|p| p.root == path) {
             return;
         }
@@ -1310,8 +1317,8 @@ impl AlacritreeApp {
     /// Put a project in the sidebar, discovering its worktrees.  A project that
     /// is already there is left alone rather than duplicated, so callers that
     /// cannot see the sidebar (IPC) need not check first.  WSL roots discover
-    /// synchronously here (no `ctx` for a worker); the folder picker uses the
-    /// async path in `add_project_via_dialog`.
+    /// synchronously here (no `ctx` for a worker); callers holding one use
+    /// `add_project_off_thread`.
     fn add_project(&mut self, path: PathBuf) -> &Project {
         if let Some(idx) = self.projects.iter().position(|p| p.root == path) {
             return &self.projects[idx];
@@ -1400,7 +1407,7 @@ impl AlacritreeApp {
             },
             file_drop::Target::ProjectsSidebar => {
                 for root in file_drop::project_roots(&paths) {
-                    self.add_project(wsl::normalize_root(root));
+                    self.add_project_off_thread(ctx, wsl::normalize_root(root));
                 }
             },
         }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -19,6 +19,7 @@ use crate::config::{
     TextEmphasis, UiFont,
 };
 use crate::doppler;
+use crate::file_drop;
 use crate::git_nav::{self, GitSection, SectionCount};
 use crate::git_status::{self, ChangeKind, DirtyCounts, FileChange, GitStatus, StatusCache};
 use crate::ipc;
@@ -1318,6 +1319,54 @@ impl AlacritreeApp {
         self.projects.push(Project::discover(path.clone()).project);
         self.persist_project(&path);
         self.projects.last().expect("just pushed")
+    }
+
+    /// Send this frame's dropped files wherever they landed.  All of the
+    /// deciding happens in `file_drop`; this only reaches the sinks.
+    fn handle_dropped_files(&mut self, ctx: &Context, regions: &file_drop::Regions) {
+        let paths: Vec<PathBuf> =
+            ctx.input(|i| i.raw.dropped_files.iter().filter_map(|f| f.path.clone()).collect());
+        if paths.is_empty() {
+            return;
+        }
+        let active_is_scratchpad =
+            self.active_session_index().is_some_and(|idx| self.sessions[idx].scratchpad.is_some());
+        let pointer = file_drop::screen_pointer(ctx);
+        let Some(target) =
+            file_drop::route(pointer, regions, active_is_scratchpad, &self.config.ui.drop)
+        else {
+            return;
+        };
+        match target {
+            file_drop::Target::Terminal => {
+                let Some(idx) = self.active_session_index() else {
+                    return;
+                };
+                let session = &self.sessions[idx];
+                let text =
+                    file_drop::shell_payload(&paths, session.wsl_distro(), &self.config.ui.drop);
+                if !text.is_empty() {
+                    paste::paste(session, &text, true);
+                }
+            },
+            file_drop::Target::Scratchpad => {
+                let Some(idx) = self.active_session_index() else {
+                    return;
+                };
+                let id = self.sessions[idx].id;
+                let Some(editor) = self.sessions[idx].scratchpad.as_mut() else {
+                    return;
+                };
+                let (preceding, following) = editor.cursor_boundary(ctx, id);
+                let text = file_drop::document_payload(&paths, preceding, following);
+                editor.insert_at_cursor(ctx, id, &text);
+            },
+            file_drop::Target::ProjectsSidebar => {
+                for root in file_drop::project_roots(&paths) {
+                    self.add_project(wsl::normalize_root(root));
+                }
+            },
+        }
     }
 
     /// Drop a project from the sidebar.  Nothing on disk is touched, and
@@ -7167,6 +7216,7 @@ impl eframe::App for AlacritreeApp {
 
         let panel_frame = Frame::default().fill(sidebar_fill).inner_margin(Margin::same(8));
 
+        let mut sidebar_rect = None;
         if self.show_left_sidebar {
             let r = self.show_project_sidebar(ctx, panel_frame.clone());
             paint_panel_border(ctx, r.right(), r.y_range(), theme.sidebar_border);
@@ -7176,6 +7226,7 @@ impl eframe::App for AlacritreeApp {
             {
                 paint_focus_outline(ctx, r, &theme);
             }
+            sidebar_rect = Some(r);
         }
 
         self.phases.mark("projects-sidebar");
@@ -7265,6 +7316,14 @@ impl eframe::App for AlacritreeApp {
             });
         if theme.focus_outline.terminal && !modal_open && self.focus == PaneFocus::Terminal {
             paint_focus_outline(ctx, central.response.rect, &theme);
+        }
+
+        // A modal or the palette owns input while it is up; a drop landing
+        // behind one would act on a surface the user cannot see.
+        if !modal_open && !self.palette.is_open() {
+            let regions =
+                file_drop::Regions::new(sidebar_rect, central.response.rect, &self.config.ui.drop);
+            self.handle_dropped_files(ctx, &regions);
         }
         self.phases.mark("central");
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1367,6 +1367,11 @@ impl AlacritreeApp {
                 }
             },
         }
+
+        // This runs after the sidebar and central panel have painted for the
+        // frame, and eframe here is reactive, so the mutation above would
+        // otherwise sit invisible until some unrelated event wakes the loop.
+        ctx.request_repaint();
     }
 
     /// Drop a project from the sidebar.  Nothing on disk is touched, and

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1379,11 +1379,15 @@ impl AlacritreeApp {
         let Some(target) =
             file_drop::route(pointer, regions, active_is_scratchpad, &self.config.ui.drop)
         else {
+            log::debug!("drop at {pointer:?} lands on no enabled target, discarding {paths:?}");
             return;
         };
         match target {
             file_drop::Target::Terminal => {
                 let Some(idx) = self.active_session_index() else {
+                    log::debug!(
+                        "drop on the terminal with no active session, discarding {paths:?}"
+                    );
                     return;
                 };
                 let session = &self.sessions[idx];
@@ -1395,6 +1399,9 @@ impl AlacritreeApp {
             },
             file_drop::Target::Scratchpad => {
                 let Some(idx) = self.active_session_index() else {
+                    log::debug!(
+                        "drop on the scratchpad with no active session, discarding {paths:?}"
+                    );
                     return;
                 };
                 let id = self.sessions[idx].id;

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -264,10 +264,6 @@ pub enum Quoting {
 }
 
 /// `Quoting` with `Auto` already decided against the receiving shell.
-// `file_drop::shell_word` is the only caller of `resolve`/`escape`, and
-// nothing routes a drop event to `file_drop` yet, so only the tests below
-// construct these directly.
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShellQuoting {
     None,
@@ -278,7 +274,6 @@ pub enum ShellQuoting {
 }
 
 impl Quoting {
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn resolve(self, wsl: bool) -> ShellQuoting {
         match self {
             Self::Auto if wsl => ShellQuoting::Posix,
@@ -295,7 +290,6 @@ impl Quoting {
 
 impl ShellQuoting {
     #[must_use]
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn escape(self, path: &str) -> String {
         match self {
             Self::None => path.to_string(),
@@ -624,8 +618,6 @@ pub struct UiTheme {
     /// which renders every path byte-for-byte as it does today.
     pub path_style: PathStyleConfig,
     /// `[ui.drop]`: what a file dragged onto the window does.
-    // Nothing reads this field in production yet — only the tests below do.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub drop: DropConfig,
 }
 

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -264,8 +264,8 @@ pub enum Quoting {
 }
 
 /// `Quoting` with `Auto` already decided against the receiving shell.
-// The drop pipeline is the only production caller of `resolve`/`escape`;
-// until it lands, only the tests below construct these.
+// File drop is the only production consumer of `resolve`/`escape`; only the
+// tests below construct these otherwise.
 #[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShellQuoting {
@@ -623,8 +623,8 @@ pub struct UiTheme {
     /// which renders every path byte-for-byte as it does today.
     pub path_style: PathStyleConfig,
     /// `[ui.drop]`: what a file dragged onto the window does.
-    // The drop pipeline is the only production reader; until it lands, only
-    // the tests below read this field.
+    // File drop is the only production reader; only the tests below read
+    // this field otherwise.
     #[cfg_attr(not(test), allow(dead_code))]
     pub drop: DropConfig,
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -326,9 +326,9 @@ fn parse_quoting(raw: Option<&str>) -> Quoting {
     }
 }
 
-/// `[ui.drop]`: what dragging files onto the window does.  Every target is on
-/// by default — a drop was discarded before, so no path here changes an
-/// existing behavior.
+/// `[ui.drop]`: what dragging files onto the window does.  Every target
+/// accepts drops by default; each one can be switched off on its own, and
+/// `enabled` turns the lot off.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DropConfig {
     /// Master switch; false ignores every drop.

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -264,8 +264,9 @@ pub enum Quoting {
 }
 
 /// `Quoting` with `Auto` already decided against the receiving shell.
-// File drop is the only production consumer of `resolve`/`escape`; only the
-// tests below construct these otherwise.
+// `file_drop::shell_word` is the only caller of `resolve`/`escape`, and
+// nothing routes a drop event to `file_drop` yet, so only the tests below
+// construct these directly.
 #[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShellQuoting {
@@ -623,8 +624,7 @@ pub struct UiTheme {
     /// which renders every path byte-for-byte as it does today.
     pub path_style: PathStyleConfig,
     /// `[ui.drop]`: what a file dragged onto the window does.
-    // File drop is the only production reader; only the tests below read
-    // this field otherwise.
+    // Nothing reads this field in production yet — only the tests below do.
     #[cfg_attr(not(test), allow(dead_code))]
     pub drop: DropConfig,
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -247,6 +247,122 @@ fn parse_confirm_session_close(raw: Option<&str>) -> ConfirmSessionClose {
     }
 }
 
+/// `[ui.drop] quote` as written in the config.  The five concrete modes are
+/// ported from wezterm's `quote_dropped_files` so an existing wezterm config
+/// carries over unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Quoting {
+    /// Decide per session: a path headed into a distro is a POSIX shell word
+    /// no matter what the host OS is.
+    #[default]
+    Auto,
+    None,
+    SpacesOnly,
+    Posix,
+    Windows,
+    WindowsAlwaysQuoted,
+}
+
+/// `Quoting` with `Auto` already decided against the receiving shell.
+// The drop pipeline is the only production caller of `resolve`/`escape`;
+// until it lands, only the tests below construct these.
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellQuoting {
+    None,
+    SpacesOnly,
+    Posix,
+    Windows,
+    WindowsAlwaysQuoted,
+}
+
+impl Quoting {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn resolve(self, wsl: bool) -> ShellQuoting {
+        match self {
+            Self::Auto if wsl => ShellQuoting::Posix,
+            Self::Auto if cfg!(windows) => ShellQuoting::Windows,
+            Self::Auto => ShellQuoting::SpacesOnly,
+            Self::None => ShellQuoting::None,
+            Self::SpacesOnly => ShellQuoting::SpacesOnly,
+            Self::Posix => ShellQuoting::Posix,
+            Self::Windows => ShellQuoting::Windows,
+            Self::WindowsAlwaysQuoted => ShellQuoting::WindowsAlwaysQuoted,
+        }
+    }
+}
+
+impl ShellQuoting {
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn escape(self, path: &str) -> String {
+        match self {
+            Self::None => path.to_string(),
+            Self::SpacesOnly => path.replace(' ', "\\ "),
+            // A quoting failure is only possible for a NUL byte, which no
+            // path from the OS carries; wezterm collapses it the same way.
+            Self::Posix => shlex::try_quote(path).unwrap_or_default().into_owned(),
+            Self::Windows => {
+                const NEEDS_QUOTING: [char; 5] = [' ', '\t', '\n', '\x0b', '"'];
+                if path.chars().any(|c| NEEDS_QUOTING.contains(&c)) {
+                    format!("\"{path}\"")
+                } else {
+                    path.to_string()
+                }
+            },
+            Self::WindowsAlwaysQuoted => format!("\"{path}\""),
+        }
+    }
+}
+
+fn parse_quoting(raw: Option<&str>) -> Quoting {
+    match raw {
+        None => Quoting::default(),
+        Some("auto") => Quoting::Auto,
+        Some("none") => Quoting::None,
+        Some("spaces_only") => Quoting::SpacesOnly,
+        Some("posix") => Quoting::Posix,
+        Some("windows") => Quoting::Windows,
+        Some("windows_always_quoted") => Quoting::WindowsAlwaysQuoted,
+        Some(other) => {
+            log::warn!("unknown ui.drop.quote value {other:?}, using \"auto\"");
+            Quoting::default()
+        },
+    }
+}
+
+/// `[ui.drop]`: what dragging files onto the window does.  Every target is on
+/// by default — a drop was discarded before, so no path here changes an
+/// existing behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DropConfig {
+    /// Master switch; false ignores every drop.
+    pub enabled: bool,
+    pub terminal: bool,
+    pub sidebar: bool,
+    pub scratchpad: bool,
+    pub quote: Quoting,
+    /// Rewrite a Windows path to its distro-side spelling before it reaches a
+    /// WSL shell, where a `C:\` path resolves to nothing.
+    pub wsl_translate: bool,
+    /// Tint the region a drop would land on while files hover.
+    pub highlight: bool,
+}
+
+impl Default for DropConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            terminal: true,
+            sidebar: true,
+            scratchpad: true,
+            quote: Quoting::Auto,
+            wsl_translate: true,
+            highlight: true,
+        }
+    }
+}
+
 /// How the sidebar scroll areas draw their scrollbar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ScrollbarStyle {
@@ -506,6 +622,11 @@ pub struct UiTheme {
     /// `[ui.path_style]`: per-site path abbreviation.  All `Full` by default,
     /// which renders every path byte-for-byte as it does today.
     pub path_style: PathStyleConfig,
+    /// `[ui.drop]`: what a file dragged onto the window does.
+    // The drop pipeline is the only production reader; until it lands, only
+    // the tests below read this field.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub drop: DropConfig,
 }
 
 impl Default for UiTheme {
@@ -530,6 +651,7 @@ impl Default for UiTheme {
             worktree_name: None,
             project_name: None,
             path_style: PathStyleConfig::default(),
+            drop: DropConfig::default(),
         }
     }
 }
@@ -1151,6 +1273,18 @@ struct RawFocusOutline {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
+struct RawUiDrop {
+    enabled: Option<bool>,
+    terminal: Option<bool>,
+    sidebar: Option<bool>,
+    scratchpad: Option<bool>,
+    quote: Option<String>,
+    wsl_translate: Option<bool>,
+    highlight: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 struct RawUi {
     sidebar_background: Option<RgbStr>,
     sidebar_foreground: Option<RgbStr>,
@@ -1188,6 +1322,8 @@ struct RawUi {
     /// Default true.
     vsync: Option<bool>,
     path_style: RawPathStyle,
+    /// What a file dragged onto the window does.  Default: every target on.
+    drop: RawUiDrop,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1358,6 +1494,15 @@ impl RawConfig {
                 git_header: parse_path_style(self.ui.path_style.git_header.as_deref()),
                 filename: text_emphasis(&self.ui.path_style.filename),
                 parent: text_emphasis(&self.ui.path_style.parent),
+            },
+            drop: DropConfig {
+                enabled: self.ui.drop.enabled.unwrap_or(true),
+                terminal: self.ui.drop.terminal.unwrap_or(true),
+                sidebar: self.ui.drop.sidebar.unwrap_or(true),
+                scratchpad: self.ui.drop.scratchpad.unwrap_or(true),
+                quote: parse_quoting(self.ui.drop.quote.as_deref()),
+                wsl_translate: self.ui.drop.wsl_translate.unwrap_or(true),
+                highlight: self.ui.drop.highlight.unwrap_or(true),
             },
         };
 
@@ -2177,5 +2322,120 @@ program = "second"
     fn blank_name_templates_are_dropped() {
         let ui = ui_from_toml("[ui]\nworktree_name = \"  \"");
         assert_eq!(ui.worktree_name, None);
+    }
+
+    #[test]
+    fn quoting_none_passes_the_path_through() {
+        assert_eq!(ShellQuoting::None.escape("hello ($world)"), "hello ($world)");
+    }
+
+    #[test]
+    fn quoting_spaces_only_escapes_spaces_and_nothing_else() {
+        assert_eq!(ShellQuoting::SpacesOnly.escape("hello ($world)"), "hello\\ ($world)");
+    }
+
+    #[test]
+    fn quoting_posix_single_quotes_a_path_with_shell_metacharacters() {
+        assert_eq!(ShellQuoting::Posix.escape("hello ($world)"), "'hello ($world)'");
+        assert_eq!(ShellQuoting::Posix.escape("/mnt/c/plain.png"), "/mnt/c/plain.png");
+        assert_eq!(
+            ShellQuoting::Posix.escape("/mnt/c/Users/Lev/my pic.png"),
+            "'/mnt/c/Users/Lev/my pic.png'"
+        );
+    }
+
+    #[test]
+    fn quoting_windows_quotes_only_when_the_path_needs_it() {
+        assert_eq!(ShellQuoting::Windows.escape("hello ($world)"), "\"hello ($world)\"");
+        assert_eq!(ShellQuoting::Windows.escape("C:\\pics\\plain.png"), "C:\\pics\\plain.png");
+    }
+
+    #[test]
+    fn quoting_windows_always_quoted_quotes_unconditionally() {
+        assert_eq!(
+            ShellQuoting::WindowsAlwaysQuoted.escape("C:\\pics\\plain.png"),
+            "\"C:\\pics\\plain.png\""
+        );
+    }
+
+    #[test]
+    fn auto_quoting_picks_posix_inside_a_distro() {
+        assert_eq!(Quoting::Auto.resolve(true), ShellQuoting::Posix);
+    }
+
+    #[test]
+    fn auto_quoting_picks_the_host_default_outside_a_distro() {
+        let expected = if cfg!(windows) { ShellQuoting::Windows } else { ShellQuoting::SpacesOnly };
+        assert_eq!(Quoting::Auto.resolve(false), expected);
+    }
+
+    #[test]
+    fn an_explicit_quoting_mode_ignores_the_shell() {
+        assert_eq!(Quoting::None.resolve(true), ShellQuoting::None);
+        assert_eq!(Quoting::Windows.resolve(true), ShellQuoting::Windows);
+    }
+
+    #[test]
+    fn drop_options_default_to_on_with_auto_quoting() {
+        let ui = ui_from_toml("");
+        assert_eq!(
+            ui.drop,
+            DropConfig {
+                enabled: true,
+                terminal: true,
+                sidebar: true,
+                scratchpad: true,
+                quote: Quoting::Auto,
+                wsl_translate: true,
+                highlight: true,
+            }
+        );
+    }
+
+    #[test]
+    fn drop_options_parse_from_the_ui_drop_table() {
+        let ui = ui_from_toml(
+            "[ui.drop]\n\
+             enabled = false\n\
+             terminal = false\n\
+             sidebar = false\n\
+             scratchpad = false\n\
+             quote = \"posix\"\n\
+             wsl_translate = false\n\
+             highlight = false\n",
+        );
+        assert_eq!(
+            ui.drop,
+            DropConfig {
+                enabled: false,
+                terminal: false,
+                sidebar: false,
+                scratchpad: false,
+                quote: Quoting::Posix,
+                wsl_translate: false,
+                highlight: false,
+            }
+        );
+    }
+
+    #[test]
+    fn every_quoting_name_parses() {
+        for (raw, expected) in [
+            ("auto", Quoting::Auto),
+            ("none", Quoting::None),
+            ("spaces_only", Quoting::SpacesOnly),
+            ("posix", Quoting::Posix),
+            ("windows", Quoting::Windows),
+            ("windows_always_quoted", Quoting::WindowsAlwaysQuoted),
+        ] {
+            let ui = ui_from_toml(&format!("[ui.drop]\nquote = \"{raw}\""));
+            assert_eq!(ui.drop.quote, expected, "{raw}");
+        }
+    }
+
+    #[test]
+    fn an_unknown_quoting_name_falls_back_to_auto() {
+        let ui = ui_from_toml("[ui.drop]\nquote = \"shell\"");
+        assert_eq!(ui.drop.quote, Quoting::Auto);
     }
 }

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -1,9 +1,10 @@
 //! Where a dropped file goes and what text it becomes.
 //!
-//! Everything here is a pure function over a pointer position, a set of paths
-//! and the config; `app.rs` supplies the region rectangles and owns the sinks.
-//! Keeping the decisions out of the frame loop is what makes them testable
-//! without a window.
+//! The decisions are functions of a pointer position, a set of paths and the
+//! config, with two exceptions: `project_roots` stats the paths it is given,
+//! and `screen_pointer` asks the OS and egui where the cursor is.  `app.rs`
+//! supplies the region rectangles and owns the sinks; keeping the rest out of
+//! the frame loop is what makes it testable without a window.
 
 use std::path::{Path, PathBuf};
 
@@ -181,6 +182,10 @@ pub fn project_roots(paths: &[PathBuf]) -> Vec<PathBuf> {
         } else if path.is_file() {
             path.parent().map(Path::to_path_buf)
         } else {
+            // Both queries also come back false when the metadata call was
+            // refused, so this covers a permission error as well as a path
+            // that has gone away between the drag and the drop.
+            log::debug!("dropped path {} is neither a file nor a directory", path.display());
             None
         };
         if let Some(root) = root.filter(|r| !roots.contains(r)) {
@@ -196,8 +201,8 @@ pub fn project_roots(paths: &[PathBuf]) -> Vec<PathBuf> {
 /// `DragEnter`/`DragOver`/`Drop` handlers all ignore their `POINTL`, and no
 /// `CursorMoved` is synthesized during a drag — so egui's own pointer is still
 /// wherever it was before the drag began.  Asking Win32 directly is the only
-/// way to learn where a drop landed.  Other platforms have no equivalent here
-/// yet, so they route by the central-panel fallback in `route`.
+/// way to learn where a drop landed.  No other platform has an equivalent
+/// here, so they route by the central-panel fallback in `route`.
 #[cfg(windows)]
 pub fn screen_pointer(ctx: &egui::Context) -> Option<egui::Pos2> {
     use windows_sys::Win32::Foundation::POINT;

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -1,0 +1,480 @@
+//! Where a dropped file goes and what text it becomes.
+//!
+//! Everything here is a pure function over a pointer position, a set of paths
+//! and the config; `app.rs` supplies the region rectangles and owns the sinks.
+//! Keeping the decisions out of the frame loop is what makes them testable
+//! without a window.
+
+// Nothing routes a drop event here yet, so every item in this module is only
+// reached from the tests below.
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::path::{Path, PathBuf};
+
+use crate::config::{DropConfig, ShellQuoting};
+use crate::wsl;
+
+/// Which region a drop landed on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Target {
+    Terminal,
+    ProjectsSidebar,
+    Scratchpad,
+}
+
+/// The drop-accepting rectangles of the current frame, in egui coordinates.
+/// The git-status sidebar is deliberately absent: it accepts nothing, so a
+/// drop over it falls through to `None`.
+pub struct Regions {
+    /// `None` when the projects sidebar is hidden or its target is disabled.
+    pub sidebar: Option<egui::Rect>,
+    pub central: egui::Rect,
+}
+
+impl Regions {
+    /// A hidden sidebar and a disabled sidebar target collapse to the same
+    /// `None`, so `route` needs to know about neither.
+    pub fn new(sidebar: Option<egui::Rect>, central: egui::Rect, cfg: &DropConfig) -> Self {
+        Self { sidebar: sidebar.filter(|_| cfg.sidebar), central }
+    }
+}
+
+/// `None` when the drop lands nowhere useful — outside every region, over the
+/// git-status sidebar, or on a target the config switched off.
+///
+/// An unknown pointer resolves to the central panel rather than nothing:
+/// winit reports no cursor position during a drag on any platform, so off
+/// Windows this is the only branch that ever runs, and pasting into the shell
+/// is what every other terminal does with a drop.
+pub fn route(
+    pointer: Option<egui::Pos2>,
+    regions: &Regions,
+    active_is_scratchpad: bool,
+    cfg: &DropConfig,
+) -> Option<Target> {
+    if !cfg.enabled {
+        return None;
+    }
+    let central = match (active_is_scratchpad, cfg.scratchpad, cfg.terminal) {
+        (true, true, _) => Some(Target::Scratchpad),
+        (false, _, true) => Some(Target::Terminal),
+        _ => None,
+    };
+    let Some(pointer) = pointer else {
+        return central;
+    };
+    if regions.sidebar.is_some_and(|r| r.contains(pointer)) {
+        return cfg.sidebar.then_some(Target::ProjectsSidebar);
+    }
+    if regions.central.contains(pointer) {
+        return central;
+    }
+    None
+}
+
+/// Characters that would make a pasted path do something other than sit on the
+/// command line.  `paste::paste` strips ESC and ETX, but only on its
+/// bracketed-paste branch; without bracketed paste it turns `\n` into `\r`,
+/// which is Enter (`paste.rs:29`).
+const UNSAFE_IN_TERMINAL: [char; 4] = ['\r', '\n', '\x1b', '\x03'];
+
+/// Whether a path can go on a PTY without acting as input in its own right.
+/// Quoting is no substitute: `shlex` will happily put a newline inside single
+/// quotes, and the newline rewrite happens downstream of any quoting.
+pub fn is_terminal_safe(path: &str) -> bool {
+    !path.contains(UNSAFE_IN_TERMINAL)
+}
+
+/// The text a set of dropped paths becomes for a shell: each path translated
+/// and escaped, joined with spaces, with the trailing space wezterm appends so
+/// the next argument does not run into the last path.
+///
+/// `distro` names the WSL distro the receiving session runs in, `None` for a
+/// native session.  Paths that would act as terminal input are left out.
+pub fn shell_payload(paths: &[PathBuf], distro: Option<&str>, cfg: &DropConfig) -> String {
+    let mut out = String::new();
+    for path in paths {
+        let (word, quoting) = shell_word(path, distro, cfg);
+        if !is_terminal_safe(&word) {
+            log::warn!("dropped path {word:?} carries terminal control characters, skipping it");
+            continue;
+        }
+        out.push_str(&quoting.escape(&word));
+        out.push(' ');
+    }
+    out
+}
+
+/// A path as the receiving shell should spell it, with the quoting rules that
+/// spelling implies.  A path rewritten for a distro is a POSIX shell word even
+/// when the configured mode says otherwise — `windows` quoting fed to `bash` is
+/// broken by construction.
+fn shell_word(path: &Path, distro: Option<&str>, cfg: &DropConfig) -> (String, ShellQuoting) {
+    if let Some(distro) = distro.filter(|_| cfg.wsl_translate) {
+        if let Some(linux) = distro_path(path, distro) {
+            return (linux, ShellQuoting::Posix);
+        }
+        log::debug!("no path in {distro} for {}, pasting it as-is", path.display());
+    }
+    (path.to_string_lossy().into_owned(), cfg.quote.resolve(distro.is_some()))
+}
+
+/// The path as `distro` resolves it, or `None` when it has no spelling there.
+///
+/// `windows_to_linux` discards which distro a UNC path names (`wsl.rs:141`), so
+/// handing it `\\wsl.localhost\Ubuntu\home\a` inside a Kali session would return
+/// `/home/a` — a different file, with nothing to show for it.  Classify first
+/// and only accept a UNC path that belongs to this distro.
+fn distro_path(path: &Path, distro: &str) -> Option<String> {
+    match wsl::classify(path) {
+        wsl::Location::Wsl { distro: owner, linux_path } => {
+            if owner.eq_ignore_ascii_case(distro) {
+                return Some(linux_path);
+            }
+            // Louder than the plain-UNC case below: a share that no distro owns
+            // has no distro-side spelling at all, but this one looks as though
+            // it does and silently would not resolve to the same file.
+            log::warn!("{} belongs to {owner}, not {distro}; pasting it as-is", path.display());
+            None
+        },
+        wsl::Location::Windows(_) => wsl::windows_to_linux(path),
+    }
+}
+
+/// Dropped paths as text for the Markdown scratchpad: no shell quoting, one per
+/// line, since a document is not a command line.
+///
+/// `preceding` and `following` are the characters either side of the insertion
+/// point.  Without the boundary newlines a drop into the middle of a line welds
+/// the first path onto the text before it and the last onto the text after.
+pub fn document_payload(
+    paths: &[PathBuf],
+    preceding: Option<char>,
+    following: Option<char>,
+) -> String {
+    if paths.is_empty() {
+        return String::new();
+    }
+    let needs_newline = |edge: Option<char>| matches!(edge, Some(c) if c != '\n');
+    let mut out = String::new();
+    if needs_newline(preceding) {
+        out.push('\n');
+    }
+    for (i, path) in paths.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&path.to_string_lossy());
+    }
+    if needs_newline(following) {
+        out.push('\n');
+    }
+    out
+}
+
+/// The project roots a set of dropped paths names.  A directory is its own
+/// root; a file means the directory holding it, which is what dragging a file
+/// out of a checkout is asking for.  Dragging several files from one folder is
+/// ordinary, so repeats collapse rather than adding the same project twice.
+pub fn project_roots(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    for path in paths {
+        let root = if path.is_dir() {
+            Some(path.clone())
+        } else if path.is_file() {
+            path.parent().map(Path::to_path_buf)
+        } else {
+            None
+        };
+        if let Some(root) = root.filter(|r| !roots.contains(r)) {
+            roots.push(root);
+        }
+    }
+    roots
+}
+
+#[cfg(test)]
+mod tests {
+    use egui::{Rect, pos2};
+
+    use super::*;
+    use crate::config::{DropConfig, Quoting};
+
+    fn regions() -> Regions {
+        Regions {
+            sidebar: Some(Rect::from_min_max(pos2(0.0, 0.0), pos2(200.0, 600.0))),
+            central: Rect::from_min_max(pos2(200.0, 0.0), pos2(1000.0, 600.0)),
+        }
+    }
+
+    #[test]
+    fn a_pointer_over_the_sidebar_routes_to_the_sidebar() {
+        let cfg = DropConfig::default();
+        assert_eq!(
+            route(Some(pos2(100.0, 300.0)), &regions(), false, &cfg),
+            Some(Target::ProjectsSidebar)
+        );
+    }
+
+    #[test]
+    fn a_pointer_over_the_central_panel_routes_to_the_terminal() {
+        let cfg = DropConfig::default();
+        assert_eq!(
+            route(Some(pos2(600.0, 300.0)), &regions(), false, &cfg),
+            Some(Target::Terminal)
+        );
+    }
+
+    #[test]
+    fn the_central_panel_routes_to_the_scratchpad_when_that_tab_is_active() {
+        let cfg = DropConfig::default();
+        assert_eq!(
+            route(Some(pos2(600.0, 300.0)), &regions(), true, &cfg),
+            Some(Target::Scratchpad)
+        );
+    }
+
+    /// No cursor position is available off Windows, and the central panel is
+    /// the only sane assumption: the terminal is what every other terminal
+    /// emulator does with a drop.
+    #[test]
+    fn an_unknown_pointer_falls_back_to_the_central_panel() {
+        let cfg = DropConfig::default();
+        assert_eq!(route(None, &regions(), false, &cfg), Some(Target::Terminal));
+        assert_eq!(route(None, &regions(), true, &cfg), Some(Target::Scratchpad));
+    }
+
+    /// A hidden sidebar, or `[ui.drop] sidebar = false`, is passed as `None`.
+    #[test]
+    fn a_missing_sidebar_region_can_never_be_hit() {
+        let cfg = DropConfig::default();
+        let regions = Regions { sidebar: None, ..regions() };
+        assert_eq!(route(Some(pos2(100.0, 300.0)), &regions, false, &cfg), None);
+    }
+
+    /// A hidden sidebar and `[ui.drop] sidebar = false` are the same thing to
+    /// `route`: no rectangle, so no hit.
+    #[test]
+    fn regions_drop_the_sidebar_when_it_is_hidden_or_disabled() {
+        let visible = Rect::from_min_max(pos2(0.0, 0.0), pos2(200.0, 600.0));
+        let central = Rect::from_min_max(pos2(200.0, 0.0), pos2(1000.0, 600.0));
+        let on = DropConfig::default();
+        let off = DropConfig { sidebar: false, ..DropConfig::default() };
+
+        assert!(Regions::new(Some(visible), central, &on).sidebar.is_some());
+        assert!(Regions::new(None, central, &on).sidebar.is_none());
+        assert!(Regions::new(Some(visible), central, &off).sidebar.is_none());
+    }
+
+    #[test]
+    fn a_pointer_outside_every_region_routes_nowhere() {
+        let cfg = DropConfig::default();
+        assert_eq!(route(Some(pos2(5000.0, 5000.0)), &regions(), false, &cfg), None);
+    }
+
+    #[test]
+    fn each_target_can_be_switched_off_on_its_own() {
+        let no_terminal = DropConfig { terminal: false, ..DropConfig::default() };
+        assert_eq!(route(Some(pos2(600.0, 300.0)), &regions(), false, &no_terminal), None);
+
+        let no_scratchpad = DropConfig { scratchpad: false, ..DropConfig::default() };
+        assert_eq!(route(Some(pos2(600.0, 300.0)), &regions(), true, &no_scratchpad), None);
+    }
+
+    #[test]
+    fn the_master_switch_disables_every_target() {
+        let off = DropConfig { enabled: false, ..DropConfig::default() };
+        assert_eq!(route(Some(pos2(100.0, 300.0)), &regions(), false, &off), None);
+        assert_eq!(route(Some(pos2(600.0, 300.0)), &regions(), false, &off), None);
+        assert_eq!(route(None, &regions(), true, &off), None);
+    }
+
+    #[test]
+    fn a_shell_payload_joins_paths_with_spaces_and_ends_with_one() {
+        let cfg =
+            DropConfig { quote: Quoting::None, wsl_translate: false, ..DropConfig::default() };
+        let paths = [PathBuf::from("/a/one.png"), PathBuf::from("/a/two.png")];
+        assert_eq!(shell_payload(&paths, None, &cfg), "/a/one.png /a/two.png ");
+    }
+
+    #[test]
+    fn a_shell_payload_quotes_a_path_containing_spaces() {
+        let cfg =
+            DropConfig { quote: Quoting::Posix, wsl_translate: false, ..DropConfig::default() };
+        let paths = [PathBuf::from("/a/my pic.png")];
+        assert_eq!(shell_payload(&paths, None, &cfg), "'/a/my pic.png' ");
+    }
+
+    #[test]
+    fn an_empty_drop_produces_no_payload() {
+        let cfg = DropConfig::default();
+        assert_eq!(shell_payload(&[], None, &cfg), "");
+    }
+
+    #[test]
+    fn a_path_carrying_a_terminal_control_character_is_not_safe() {
+        assert!(is_terminal_safe("/a/ordinary name.png"));
+        assert!(!is_terminal_safe("/a/two\nlines.png"));
+        assert!(!is_terminal_safe("/a/carriage\rreturn.png"));
+        assert!(!is_terminal_safe("/a/escape\x1b[0m.png"));
+        assert!(!is_terminal_safe("/a/interrupt\x03.png"));
+    }
+
+    /// `paste::paste` rewrites `\n` to `\r` when the receiving application has
+    /// not enabled bracketed paste (`paste.rs:29`), and `\r` is Enter — so a
+    /// filename containing a newline would run whatever follows it without the
+    /// user touching the keyboard.  Quoting does not help: `shlex` wraps the
+    /// newline inside single quotes and the rewrite still fires.
+    #[test]
+    fn an_unsafe_path_is_dropped_and_the_rest_of_the_batch_survives() {
+        let cfg =
+            DropConfig { quote: Quoting::None, wsl_translate: false, ..DropConfig::default() };
+        let paths = [
+            PathBuf::from("/a/one.png"),
+            PathBuf::from("/a/evil\nrm -rf ~"),
+            PathBuf::from("/a/two.png"),
+        ];
+        assert_eq!(shell_payload(&paths, None, &cfg), "/a/one.png /a/two.png ");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn a_drive_path_becomes_a_distro_path_for_a_wsl_shell() {
+        let cfg = DropConfig::default();
+        let paths = [PathBuf::from(r"C:\pics\a.png")];
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "/mnt/c/pics/a.png ");
+    }
+
+    /// Translation forces POSIX rules even under `quote = "windows"`: the
+    /// string is a word for a Linux shell once it has been rewritten.
+    #[cfg(windows)]
+    #[test]
+    fn a_translated_path_is_quoted_posix_style_whatever_the_mode_says() {
+        let cfg = DropConfig { quote: Quoting::Windows, ..DropConfig::default() };
+        let paths = [PathBuf::from(r"C:\pics\my pic.png")];
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "'/mnt/c/pics/my pic.png' ");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn translation_off_leaves_the_windows_path_alone() {
+        let cfg =
+            DropConfig { wsl_translate: false, quote: Quoting::None, ..DropConfig::default() };
+        let paths = [PathBuf::from(r"C:\pics\a.png")];
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "C:\\pics\\a.png ");
+    }
+
+    /// A plain UNC share has no distro-side spelling.  Pasting the raw path is
+    /// more useful than pasting nothing.
+    #[cfg(windows)]
+    #[test]
+    fn an_untranslatable_path_falls_back_to_the_raw_spelling() {
+        let cfg = DropConfig { quote: Quoting::None, ..DropConfig::default() };
+        let paths = [PathBuf::from(r"\\fileserver\share\a.png")];
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "\\\\fileserver\\share\\a.png ");
+    }
+
+    /// The distro is compared the way Windows compares the UNC share name.
+    #[cfg(windows)]
+    #[test]
+    fn a_unc_path_for_this_distro_strips_to_its_linux_form() {
+        let cfg = DropConfig { quote: Quoting::None, ..DropConfig::default() };
+        let paths = [PathBuf::from(r"\\wsl.localhost\Ubuntu\home\lev\a.png")];
+        assert_eq!(shell_payload(&paths, Some("ubuntu"), &cfg), "/home/lev/a.png ");
+    }
+
+    /// `windows_to_linux` throws the distro away (`wsl.rs:141`), so stripping a
+    /// UNC prefix that belongs to another distro would name a different file
+    /// with no error.  Refuse it: an unresolvable Windows path fails loudly.
+    #[cfg(windows)]
+    #[test]
+    fn a_unc_path_for_another_distro_is_never_stripped() {
+        let cfg = DropConfig { quote: Quoting::None, ..DropConfig::default() };
+        let paths = [PathBuf::from(r"\\wsl.localhost\Ubuntu\home\lev\a.png")];
+        assert_eq!(
+            shell_payload(&paths, Some("kali-linux"), &cfg),
+            "\\\\wsl.localhost\\Ubuntu\\home\\lev\\a.png "
+        );
+    }
+
+    #[test]
+    fn a_document_payload_is_unquoted_and_newline_separated() {
+        let paths = [PathBuf::from("/a/my pic.png"), PathBuf::from("/a/two.png")];
+        assert_eq!(document_payload(&paths, None, None), "/a/my pic.png\n/a/two.png");
+    }
+
+    /// Dropping mid-line must not weld the first path onto the text before the
+    /// cursor, nor the last onto the text after it.
+    #[test]
+    fn a_document_payload_adds_the_newlines_its_neighbours_need() {
+        let paths = [PathBuf::from("/a/one.png")];
+        assert_eq!(document_payload(&paths, Some('c'), Some('d')), "\n/a/one.png\n");
+    }
+
+    #[test]
+    fn a_document_payload_adds_no_newline_where_there_already_is_one() {
+        let paths = [PathBuf::from("/a/one.png")];
+        assert_eq!(document_payload(&paths, Some('\n'), Some('\n')), "/a/one.png");
+    }
+
+    #[test]
+    fn project_roots_keeps_a_directory_and_lifts_a_file_to_its_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("a.txt");
+        std::fs::write(&file, "x").unwrap();
+
+        let roots = project_roots(&[dir.path().to_path_buf(), file]);
+
+        assert_eq!(roots, vec![dir.path().to_path_buf()]);
+    }
+
+    /// Selecting several files in one folder is the ordinary way to drag, and
+    /// every one of them names the same root.
+    #[test]
+    fn project_roots_collapses_repeats_in_first_seen_order() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        for dir in [&first, &second] {
+            std::fs::write(dir.path().join("a.txt"), "x").unwrap();
+            std::fs::write(dir.path().join("b.txt"), "x").unwrap();
+        }
+
+        let roots = project_roots(&[
+            second.path().join("a.txt"),
+            first.path().join("a.txt"),
+            second.path().join("b.txt"),
+            first.path().join("b.txt"),
+        ]);
+
+        assert_eq!(roots, vec![second.path().to_path_buf(), first.path().to_path_buf()]);
+    }
+
+    /// Derived from a real temporary directory rather than a hardcoded
+    /// absolute path: a literal is a guess about the host, and a Unix-shaped
+    /// one is a guess about the platform too.
+    #[test]
+    fn project_roots_skips_a_path_that_does_not_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("never-created");
+
+        assert!(project_roots(&[missing]).is_empty());
+    }
+
+    /// The seam, not either half.  `shell_payload` cannot see what `paste.rs`
+    /// does to its output and `paste.rs` cannot see where the text came from,
+    /// so a filename carrying a newline is inert only if the two agree.  This
+    /// is the assertion that fails if the control-character filter is ever
+    /// removed as redundant with quoting.  It stops at the bytes `paste` would
+    /// write — reaching the PTY needs a spawned child.
+    #[test]
+    fn a_payload_reaching_an_unbracketed_paste_submits_nothing() {
+        let cfg =
+            DropConfig { quote: Quoting::None, wsl_translate: false, ..DropConfig::default() };
+        let paths = [PathBuf::from("/a/evil\nrm -rf ~"), PathBuf::from("/a/ok.png")];
+
+        let on_the_pty = crate::paste::paste_bytes(&shell_payload(&paths, None, &cfg), true, false);
+
+        assert!(!on_the_pty.contains(&b'\r'), "{on_the_pty:?} would press Enter on its own");
+        assert_eq!(on_the_pty, b"/a/ok.png ".to_vec());
+    }
+}

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -68,17 +68,18 @@ pub fn route(
     None
 }
 
-/// Characters that would make a pasted path do something other than sit on the
-/// command line.  `paste::paste` strips ESC and ETX, but only on its
-/// bracketed-paste branch; without bracketed paste it turns `\n` into `\r`,
-/// which is Enter (`paste.rs:29`).
-const UNSAFE_IN_TERMINAL: [char; 4] = ['\r', '\n', '\x1b', '\x03'];
-
 /// Whether a path can go on a PTY without acting as input in its own right.
-/// Quoting is no substitute: `shlex` will happily put a newline inside single
-/// quotes, and the newline rewrite happens downstream of any quoting.
+///
+/// Every control character is rejected — C0, DEL and C1 — because far more of
+/// them than the obvious two are commands to whatever is reading the line.
+/// `paste::paste_bytes`'s unbracketed branch turns `\n` into `\r`, which is
+/// Enter; readline binds `\x0f` to `operate-and-get-next`, which accepts the
+/// line just as Enter does, `\x18\x05` to `edit-and-execute-command`, `\x04`
+/// to end-of-file and `\t` to completion.  Quoting is no substitute for any of
+/// it: the line editor acts on the byte before the shell parser ever sees the
+/// quotes around it.
 pub fn is_terminal_safe(path: &str) -> bool {
-    !path.contains(UNSAFE_IN_TERMINAL)
+    !path.contains(char::is_control)
 }
 
 /// The text a set of dropped paths becomes for a shell: each path translated
@@ -351,20 +352,28 @@ mod tests {
         assert_eq!(shell_payload(&[], None, &cfg), "");
     }
 
+    /// `\x0f` is readline's `operate-and-get-next`, which accepts the line as
+    /// if Enter had been pressed — the byte submits a command without a
+    /// carriage return anywhere in the payload.
     #[test]
-    fn a_path_carrying_a_terminal_control_character_is_not_safe() {
+    fn a_path_carrying_any_control_character_is_not_safe() {
         assert!(is_terminal_safe("/a/ordinary name.png"));
         assert!(!is_terminal_safe("/a/two\nlines.png"));
         assert!(!is_terminal_safe("/a/carriage\rreturn.png"));
         assert!(!is_terminal_safe("/a/escape\x1b[0m.png"));
         assert!(!is_terminal_safe("/a/interrupt\x03.png"));
+        assert!(!is_terminal_safe("/a/accept\x0frm -rf ~"));
+
+        for c in ('\0'..='\u{9f}').filter(|c| c.is_control()) {
+            assert!(!is_terminal_safe(&format!("/a/name{c}.png")), "{c:?} passed the filter");
+        }
     }
 
-    /// `paste::paste` rewrites `\n` to `\r` when the receiving application has
-    /// not enabled bracketed paste (`paste.rs:29`), and `\r` is Enter — so a
-    /// filename containing a newline would run whatever follows it without the
-    /// user touching the keyboard.  Quoting does not help: `shlex` wraps the
-    /// newline inside single quotes and the rewrite still fires.
+    /// `paste::paste_bytes`'s unbracketed branch rewrites `\n` to `\r`, and
+    /// `\r` is Enter — so a filename containing a newline would run whatever
+    /// follows it without the user touching the keyboard.  Quoting does not
+    /// help: `shlex` wraps the newline inside single quotes and the rewrite
+    /// still fires.
     #[test]
     fn an_unsafe_path_is_dropped_and_the_rest_of_the_batch_survives() {
         let cfg =
@@ -502,20 +511,38 @@ mod tests {
 
     /// The seam, not either half.  `shell_payload` cannot see what `paste.rs`
     /// does to its output and `paste.rs` cannot see where the text came from,
-    /// so a filename carrying a newline is inert only if the two agree.  This
-    /// is the assertion that fails if the control-character filter is ever
-    /// removed as redundant with quoting.  It stops at the bytes `paste` would
-    /// write — reaching the PTY needs a spawned child.
+    /// so a filename carrying a line-submitting byte is inert only if the two
+    /// agree.  This is the assertion that fails if the control-character filter
+    /// is ever removed as redundant with quoting — `paste::paste_bytes`'s
+    /// unbracketed branch turns `\n` into `\r`, and readline accepts the line
+    /// on `\x0f` with no `\r` involved at all.  It stops at the bytes `paste`
+    /// would write — reaching the PTY needs a spawned child.
+    ///
+    /// Run under `Auto` as well as `None` because `Auto` is what ships.
     #[test]
     fn a_payload_reaching_an_unbracketed_paste_submits_nothing() {
-        let cfg =
-            DropConfig { quote: Quoting::None, wsl_translate: false, ..DropConfig::default() };
-        let paths = [PathBuf::from("/a/evil\nrm -rf ~"), PathBuf::from("/a/ok.png")];
+        let paths = [
+            PathBuf::from("/a/evil\nrm -rf ~"),
+            PathBuf::from("/a/accept\x0frm -rf ~"),
+            PathBuf::from("/a/ok.png"),
+        ];
 
-        let on_the_pty = crate::paste::paste_bytes(&shell_payload(&paths, None, &cfg), true, false);
+        for quote in [Quoting::None, Quoting::Auto] {
+            let cfg = DropConfig { quote, wsl_translate: false, ..DropConfig::default() };
 
-        assert!(!on_the_pty.contains(&b'\r'), "{on_the_pty:?} would press Enter on its own");
-        assert_eq!(on_the_pty, b"/a/ok.png ".to_vec());
+            let on_the_pty =
+                crate::paste::paste_bytes(&shell_payload(&paths, None, &cfg), true, false);
+
+            assert!(
+                !on_the_pty.contains(&b'\r'),
+                "{quote:?}: {on_the_pty:?} would press Enter on its own"
+            );
+            assert!(
+                !on_the_pty.contains(&0x0f),
+                "{quote:?}: {on_the_pty:?} would accept the line through operate-and-get-next"
+            );
+            assert_eq!(on_the_pty, b"/a/ok.png ".to_vec(), "{quote:?}");
+        }
     }
 
     /// `GetCursorPos` reports physical screen pixels while egui works in

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -5,10 +5,6 @@
 //! Keeping the decisions out of the frame loop is what makes them testable
 //! without a window.
 
-// Nothing routes a drop event here yet, so every item in this module is only
-// reached from the tests below.
-#![cfg_attr(not(test), allow(dead_code))]
-
 use std::path::{Path, PathBuf};
 
 use crate::config::{DropConfig, ShellQuoting};
@@ -224,6 +220,10 @@ pub fn screen_pointer(_ctx: &egui::Context) -> Option<egui::Pos2> {
 /// `ViewportInfo::inner_rect` is in monitor space at ui-point scale, which is
 /// physical pixels divided by `Context::pixels_per_point` — the same divisor
 /// `egui-winit` used to produce it.
+///
+/// Only the Windows `screen_pointer` has a pixel position to convert; the
+/// conversion itself is platform-independent, so its test still runs everywhere.
+#[cfg(any(windows, test))]
 fn to_egui_pos(
     x_px: f32,
     y_px: f32,

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -193,6 +193,46 @@ pub fn project_roots(paths: &[PathBuf]) -> Vec<PathBuf> {
     roots
 }
 
+/// The OS cursor in egui coordinates, or `None` when it cannot be known.
+///
+/// winit 0.30 discards the drag position on every platform — its Windows
+/// `DragEnter`/`DragOver`/`Drop` handlers all ignore their `POINTL`, and no
+/// `CursorMoved` is synthesized during a drag — so egui's own pointer is still
+/// wherever it was before the drag began.  Asking Win32 directly is the only
+/// way to learn where a drop landed.  Other platforms have no equivalent here
+/// yet, so they route by the central-panel fallback in `route`.
+#[cfg(windows)]
+pub fn screen_pointer(ctx: &egui::Context) -> Option<egui::Pos2> {
+    use windows_sys::Win32::Foundation::POINT;
+    use windows_sys::Win32::UI::WindowsAndMessaging::GetCursorPos;
+
+    let mut point = POINT { x: 0, y: 0 };
+    // SAFETY: `GetCursorPos` only writes a `POINT` through the pointer it is
+    // given, and `point` is a live, correctly aligned local.
+    if unsafe { GetCursorPos(&mut point) } == 0 {
+        return None;
+    }
+    let origin = ctx.input(|i| i.viewport().inner_rect)?.min;
+    Some(to_egui_pos(point.x as f32, point.y as f32, origin, ctx.pixels_per_point()))
+}
+
+#[cfg(not(windows))]
+pub fn screen_pointer(_ctx: &egui::Context) -> Option<egui::Pos2> {
+    None
+}
+
+/// `ViewportInfo::inner_rect` is in monitor space at ui-point scale, which is
+/// physical pixels divided by `Context::pixels_per_point` — the same divisor
+/// `egui-winit` used to produce it.
+fn to_egui_pos(
+    x_px: f32,
+    y_px: f32,
+    window_origin: egui::Pos2,
+    pixels_per_point: f32,
+) -> egui::Pos2 {
+    egui::pos2(x_px / pixels_per_point - window_origin.x, y_px / pixels_per_point - window_origin.y)
+}
+
 #[cfg(test)]
 mod tests {
     use egui::{Rect, pos2};
@@ -476,5 +516,14 @@ mod tests {
 
         assert!(!on_the_pty.contains(&b'\r'), "{on_the_pty:?} would press Enter on its own");
         assert_eq!(on_the_pty, b"/a/ok.png ".to_vec());
+    }
+
+    /// `GetCursorPos` reports physical screen pixels while egui works in
+    /// logical points measured from the window's content origin.
+    #[test]
+    fn a_screen_pixel_converts_to_a_window_relative_egui_point() {
+        let origin = pos2(100.0, 50.0);
+        assert_eq!(to_egui_pos(300.0, 250.0, origin, 1.0), pos2(200.0, 200.0));
+        assert_eq!(to_egui_pos(600.0, 500.0, origin, 2.0), pos2(200.0, 200.0));
     }
 }

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -391,6 +391,16 @@ mod tests {
         assert_eq!(shell_payload(&paths, None, &cfg), "/a/one.png /a/two.png ");
     }
 
+    /// The guard in `app.rs` skips the paste on an empty payload, so a batch
+    /// where nothing survives the filter must produce exactly that.
+    #[test]
+    fn a_batch_of_only_unsafe_paths_produces_no_payload() {
+        let cfg =
+            DropConfig { quote: Quoting::None, wsl_translate: false, ..DropConfig::default() };
+        let paths = [PathBuf::from("/a/evil\nrm -rf ~"), PathBuf::from("/a/accept\x0frm -rf ~")];
+        assert_eq!(shell_payload(&paths, None, &cfg), "");
+    }
+
     #[cfg(windows)]
     #[test]
     fn a_drive_path_becomes_a_distro_path_for_a_wsl_shell() {
@@ -416,6 +426,19 @@ mod tests {
             DropConfig { wsl_translate: false, quote: Quoting::None, ..DropConfig::default() };
         let paths = [PathBuf::from(r"C:\pics\a.png")];
         assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "C:\\pics\\a.png ");
+    }
+
+    /// `auto` follows the receiving shell, not the path: a WSL session gets
+    /// POSIX quoting even where translation is off and the word being quoted is
+    /// still a `C:\` path, whose separators the quoting then escapes so the
+    /// shell hands the backslashes on intact.
+    #[cfg(windows)]
+    #[test]
+    fn an_untranslated_path_for_a_wsl_shell_is_still_quoted_posix_style() {
+        let cfg =
+            DropConfig { wsl_translate: false, quote: Quoting::Auto, ..DropConfig::default() };
+        let paths = [PathBuf::from(r"C:\pics\my pic.png")];
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), r#""C:\\pics\\my pic.png" "#);
     }
 
     /// A plain UNC share has no distro-side spelling.  Pasting the raw path is
@@ -469,6 +492,15 @@ mod tests {
     fn a_document_payload_adds_no_newline_where_there_already_is_one() {
         let paths = [PathBuf::from("/a/one.png")];
         assert_eq!(document_payload(&paths, Some('\n'), Some('\n')), "/a/one.png");
+    }
+
+    /// Each boundary is decided on its own, so a drop at the start of a
+    /// non-empty line needs a newline after it and none before.
+    #[test]
+    fn a_document_payload_treats_its_two_boundaries_separately() {
+        let paths = [PathBuf::from("/a/one.png")];
+        assert_eq!(document_payload(&paths, None, Some('d')), "/a/one.png\n");
+        assert_eq!(document_payload(&paths, Some('c'), None), "\n/a/one.png");
     }
 
     #[test]
@@ -557,5 +589,15 @@ mod tests {
         let origin = pos2(100.0, 50.0);
         assert_eq!(to_egui_pos(300.0, 250.0, origin, 1.0), pos2(200.0, 200.0));
         assert_eq!(to_egui_pos(600.0, 500.0, origin, 2.0), pos2(200.0, 200.0));
+    }
+
+    /// A monitor left of or above the primary one has negative coordinates, and
+    /// a window on it has a negative origin — the ordinary multi-display
+    /// layout, not an edge case.
+    #[test]
+    fn a_window_on_a_monitor_left_of_the_primary_converts_the_same_way() {
+        let origin = pos2(-1920.0, -200.0);
+        assert_eq!(to_egui_pos(-1720.0, -100.0, origin, 1.0), pos2(200.0, 100.0));
+        assert_eq!(to_egui_pos(-3840.0, -400.0, origin, 2.0), pos2(0.0, 0.0));
     }
 }

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -11,6 +11,7 @@ mod command_ext;
 mod command_palette;
 mod config;
 mod doppler;
+mod file_drop;
 mod fonts;
 mod frame_log;
 mod git_nav;

--- a/alacritree/src/paste.rs
+++ b/alacritree/src/paste.rs
@@ -16,20 +16,25 @@ pub fn paste(session: &Session, text: &str, bracketed: bool) {
 
     on_terminal_input_start(session);
 
+    session.write(paste_bytes(text, bracketed, bracketed_active));
+}
+
+/// The bytes a paste puts on the PTY.
+///
+/// ESC and ETX are stripped inside a bracketed paste so the text cannot forge
+/// the end marker.  Without bracketed paste the receiving application cannot
+/// tell a paste from typing, so a newline has to become `\r` — which is also
+/// what Enter sends, meaning any newline reaching here submits a line.  That is
+/// why text built from filenames is filtered first
+/// (`file_drop::is_terminal_safe`).
+pub(crate) fn paste_bytes(text: &str, bracketed: bool, bracketed_active: bool) -> Vec<u8> {
     if bracketed && bracketed_active {
-        // Strip ESC/ETX so pasted text can't forge the end marker or trip a
-        // shell into terminating paste early.
-        session.write(b"\x1b[200~".to_vec());
         let filtered = text.replace(['\x1b', '\x03'], "");
-        session.write(filtered.into_bytes());
-        session.write(b"\x1b[201~".to_vec());
+        format!("\x1b[200~{filtered}\x1b[201~").into_bytes()
     } else if bracketed {
-        // Apps that didn't enable bracketed paste can't tell paste from
-        // keystrokes — collapse newlines to `\r` (what Enter sends).
-        let payload = text.replace("\r\n", "\r").replace('\n', "\r");
-        session.write(payload.into_bytes());
+        text.replace("\r\n", "\r").replace('\n', "\r").into_bytes()
     } else {
-        session.write(text.as_bytes().to_vec());
+        text.as_bytes().to_vec()
     }
 }
 
@@ -60,5 +65,29 @@ pub fn on_terminal_input_start(session: &Session) {
     let _ = term.selection.take();
     if term.grid().display_offset() != 0 {
         term.scroll_display(Scroll::Bottom);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bracketed_paste_wraps_the_text_and_strips_the_end_marker_bytes() {
+        let bytes = paste_bytes("a\x1bb\x03c", true, true);
+        assert_eq!(bytes, b"\x1b[200~abc\x1b[201~".to_vec());
+    }
+
+    /// An application that never enabled bracketed paste sees typing, and `\r`
+    /// is Enter — so every newline here submits a line.
+    #[test]
+    fn a_paste_into_an_app_without_bracketed_paste_turns_newlines_into_enter() {
+        assert_eq!(paste_bytes("a\r\nb\nc", true, false), b"a\rb\rc".to_vec());
+    }
+
+    /// `bracketed = false` is for writes that must reach the PTY verbatim.
+    #[test]
+    fn an_unbracketed_write_is_passed_through_untouched() {
+        assert_eq!(paste_bytes("a\nb\x1b", false, true), "a\nb\x1b".as_bytes().to_vec());
     }
 }

--- a/alacritree/src/scratchpad.rs
+++ b/alacritree/src/scratchpad.rs
@@ -59,6 +59,25 @@ impl Editor {
         self.save();
     }
 
+    /// The characters either side of where `insert_at_cursor` would write, so a
+    /// caller inserting a block can tell whether it needs its own newlines.
+    /// A selection is replaced, so the following character is the one at the
+    /// end of the range, not the start.
+    pub fn cursor_boundary(
+        &self,
+        ctx: &egui::Context,
+        session_id: u64,
+    ) -> (Option<char>, Option<char>) {
+        let end = self.text.chars().count();
+        let range = TextEdit::load_state(ctx, editor_id(session_id))
+            .and_then(|state| state.cursor.char_range())
+            .unwrap_or_else(|| CCursorRange::one(CCursor::new(end)));
+        let [min, max] = range.sorted();
+        let mut chars = self.text.chars();
+        let preceding = (min.index > 0).then(|| chars.nth(min.index - 1)).flatten();
+        (preceding, self.text.chars().nth(max.index))
+    }
+
     pub fn selected_text(&self, ctx: &egui::Context, session_id: u64) -> Option<String> {
         let state = TextEdit::load_state(ctx, editor_id(session_id))?;
         let [min, max] = state.cursor.char_range()?.sorted();
@@ -349,5 +368,93 @@ mod tests {
         assert_eq!(value["exists"], true);
         assert_eq!(ensure_file_in(dir.path(), &workspace).unwrap(), path);
         assert_eq!(fs::read_to_string(path).unwrap(), "# Notes\n\nkeep me\n");
+    }
+
+    fn editor_holding(dir: &TempDir, text: &str) -> Editor {
+        let path = dir.path().join("note.md");
+        fs::write(&path, text).unwrap();
+        Editor::open(path).unwrap()
+    }
+
+    fn put_cursor(ctx: &egui::Context, session_id: u64, range: CCursorRange) {
+        let mut state = egui::text_edit::TextEditState::default();
+        state.cursor.set_char_range(Some(range));
+        TextEdit::store_state(ctx, editor_id(session_id), state);
+    }
+
+    #[test]
+    fn a_collapsed_cursor_reports_the_characters_either_side_of_it() {
+        let dir = TempDir::new().unwrap();
+        let editor = editor_holding(&dir, "abcd");
+        let ctx = egui::Context::default();
+
+        put_cursor(&ctx, 1, CCursorRange::one(CCursor::new(2)));
+
+        assert_eq!(editor.cursor_boundary(&ctx, 1), (Some('b'), Some('c')));
+    }
+
+    #[test]
+    fn a_cursor_at_either_end_of_the_buffer_reports_no_neighbour_there() {
+        let dir = TempDir::new().unwrap();
+        let editor = editor_holding(&dir, "abcd");
+        let ctx = egui::Context::default();
+
+        put_cursor(&ctx, 1, CCursorRange::one(CCursor::new(0)));
+        assert_eq!(editor.cursor_boundary(&ctx, 1), (None, Some('a')));
+
+        put_cursor(&ctx, 1, CCursorRange::one(CCursor::new(4)));
+        assert_eq!(editor.cursor_boundary(&ctx, 1), (Some('d'), None));
+    }
+
+    /// `insert_at_cursor` replaces the selection, so the text that survives
+    /// after the insertion starts at the *end* of the range.  Reading the
+    /// following character from `min.index` would report a character the
+    /// insertion is about to delete.
+    #[test]
+    fn a_selection_reports_what_survives_it_not_what_it_replaces() {
+        let dir = TempDir::new().unwrap();
+        let editor = editor_holding(&dir, "abcdef");
+        let ctx = egui::Context::default();
+
+        put_cursor(&ctx, 1, CCursorRange::two(CCursor::new(2), CCursor::new(4)));
+
+        assert_eq!(editor.cursor_boundary(&ctx, 1), (Some('b'), Some('e')));
+    }
+
+    /// Dragging a selection right-to-left stores it reversed; `sorted()` is
+    /// what makes the two directions agree.
+    #[test]
+    fn a_backwards_selection_reads_the_same_as_a_forwards_one() {
+        let dir = TempDir::new().unwrap();
+        let editor = editor_holding(&dir, "abcdef");
+        let ctx = egui::Context::default();
+
+        put_cursor(&ctx, 1, CCursorRange::two(CCursor::new(4), CCursor::new(2)));
+
+        assert_eq!(editor.cursor_boundary(&ctx, 1), (Some('b'), Some('e')));
+    }
+
+    /// `CCursor` counts characters, not bytes.  Indexing the buffer by byte
+    /// would land mid-codepoint here.
+    #[test]
+    fn multibyte_neighbours_are_read_as_whole_characters() {
+        let dir = TempDir::new().unwrap();
+        let editor = editor_holding(&dir, "aé→b");
+        let ctx = egui::Context::default();
+
+        put_cursor(&ctx, 1, CCursorRange::one(CCursor::new(2)));
+
+        assert_eq!(editor.cursor_boundary(&ctx, 1), (Some('é'), Some('→')));
+    }
+
+    /// A tab that has never been focused has no stored cursor, and
+    /// `insert_at_cursor` appends in that case — the boundary has to agree.
+    #[test]
+    fn an_editor_with_no_stored_cursor_reports_the_end_of_the_buffer() {
+        let dir = TempDir::new().unwrap();
+        let editor = editor_holding(&dir, "abcd");
+        let ctx = egui::Context::default();
+
+        assert_eq!(editor.cursor_boundary(&ctx, 1), (Some('d'), None));
     }
 }

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -1302,6 +1302,12 @@ impl Session {
         self.exited
     }
 
+    /// The distro a shimmed WSL session runs in.  Dropped paths need it to
+    /// decide whether a `C:\` path has to be rewritten before a shell sees it.
+    pub fn wsl_distro(&self) -> Option<&str> {
+        self.wsl_probe.as_ref().map(|probe| probe.distro.as_str())
+    }
+
     /// Sidebar glyph for the agent running here.  Identity comes from the
     /// PTY's foreground process (`/proc` on Linux, `sysctl` on macOS); the
     /// displayed glyph

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -200,6 +200,40 @@ Two clipboards are distinguished:
 
 OSC 52 in the terminal flows through the same wrapper.
 
+### Drag and drop
+
+Dropping files on the window does something different per region:
+
+- **Terminal grid** — the paths are *pasted*, quoted for the shell, joined by
+  spaces, with a trailing space. It is a paste, not typing: bracketed paste is
+  honoured and there is no newline, so nothing runs until you press Enter.
+  Dropping an image on a session running Claude Code gives you `[Image #N]`,
+  because Claude Code resolves a pasted image path.
+- **Projects sidebar** — a folder is added as a project; a file adds the folder
+  containing it. Several files from one folder add it once.
+- **Scratchpad tab** — the plain path is inserted at the cursor, one per line
+  and unquoted, since a document is not a command line. Dropping mid-line puts
+  the block on lines of its own rather than welding it to the text either side.
+
+Paths dropped into a WSL session are rewritten to their distro-side spelling
+(`C:\pics\a.png` becomes `/mnt/c/pics/a.png`) and quoted POSIX-style, because a
+`C:` path resolves to nothing inside a distro. That POSIX quoting applies even
+when `quote` names another mode — `windows` quoting fed to `bash` is broken by
+construction. A `\\wsl.localhost\<distro>\…` path is only rewritten when it
+belongs to the distro the session is running in; one from a *different* distro
+is pasted as-is, because the same Linux path means a different file there.
+
+Filenames carrying a carriage return, newline, ESC or ETX (control-C) are
+skipped. An application that has not enabled bracketed paste cannot tell a paste
+from typing, so a newline in a pasted path would submit a line on its own.
+
+While files hover, the region that would receive them is tinted.
+
+Windows only, for now: winit reports no cursor position during a drag, so on
+other platforms the sidebar cannot be targeted and no tint is drawn. Drops
+still reach the terminal or the scratchpad there, chosen by which tab is
+active.
+
 ## Input and key bindings
 
 Input handling is layered:
@@ -285,6 +319,21 @@ vsync              = true   # restart required — wait for the display's refres
 
 [ui.icons]                  # sidebar glyph overrides (e.g. Nerd Font icons)
 search = "⌕"                # glyph prefixing the sidebar search prompt
+
+[ui.drop]                   # what dragging files onto the window does
+enabled       = true        # master switch; false ignores every drop
+terminal      = true        # paste the paths into the shell
+sidebar       = true        # a folder dropped on the projects sidebar becomes a project
+scratchpad    = true        # insert the path into an open scratchpad tab
+quote         = "auto"      # "auto" (POSIX inside a distro, otherwise the host
+                            # default), or "none" / "spaces_only" / "posix" /
+                            # "windows" / "windows_always_quoted" to force one.
+                            # A path rewritten for WSL is always POSIX-quoted.
+                            # No mode escapes shell metacharacters beyond what
+                            # the receiving OS needs: "posix" is the only one
+                            # that makes an arbitrary filename inert.
+wsl_translate = true        # rewrite C:\x as /mnt/c/x for a WSL session
+highlight     = true        # tint the region a drop would land on
 
 [workspace]
 worktree_dir = "~/dev/worktrees"   # base dir for new worktrees (default ~/.alacritree/worktrees)

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -206,7 +206,8 @@ Dropping files on the window does something different per region:
 
 - **Terminal grid** — the paths are *pasted*, quoted for the shell, joined by
   spaces, with a trailing space. It is a paste, not typing: bracketed paste is
-  honoured and there is no newline, so nothing runs until you press Enter.
+  honoured, and any path carrying a control character is left out of the payload
+  (see below), so what arrives is a command line waiting on your Enter.
   Dropping an image on a session running Claude Code gives you `[Image #N]`,
   because Claude Code resolves a pasted image path.
 - **Projects sidebar** — a folder is added as a project; a file adds the folder
@@ -223,9 +224,11 @@ construction. A `\\wsl.localhost\<distro>\…` path is only rewritten when it
 belongs to the distro the session is running in; one from a *different* distro
 is pasted as-is, because the same Linux path means a different file there.
 
-Filenames carrying a carriage return, newline, ESC or ETX (control-C) are
-skipped. An application that has not enabled bracketed paste cannot tell a paste
-from typing, so a newline in a pasted path would submit a line on its own.
+Filenames carrying any control character are skipped. An application that has
+not enabled bracketed paste cannot tell a paste from typing, and a line editor
+acts on those bytes as commands: a newline arrives as Enter, and readline
+accepts the line on `Ctrl-O` as well. Quoting is no defence, because the editor
+binds the byte before the shell ever parses the quotes around it.
 
 While files hover, the region that would receive them is tinted.
 


### PR DESCRIPTION
Dragging files onto the window now does something, and what it does depends on where you drop them:

- **Terminal grid** — the paths are *pasted*, shell-quoted and space-joined with a trailing space, leaving a command line waiting on Enter. It goes through the paste path, so bracketed paste is honoured.
- **Projects sidebar** — a dropped folder becomes a project; a dropped file adds its containing folder. Several files from one folder add it once.
- **Scratchpad tab** — the plain, unquoted path is inserted at the cursor, one per line, since a document is not a command line.

Paths dropped into a WSL session are rewritten to their distro-side spelling (`C:\pics\a.png` → `/mnt/c/pics/a.png`) and POSIX-quoted, because a `C:` path resolves to nothing inside a distro. A `\\wsl.localhost\<distro>\…` path is only rewritten when it belongs to the distro the session is running in — the same Linux path names a different file in another distro.

Filenames carrying a control character are dropped from the payload. An application that has not enabled bracketed paste cannot distinguish a paste from typing, and a line editor acts on those bytes as commands — a newline arrives as Enter, and readline accepts the line on `Ctrl-O`. Quoting is no defence, because the editor binds the byte before the shell parses the quotes around it.

While files hover, the region that would receive them is tinted.

Windows only for now: winit reports no cursor position during a drag, so on other platforms the sidebar cannot be targeted and no tint is drawn. Drops still reach the terminal or the scratchpad there, chosen by the active tab.

## Configuration

Everything is under a new `[ui.drop]` table, documented in `docs/alacritree.md`:

```toml
[ui.drop]
enabled       = true        # master switch; false ignores every drop
terminal      = true        # paste the paths into the shell
sidebar       = true        # a folder dropped on the projects sidebar becomes a project
scratchpad    = true        # insert the path into an open scratchpad tab
quote         = "auto"      # or "none" / "spaces_only" / "posix" / "windows" /
                            # "windows_always_quoted"
wsl_translate = true        # rewrite C:\x as /mnt/c/x for a WSL session
highlight     = true        # tint the region a drop would land on
```

The defaults turn the feature on, matching what wezterm and other terminals do with a drop. `enabled = false` restores the current no-op behaviour.

## Notes

- `shlex` is a new dependency, for POSIX word quoting — the same crate wezterm uses for its `quote_dropped_files = "Posix"` mode.
- `Win32_UI_WindowsAndMessaging` is added to the existing `windows` feature list to read the cursor position during a drag, which winit discards.
- 666 tests pass; `cargo fmt` and `cargo clippy -p alacritree --all-targets --no-deps` are clean for the new code.
