### PR TITLE
feat(session): land a close on the neighbour [4]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1034,10 +1034,11 @@ impl AlacritreeApp {
         let workspace = self.sessions[idx].working_directory.clone();
         self.sessions.remove(idx);
 
+        let remaining: Vec<(WorkspaceKey, SessionId)> =
+            self.sessions.iter().map(|s| (s.working_directory.clone(), s.id)).collect();
+
         if self.active_session.get(&workspace).copied() == Some(id) {
-            let fallback =
-                self.sessions.iter().find(|s| s.working_directory == workspace).map(|s| s.id);
-            match fallback {
+            match close_landing(&remaining, &workspace, idx, self.config.ui.sidebar_focus) {
                 Some(new_id) => {
                     self.active_session.insert(workspace.clone(), new_id);
                 },
@@ -1051,8 +1052,6 @@ impl AlacritreeApp {
         // view on an empty pane. What happens instead is policy: `respawn`
         // recycles a shell in place (the last session is by design
         // unclosable), `navigate` falls back to the project main, then home.
-        let remaining: Vec<(WorkspaceKey, SessionId)> =
-            self.sessions.iter().map(|s| (s.working_directory.clone(), s.id)).collect();
         let main = workspace.as_deref().and_then(|p| project_main_for(&self.projects, p));
         let verdict = close_fallback(&workspace, &self.current_workspace, &remaining, main);
         if verdict != CloseFallback::Stay
@@ -5356,6 +5355,40 @@ enum CloseFallback {
     Home,
 }
 
+/// Which session a workspace switches to when the one at `removed_idx` is
+/// closed.  `sessions` is the list *after* removal; `removed_idx` indexes the
+/// list *before* it, so the first surviving sibling at or past it is the
+/// closed session's successor.  Pure over (workspace, id) pairs for the same
+/// reason as `close_fallback`.
+///
+/// `Preserve` hands the workspace its first session whichever one closed.
+/// `Follow` takes the successor, or the predecessor when the last session
+/// closed — the ordinal rule `sidebar_focus::slide` lands the cursor by, so a
+/// close that moves both cannot point them at different siblings.
+fn close_landing(
+    sessions: &[(WorkspaceKey, SessionId)],
+    workspace: &WorkspaceKey,
+    removed_idx: usize,
+    mode: SidebarFocus,
+) -> Option<SessionId> {
+    let mut siblings = sessions
+        .iter()
+        .enumerate()
+        .filter(|(_, (w, _))| w == workspace)
+        .map(|(i, (_, id))| (i, *id));
+    if !mode.follows() {
+        return siblings.next().map(|(_, id)| id);
+    }
+    let mut predecessor = None;
+    for (i, id) in siblings {
+        if i >= removed_idx {
+            return Some(id);
+        }
+        predecessor = Some(id);
+    }
+    predecessor
+}
+
 /// Post-close navigation for the workspace that just lost a session.
 /// `remaining` is the session list after removal; `main_checkout` is the
 /// removed workspace's project main (None when the workspace *is* the main,
@@ -7926,6 +7959,73 @@ mod tests {
             expanded: true,
             shell_override: None,
             home: None,
+        }
+    }
+
+    /// One worktree holding a `main` shell and three more, with an unrelated
+    /// workspace ahead of them so a landing that ignored `workspace` would
+    /// show up as picking id 9.
+    fn close_row() -> Vec<(WorkspaceKey, SessionId)> {
+        vec![
+            (ws("/other"), 9),
+            (ws("/repo/wt"), 1),
+            (ws("/repo/wt"), 2),
+            (ws("/repo/wt"), 3),
+            (ws("/repo/wt"), 4),
+        ]
+    }
+
+    fn closing(idx: usize) -> Vec<(WorkspaceKey, SessionId)> {
+        let mut sessions = close_row();
+        sessions.remove(idx);
+        sessions
+    }
+
+    #[test]
+    fn preserve_hands_the_workspace_its_first_session() {
+        for (removed_idx, expected) in [(1, 2), (2, 1), (3, 1), (4, 1)] {
+            assert_eq!(
+                close_landing(
+                    &closing(removed_idx),
+                    &ws("/repo/wt"),
+                    removed_idx,
+                    SidebarFocus::Preserve
+                ),
+                Some(expected),
+                "closing index {removed_idx}"
+            );
+        }
+    }
+
+    #[test]
+    fn follow_lands_on_the_successor() {
+        for (removed_idx, expected) in [(1, 2), (2, 3), (3, 4)] {
+            assert_eq!(
+                close_landing(
+                    &closing(removed_idx),
+                    &ws("/repo/wt"),
+                    removed_idx,
+                    SidebarFocus::Follow
+                ),
+                Some(expected),
+                "closing index {removed_idx}"
+            );
+        }
+    }
+
+    /// Matches `sidebar_focus::slide`, which falls back to the last survivor
+    /// when the removed row had no successor; cursor and terminal would
+    /// otherwise pick different siblings under `"follow"`.
+    #[test]
+    fn follow_lands_on_the_predecessor_when_the_last_session_closes() {
+        assert_eq!(close_landing(&closing(4), &ws("/repo/wt"), 4, SidebarFocus::Follow), Some(3));
+    }
+
+    #[test]
+    fn an_emptied_workspace_has_no_landing_under_either_mode() {
+        let remaining = vec![(ws("/other"), 9)];
+        for mode in [SidebarFocus::Preserve, SidebarFocus::Follow] {
+            assert_eq!(close_landing(&remaining, &ws("/repo/wt"), 1, mode), None, "{mode:?}");
         }
     }
 

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -316,7 +316,9 @@ sidebar_focus      = "preserve"  # how far the projects sidebar goes when the
                                   # returns when the filter widens; a deleted row
                                   # slides to a sibling bounded by its parent.
                                   # "follow": also moves the terminal to a delete
-                                  # landing that has a live session
+                                  # landing that has a live session, and lands a
+                                  # closed session on its neighbour instead of on
+                                  # the workspace's first session
 vsync              = true   # restart required — wait for the display's refresh
                             # before showing a finished frame (default true).
                             # false presents each frame as soon as it is drawn,
@@ -445,6 +447,13 @@ The sidebar cursor used to drop to the first row whenever its own row stopped
 being rendered — by a filter, or by deleting a session or worktree. It now
 climbs or slides instead, under `sidebar_focus = "preserve"`. There is no
 setting that restores the old drop-to-first-row behavior.
+
+Closing a session is the one removal the cursor cannot speak for: `Ctrl+Shift+W`
+from the terminal and a shell exiting on its own both originate outside the
+sidebar, so there is no cursor to slide. Under `"preserve"` the workspace falls
+back to its first session, whichever one closed. `"follow"` lands on the closed
+session's neighbour instead — the next one, or the previous when the last
+session closed, the same ordinal rule the cursor slides by.
 
 Alacritty's palette, cursor, scrolling, window padding, shell, env, and binding
 tables are read by the same `Raw*` structs, so those parts of an existing


### PR DESCRIPTION
## TL;DR (human written)

Part of an implementation for how closing sessions, deleting worktrees, and projects didn't work correctly. This PR fixes it, so it behaves in a way that's more consistent with other UIs. The feature is gated by user config.

---

## AI Summary

Closing a session handed the workspace its first session whichever one closed, so in a worktree running several shells every close jumped back to the first one. With `main`, `s1`, `s2`, `s3` open, closing any of `s1`/`s2`/`s3` landed on `main`.

Deleting a worktree or project never had this problem. Both can only be triggered from the sidebar cursor (`request_worktree_delete` is reachable only from `DeleteSelected` and a row's own delete affordance), so the cursor is on the vanished row by construction and `sidebar_focus::slide` picks the neighbour. Sessions are the exception: `Ctrl+Shift+W` from the terminal explicitly falls back to the active session when the sidebar isn't focused, and a shell exiting on its own originates in the PTY. Neither has a cursor to slide, so the hardcoded first-match in `close_session` was all that was left.

## Change

The landing choice moves into a pure `close_landing(sessions, workspace, removed_idx, mode)`, sitting next to `close_fallback` and testable the same way — over `(workspace, id)` pairs, without spawning PTYs.

- `sidebar_focus = "preserve"` (default): returns the workspace's first session. Byte-identical to the previous `find`, so unconfigured behavior does not move.
- `sidebar_focus = "follow"`: returns the closed session's successor, or its predecessor when the last session closed.

That tie-break is deliberately the same ordinal rule `sidebar_focus::slide` lands the cursor by. A close that moves both the cursor and the terminal therefore cannot point them at different siblings.

Reusing `sidebar_focus` rather than adding a key: `"follow"` already means "a removal landing that has a live session also moves the terminal to it", which is exactly this case — the session-close path simply had no cursor to derive that landing from.

## Interaction with the existing deferral

Under `"follow"`, `close_session` defers navigation to the reconciler. Closing a non-last session yields `CloseFallback::Stay`, so the deferral does not engage and the new landing stands. Closing the last session in a workspace yields `None` and the deferral behaves exactly as before.

## Tests

Four cases against `close_landing`, using the repro above as the fixture plus an unrelated workspace ahead of it so a landing that ignored `workspace` would be visible:

- `preserve_hands_the_workspace_its_first_session`
- `follow_lands_on_the_successor`
- `follow_lands_on_the_predecessor_when_the_last_session_closes`
- `an_emptied_workspace_has_no_landing_under_either_mode`

Confirmed red before the fix (`left: Some(1)` — the first session — against the expected neighbour), green after. Full suite 670 passed / 0 failed / 9 ignored.

Worth flagging: these cover the policy function, not the three key paths into it. `Session` owns a real PTY and there is no harness that constructs an `AlacritreeApp`, so `close_session` itself is not driven end-to-end here.

## Docs

`docs/alacritree.md` — extended the `sidebar_focus` comment and added a paragraph on why closing a session is the one removal the cursor cannot speak for.
