### PR TITLE
docs: fix stale claims about bindings, IPC, and config [2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,10 @@ that always carries a warning is a report nobody reads.
   compares against worktree CLIs, AI-agent orchestrators, and other native
   terminals in the space.
 - [`docs/keyboard-shortcuts.md`](docs/keyboard-shortcuts.md) — every key
-  binding the app understands, split between hard-coded app shortcuts
-  (sidebar toggles, workspace and session switching, modals) and the
-  configurable `[[keyboard.bindings]]` layer, including the full list of
-  supported `action = "…"` values and which Alacritty actions are
-  intentionally not wired up.
+  binding the app understands: the defaults it ships with (sidebar toggles,
+  workspace and session switching, palette), the full list of supported
+  `action = "…"` values for the `[[keyboard.bindings]]` layer, and which
+  Alacritty actions are intentionally not wired up.
 - [`docs/features.md`](docs/features.md) — upstream Alacritty's feature
   overview (vi mode, search, hints, selection expansion). Kept for reference;
   not everything listed is implemented in the egui shell yet.

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -244,8 +244,9 @@ Input handling is layered:
 1. **Key bindings** — parsed from `[[keyboard.bindings]]` in the TOML config.
    Alacritty's default set is preloaded, and so are alacritree's own (sidebar
    toggles, workspace switches, session spawn / cycle, palette); your entries
-   are checked first so any default can be overridden or unbound (`action =
-   "None"`).
+   are checked first so any default can be overridden, forwarded to the
+   terminal (`action = "ReceiveChar"`), or consumed without an action (`action
+   = "None"`).
 2. **Modal Enter/Escape** — consumed by whichever dialog is open. These are
    not bindings and cannot be rebound.
 3. **Egui text events** — preferred for printable input because they handle
@@ -506,12 +507,15 @@ Tools:
 the editor tab is closed. Because the built-in editor writes every change
 immediately, MCP clients see the same auto-saved contents as the editor.
 
-Under the hood this mirrors Alacritty's IPC design, on every platform: the app
-listens on a unix socket at `$XDG_RUNTIME_DIR/alacritree/alacritree-<pid>.sock`,
-or on Windows a named pipe at `\\.\pipe\alacritree-<pid>.sock`, and advertises
-the path to child PTYs via `ALACRITREE_SOCKET` — so an agent running *inside*
-an Alacritree session automatically targets the instance hosting it. Other
-clients fall back to scanning the socket directory, or can pass
+Under the hood this mirrors Alacritty's IPC design, on every platform. On Unix,
+the app listens under `$XDG_RUNTIME_DIR/alacritree`, or under
+`/run/user/$UID/alacritree` on Linux when that environment variable is absent;
+if the runtime path cannot be created, it falls back to the system temporary
+directory. On Windows it uses a named pipe at
+`\\.\pipe\alacritree-<pid>.sock`. The path is advertised to child PTYs via
+`ALACRITREE_SOCKET`, so an agent running *inside* an Alacritree session
+automatically targets the instance hosting it. Other clients fall back to
+scanning the socket directory, or can pass
 `alacritree mcp --socket <path>` explicitly. Set `ipc_socket = false` under
 `[general]` (shared with Alacritty's option of the same name) to disable the
 socket entirely.

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -241,12 +241,13 @@ active.
 
 Input handling is layered:
 
-1. **Built-in app shortcuts** — sidebar toggles, workspace switches, session
-   spawn / cycle, modal Enter/Escape. Hard-coded today.
-2. **Configurable terminal bindings** — parsed from `[[keyboard.bindings]]`
-   in the TOML config. Alacritty's default set is preloaded; your entries are
-   checked first so any default can be overridden or unbound (`action =
+1. **Key bindings** — parsed from `[[keyboard.bindings]]` in the TOML config.
+   Alacritty's default set is preloaded, and so are alacritree's own (sidebar
+   toggles, workspace switches, session spawn / cycle, palette); your entries
+   are checked first so any default can be overridden or unbound (`action =
    "None"`).
+2. **Modal Enter/Escape** — consumed by whichever dialog is open. These are
+   not bindings and cannot be rebound.
 3. **Egui text events** — preferred for printable input because they handle
    dead keys and IME correctly. Control bytes (`Ctrl-<letter>`), CSI sequences
    for arrows / function keys, and `ESC + key` for `Alt+<key>` are derived
@@ -354,8 +355,11 @@ being rendered — by a filter, or by deleting a session or worktree. It now
 climbs or slides instead, under `sidebar_focus = "preserve"`. There is no
 setting that restores the old drop-to-first-row behavior.
 
-Everything Alacritty's TOML accepts for palette, cursor, scrolling, window
-padding, shell, env, and bindings is parsed by the same `Raw*` structs.
+Alacritty's palette, cursor, scrolling, window padding, shell, env, and binding
+tables are read by the same `Raw*` structs, so those parts of an existing
+`alacritty.toml` carry over. The structs cover the fields alacritree acts on
+rather than Alacritty's full schema — see `config.rs` for what a given table
+actually accepts.
 
 ### Shell launch profiles
 
@@ -438,8 +442,9 @@ Tools:
 the editor tab is closed. Because the built-in editor writes every change
 immediately, MCP clients see the same auto-saved contents as the editor.
 
-Under the hood this mirrors Alacritty's IPC design (unix only): the app
-listens on `$XDG_RUNTIME_DIR/alacritree/alacritree-<pid>.sock` and advertises
+Under the hood this mirrors Alacritty's IPC design, on every platform: the app
+listens on a unix socket at `$XDG_RUNTIME_DIR/alacritree/alacritree-<pid>.sock`,
+or on Windows a named pipe at `\\.\pipe\alacritree-<pid>.sock`, and advertises
 the path to child PTYs via `ALACRITREE_SOCKET` — so an agent running *inside*
 an Alacritree session automatically targets the instance hosting it. Other
 clients fall back to scanning the socket directory, or can pass

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -320,9 +320,61 @@ vsync              = true   # restart required — wait for the display's refres
                             # before showing a finished frame (default true).
                             # false presents each frame as soon as it is drawn,
                             # trading tearing for lower keystroke-to-screen delay
+confirm_session_close = "never"  # when the sidebar × asks before killing a PTY:
+                                 # "never" (default) | "busy" | "always"
+last_session_close = "respawn"   # closing the on-screen workspace's last
+                                 # session: "respawn" (default) starts a fresh
+                                 # one, "navigate" moves to another workspace
+pr_status          = false  # poll `gh` for each branch's open PR, which drives
+                            # the PR row icons and $pr below (default false)
+delta_path         = "delta"     # explicit delta binary for the diff pane;
+                                 # unset discovers it on PATH
+worktree_name      = "$name ${pr: }"  # template for worktree row labels:
+                            # $name, $branch, $path, $pr (as #123, needs
+                            # pr_status), and ${var:fallback}. Unset keeps the
+                            # plain worktree name
+project_name       = "$name"     # same for project rows ($name, $path). A
+                                 # manual rename always wins over the template
+
+[ui.font]                   # chrome only — sidebars and modals, not the grid
+family = "Inter"            # unset derives from [font]
+size   = 12.0               # points, same unit as [font] size
+
+[ui.session_display]        # startup defaults; key bindings toggle both at runtime
+sidebar_always = false      # keep a sidebar session row even with one session
+tabs_always    = false      # keep a tab-strip segment even with one session
+
+[ui.focus_outline]          # off by default, which keeps the current look
+sidebar   = false           # outline the projects sidebar when it has focus
+terminal  = false           # outline the terminal when it has focus
+color     = "#6a9fb5"       # unset falls back to the theme accent
+thickness = 1.0             # logical pixels, not scaled by ui_scale
+
+[ui.path_style]             # per-site path abbreviation, all "full" by default
+diff_title = "full"         # "full" | "fish" (a/b/c) | "zed" (leading dirs cut)
+git_rows   = "full"
+git_header = "full"
+
+[ui.path_style.filename]    # emphasis for the last path segment
+color  = "#d8d8d8"
+bold   = true
+italic = false
+
+[ui.path_style.parent]      # emphasis for the leading directories
+color  = "#8a8a8a"
 
 [ui.icons]                  # sidebar glyph overrides (e.g. Nerd Font icons)
 search = "⌕"                # glyph prefixing the sidebar search prompt
+worktree_main = "●"         # the project's main checkout
+worktree = "○"
+session = "▪"
+home = "⌂"
+project_expanded = "▾"
+project_collapsed = "▸"
+pr_open = "⬤"               # the four PR glyphs need pr_status = true; they
+pr_draft = "◯"              # differ by colour, so overriding one shape is
+pr_merged = "⬤"             # usually not what you want
+pr_closed = "⬤"
 
 [ui.drop]                   # what dragging files onto the window does
 enabled       = true        # master switch; false ignores every drop
@@ -345,6 +397,18 @@ worktree_dir = "~/dev/worktrees"   # base dir for new worktrees (default ~/.alac
 [[workspace.overrides]]            # optional per-project override
 project = "~/Git/github/alacritree"
 worktree_dir = "D:/wt"
+
+[wsl]                       # how the app talks to distros, not presentation
+resident_helper = true      # keep one helper process per distro for foreground
+                            # probes, batched git queries, and tool discovery
+                            # (default true). false restores one-shot wsl.exe
+                            # spawns; WSL sessions then always report "no TUI",
+                            # so FocusLeft/FocusRight always move panel focus
+automount_root = "/mnt"     # distro-side mount point for Windows drives,
+                            # mirroring wsl.conf's [automount] root. Only
+                            # applies to paths alacritree translates itself;
+                            # `wsl.exe --cd` uses the distro's real mount table
+                            # either way. Supersedes the older [ui.wsl] key
 
 [window]
 opacity = 0.92   # restart required — transparency is a ViewportBuilder flag

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,7 +2,13 @@
 
 This document gives an overview over Alacritty's features beyond its terminal
 emulation capabilities. To get a list with supported control sequences take a
-look at [Alacritty's escape sequence support](./escape_support.md).
+look at [Alacritty's escape sequence support](https://github.com/alacritty/alacritty/blob/master/docs/escape_support.md).
+
+> **Scope:** this is upstream Alacritty's document, kept for reference. It
+> describes the winit/OpenGL binary, not the egui shell Alacritree ships.
+> Vi mode, search mode, and hints are among the features Alacritree does not
+> implement — see [`keyboard-shortcuts.md`](./keyboard-shortcuts.md) for what
+> it actually supports.
 
 ## Vi Mode
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -27,7 +27,8 @@ These only fire while a modal is open and never reach the terminal grid.
 These are parsed from `[[keyboard.bindings]]` and matched against egui key
 events before the terminal sees them. The default set is preloaded, and your
 TOML entries are checked first — so any default can be rebound, or freed for
-the shell with `action = "None"`.
+the shell with `action = "ReceiveChar"`. Use `action = "None"` when the key
+should be consumed without running an action or reaching the shell.
 
 The alacritree-specific defaults are ordinary bindings like the rest. Nothing
 below is hard-coded.
@@ -311,7 +312,7 @@ deep-merged, so alacritree-specific overrides can live in `alacritree.toml`
 without touching the alacritty config.
 
 ```toml
-# Example: bind Ctrl+Shift+T to open a new session, and unbind Cmd+M on macOS.
+# Example: bind Ctrl+Shift+T to open a new session, and disable Cmd+M on macOS.
 [[keyboard.bindings]]
 key = "T"
 mods = "Control|Shift"

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -2,43 +2,35 @@
 
 Alacritree has two layers of shortcuts:
 
-1. **Built-in app shortcuts** — hard-coded, not configurable. They drive
-   alacritree-specific UI (sidebars, workspaces, session list, quit dialog).
-2. **Configurable terminal bindings** — parsed from your
-   `[[keyboard.bindings]]` tables in `alacritty.toml` / `alacritree.toml`, with
-   a set of defaults that mirror alacritty.
-
-When both layers would match the same key, the built-in shortcut wins.
+1. **Key bindings** — parsed from your `[[keyboard.bindings]]` tables in
+   `alacritty.toml` / `alacritree.toml`. Alacritty's defaults are preloaded,
+   and so are alacritree's own (sidebars, workspaces, sessions, palette).
+   Everything in this layer is rebindable.
+2. **Modal keys** — `Enter` and `Escape` while a dialog is open. The modal
+   consumes them directly; they are not bindings and cannot be rebound.
 
 ---
 
-## Built-in app shortcuts
-
-These cannot be rebound today.
+## Modal keys
 
 | Shortcut             | Action                                                |
 | -------------------- | ----------------------------------------------------- |
-| `Ctrl+B`             | Toggle the left (projects/worktrees) sidebar          |
-| `Ctrl+G`             | Toggle the right (git status) sidebar                 |
-| `Ctrl+T`             | Open a new shell session in the current workspace     |
-| `Ctrl+Tab`           | Cycle to the next session in the current workspace    |
-| `Ctrl+Shift+Tab`     | Cycle to the previous session                         |
-| `Alt+Right`          | Switch to the next workspace (home / worktrees)       |
-| `Alt+Left`           | Switch to the previous workspace                      |
-| `Ctrl+Q`             | Open the quit confirmation dialog                     |
 | `Enter`              | Confirm a modal (quit, delete worktree, create branch)|
 | `Escape`             | Cancel a modal                                        |
 
-Modal-specific keys (`Enter`/`Escape`) only fire while a modal is open and never
-reach the terminal grid.
+These only fire while a modal is open and never reach the terminal grid.
 
 ---
 
-## Configurable terminal bindings
+## Key bindings
 
 These are parsed from `[[keyboard.bindings]]` and matched against egui key
-events before the terminal sees them. Alacritty's own default set is preloaded,
-and your TOML entries are checked first — so your config overrides any default.
+events before the terminal sees them. The default set is preloaded, and your
+TOML entries are checked first — so any default can be rebound, or freed for
+the shell with `action = "None"`.
+
+The alacritree-specific defaults are ordinary bindings like the rest. Nothing
+below is hard-coded.
 
 ### Defaults on every platform
 
@@ -46,6 +38,15 @@ and your TOML entries are checked first — so your config overrides any default
 | -------------------- | ----------------------------------------------------- |
 | `Ctrl+Shift+V`       | Paste from the clipboard                              |
 | `Ctrl+Shift+C`       | Copy the current selection                            |
+| `Ctrl+B`             | Toggle the left (projects/worktrees) sidebar          |
+| `Ctrl+G`             | Toggle the right (git status) sidebar                 |
+| `Ctrl+T`             | Open a new shell session in the current workspace     |
+| `Ctrl+Tab`           | Cycle to the next session in the current workspace    |
+| `Ctrl+Shift+Tab`     | Cycle to the previous session                         |
+| `Alt+Right`          | Switch to the next workspace (home / worktrees)       |
+| `Alt+Left`           | Switch to the previous workspace                      |
+| `Ctrl+Shift+O`       | Add a project to the sidebar                          |
+| `Ctrl+Q`             | Open the quit confirmation dialog                     |
 | `Ctrl+Backtick`      | Toggle the workspace's persistent scratchpad tab      |
 | `Shift+Insert`       | Paste from the primary (X11) selection                |
 | `Ctrl+0`             | Reset font size                                       |
@@ -58,6 +59,7 @@ and your TOML entries are checked first — so your config overrides any default
 | `Shift+Tab`          | Send `CSI Z` (reverse tab — readline/vim)             |
 | `Alt+Shift+Tab`      | Send `ESC` + `CSI Z`                                  |
 | `Ctrl+Shift+B`       | Toggle keyboard focus between terminal and sidebar    |
+| `Ctrl+Shift+G`       | Move focus to the git status sidebar                  |
 | `Ctrl+Shift+W`       | Close the cursored session (sidebar) or the current shell |
 | `Home` / `End`       | Sidebar focused: cursor to the first / last row       |
 | `PageUp` / `PageDown`| Sidebar focused: jump to the previous / next project  |
@@ -213,14 +215,32 @@ caret there; bind them elsewhere if you want the caret back.
 - `Minimize`
 - `Quit` — open the quit confirmation dialog.
 
+### Sidebars and workspaces
+
+- `ToggleLeftSidebar` — show or hide the projects/worktrees sidebar.
+  Default: `Ctrl+B`.
+- `ToggleRightSidebar` — show or hide the git status sidebar. Default: `Ctrl+G`.
+- `SelectNextWorkspace` / `SelectPreviousWorkspace` — move between the home tab
+  and the worktrees. Defaults: `Alt+Right` / `Alt+Left`.
+- `AddProject` — open the picker that adds a project to the sidebar.
+  Default: `Ctrl+Shift+O`.
+- `SetBaseBranch` — open the base-branch picker for the sidebar-cursored
+  worktree, or the current one when the terminal has focus. No default key.
+- `ToggleSessionRows` / `ToggleSessionTabs` — flip the runtime
+  `session_display.sidebar_always` / `session_display.tabs_always` values, which
+  control whether a lone session still gets its own sidebar row or tab segment.
+  No default keys.
+
 ### Focus navigation
 
 - `ToggleSidebarFocus` — flip keyboard focus between the terminal and the
   projects sidebar. Focusing a hidden sidebar shows it; returning focus
   hides it again unless you toggled it open yourself.
-- `FocusProjectsSidebar` / `FocusTerminal` — the same moves as explicit
-  directional actions (no default keys) for users who prefer distinct
-  bindings.
+- `FocusProjectsSidebar` / `FocusGitSidebar` / `FocusTerminal` — move focus to
+  one specific panel. `FocusGitSidebar` defaults to `Ctrl+Shift+G`; the other
+  two have no default key.
+- `FocusLeft` / `FocusRight` — directional focus moves between panels. A TUI
+  that wants the keys itself still receives them. No default keys.
 
 While the sidebar has focus: `Up`/`Down` move between rows, `Right`/`Left`
 expand/collapse a project (`Left` on a worktree jumps to its project),


### PR DESCRIPTION
Corrects documentation that no longer matches the code. Each claim below was checked against `master` and independently re-verified.

**Bindings are no longer hard-coded.** `README.md`, `docs/alacritree.md` and `docs/keyboard-shortcuts.md` all described sidebar toggles, workspace switches, session spawn/cycle and quit as "hard-coded" app shortcuts that "cannot be rebound today". They are ordinary defaults in `default_bindings()` (`alacritree/src/bindings.rs:404-476`), parseable from `[[keyboard.bindings]]`, and nothing in `app.rs` special-cases those keys. Only modal `Enter`/`Escape` are still consumed directly.

**Precedence was documented backwards.** `keyboard-shortcuts.md` said "when both layers would match the same key, the built-in shortcut wins". User entries suppress same-trigger defaults before defaults are appended.

**Eleven undocumented actions.** The TOML parser accepts `ToggleLeftSidebar`, `ToggleRightSidebar`, `AddProject`, `SelectNextWorkspace`, `SelectPreviousWorkspace`, `SetBaseBranch`, `ToggleSessionRows`, `ToggleSessionTabs`, `FocusGitSidebar`, `FocusLeft`, `FocusRight` — none appeared in "Supported actions". Added, with their default keys where they have one.

**IPC is not unix-only.** `docs/alacritree.md` said so; Windows gets a named pipe at `\.\pipe\alacritree-<pid>.sock`.

**Config claim was too broad.** "Everything Alacritty's TOML accepts … is parsed by the same `Raw*` structs" — the structs cover the fields alacritree acts on, not Alacritty's full schema.

**`docs/features.md`** is upstream Alacritty's document and describes vi mode, search and hints as working, which `keyboard-shortcuts.md` lists as unsupported. Added a scope note and repointed its dead `./escape_support.md` link upstream.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update:** second commit adds the config options that were missing from the reference entirely — `confirm_session_close`, `last_session_close`, `pr_status`, `delta_path`, the `worktree_name`/`project_name` templates, `[ui.font]`, `[ui.session_display]`, `[ui.focus_outline]`, `[ui.path_style]`, the remaining `[ui.icons]` glyphs, and the whole `[wsl]` table.
