### PR TITLE
feat(paste): paste a path when the clipboard has no text [3]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,21 @@ jobs:
 
       - name: Check
         run: cargo check -p alacritree --locked
+
+  # Clipboard file/image fallbacks and WSL path handling are primarily
+  # Windows-facing. Compile and run their pure tests before those cfg branches
+  # reach a release tag.
+  alacritree-windows:
+    runs-on: windows-2022
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rust toolchain
+        run: rustup show
+
+      - name: Check
+        run: cargo check -p alacritree --all-targets --locked
+
+      - name: Test
+        run: cargo test -p alacritree --locked

--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -47,7 +47,7 @@ ab_glyph = "0.2"
 # Font faces reach egui as mappings, not buffers.  Same version fontdb already
 # links, so no duplicate build.
 memmap2 = "0.9"
-arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+arboard = { version = "3", default-features = false, features = ["wayland-data-control", "image-data"] }
 # Rasterizes COLR/CBDT/sbix/SVG emoji, which egui's outline-only glyph pipeline
 # cannot draw.  ttf-parser could cover COLRv0 with no new dependency, but the
 # COLRv1 gradient painting that Noto Color Emoji needs is not worth hand-rolling.

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -12,6 +12,7 @@ use serde_json::{Value, json};
 
 use crate::bindings::{self, BindingAction, KeyBinding, NamedAction};
 use crate::clipboard::{self, Target};
+use crate::clipboard_image;
 use crate::colors::rgb_to_color32;
 use crate::command_palette::{self, CommandPalette, PaletteAction, PaletteItem};
 use crate::config::{
@@ -2187,28 +2188,10 @@ impl AlacritreeApp {
                 }
             },
             BindingAction::Named(NamedAction::Paste) => {
-                if let (Some(text), Some(idx)) =
-                    (clipboard::read(Target::Clipboard), self.active_session_index())
-                {
-                    let id = self.sessions[idx].id;
-                    if let Some(editor) = self.sessions[idx].scratchpad.as_mut() {
-                        editor.insert_at_cursor(ctx, id, &text);
-                    } else {
-                        paste::paste(&self.sessions[idx], &text, true);
-                    }
-                }
+                self.paste_from_clipboard(ctx, Target::Clipboard);
             },
             BindingAction::Named(NamedAction::PasteSelection) => {
-                if let (Some(text), Some(idx)) =
-                    (clipboard::read(Target::Primary), self.active_session_index())
-                {
-                    let id = self.sessions[idx].id;
-                    if let Some(editor) = self.sessions[idx].scratchpad.as_mut() {
-                        editor.insert_at_cursor(ctx, id, &text);
-                    } else {
-                        paste::paste(&self.sessions[idx], &text, true);
-                    }
-                }
+                self.paste_from_clipboard(ctx, Target::Primary);
             },
             BindingAction::Named(NamedAction::Copy) => {
                 if let Some(idx) = self.active_session_index() {
@@ -2480,6 +2463,79 @@ impl AlacritreeApp {
             },
             BindingAction::Unsupported(name) => {
                 log::debug!("unsupported keyboard binding action: {name}");
+            },
+        }
+    }
+
+    /// The target is resolved before the clipboard so a paste with nowhere to
+    /// go opens nothing.  Only the regular clipboard carries files and images:
+    /// PRIMARY is a text selection, so its probes are skipped outright.
+    fn paste_from_clipboard(&mut self, ctx: &Context, target: Target) {
+        let Some(idx) = self.active_session_index() else {
+            return;
+        };
+        let extras = target == Target::Clipboard;
+        let payload = clipboard::resolve(
+            &self.config.ui.paste,
+            || clipboard::read_text(target),
+            || if extras { clipboard::read_files() } else { clipboard::Probe::Absent },
+            || if extras { clipboard::read_image() } else { clipboard::Probe::Absent },
+        );
+
+        let paths = match payload {
+            clipboard::Payload::Text(text) => {
+                self.insert_paste(ctx, idx, &text);
+                return;
+            },
+            clipboard::Payload::Paths(paths) => paths,
+            clipboard::Payload::Image(image) => match self.store_clipboard_image(&image) {
+                Some(path) => vec![path],
+                None => return,
+            },
+            clipboard::Payload::Nothing => return,
+        };
+
+        let session = &self.sessions[idx];
+        let scratchpad = session.scratchpad.is_some();
+        let text = file_drop::paste_payload(
+            &paths,
+            scratchpad,
+            session.wsl_distro(),
+            &self.config.ui.drop.spelling,
+        );
+        // An empty payload means every path was filtered out; pasting it would
+        // send a bare space to the shell.
+        if !text.is_empty() {
+            self.insert_paste(ctx, idx, &text);
+        }
+    }
+
+    fn insert_paste(&mut self, ctx: &Context, idx: usize, text: &str) {
+        let id = self.sessions[idx].id;
+        if let Some(editor) = self.sessions[idx].scratchpad.as_mut() {
+            editor.insert_at_cursor(ctx, id, text);
+        } else {
+            paste::paste(&self.sessions[idx], text, true);
+        }
+    }
+
+    /// The clipboard bitmap as a file something else can open, or `None` with
+    /// the reason logged.
+    fn store_clipboard_image(&self, image: &arboard::ImageData<'_>) -> Option<PathBuf> {
+        let png = match clipboard_image::encode_png(image) {
+            Ok(png) => png,
+            Err(e) => {
+                log::warn!("cannot encode the clipboard image: {e}");
+                return None;
+            },
+        };
+        let cfg = &self.config.ui.paste;
+        let (dir, owned) = cfg.image_target();
+        match clipboard_image::store(&dir, &png, owned.then_some(cfg.image_keep)) {
+            Ok(path) => Some(path),
+            Err(e) => {
+                log::warn!("cannot write the clipboard image to {}: {e}", dir.display());
+                None
             },
         }
     }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1391,8 +1391,11 @@ impl AlacritreeApp {
                     return;
                 };
                 let session = &self.sessions[idx];
-                let text =
-                    file_drop::shell_payload(&paths, session.wsl_distro(), &self.config.ui.drop);
+                let text = file_drop::shell_payload(
+                    &paths,
+                    session.wsl_distro(),
+                    &self.config.ui.drop.spelling,
+                );
                 if !text.is_empty() {
                     paste::paste(session, &text, true);
                 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -2503,8 +2503,9 @@ impl AlacritreeApp {
             session.wsl_distro(),
             &self.config.ui.drop.spelling,
         );
-        // An empty payload means every path was filtered out; pasting it would
-        // send a bare space to the shell.
+        // Every path was filtered out.  A paste of nothing still clears the
+        // selection and snaps the view to the bottom, or drops the scratchpad's
+        // selection — side effects with nothing to show for them.
         if !text.is_empty() {
             self.insert_paste(ctx, idx, &text);
         }

--- a/alacritree/src/clipboard.rs
+++ b/alacritree/src/clipboard.rs
@@ -4,8 +4,12 @@
 //! target).  arboard's Linux backend supports both via the `SetExtLinux` /
 //! `GetExtLinux` extensions when built with `wayland-data-control`.
 
+use std::path::PathBuf;
+
 #[cfg(target_os = "linux")]
 use arboard::{GetExtLinux, LinuxClipboardKind, SetExtLinux};
+
+use crate::config::PasteConfig;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Target {
@@ -40,26 +44,208 @@ pub fn write(target: Target, text: &str) {
 }
 
 pub fn read(target: Target) -> Option<String> {
-    let mut clip = match arboard::Clipboard::new() {
-        Ok(c) => c,
+    match read_text(target) {
+        Probe::Found(text) => Some(text),
+        Probe::Absent | Probe::Failed => None,
+    }
+}
+
+/// What one clipboard probe found.  The distinction is load-bearing: `Absent`
+/// means "try the next format", while `Failed` must stop the paste, because a
+/// read that failed says nothing about whether the format was there.
+pub enum Probe<T> {
+    Found(T),
+    Absent,
+    Failed,
+}
+
+pub enum Payload {
+    Text(String),
+    Paths(Vec<PathBuf>),
+    Image(arboard::ImageData<'static>),
+    Nothing,
+}
+
+fn classify<T>(result: Result<T, arboard::Error>) -> Probe<T> {
+    match result {
+        Ok(value) => Probe::Found(value),
+        Err(arboard::Error::ContentNotAvailable) => Probe::Absent,
+        Err(e) => {
+            log::warn!("clipboard read failed: {e}");
+            Probe::Failed
+        },
+    }
+}
+
+fn with_clipboard<T>(
+    read: impl FnOnce(&mut arboard::Clipboard) -> Result<T, arboard::Error>,
+) -> Probe<T> {
+    match arboard::Clipboard::new() {
+        Ok(mut clip) => classify(read(&mut clip)),
         Err(e) => {
             log::warn!("clipboard unavailable: {e}");
-            return None;
+            Probe::Failed
         },
-    };
-    let res = match target {
+    }
+}
+
+pub fn read_text(target: Target) -> Probe<String> {
+    with_clipboard(|clip| match target {
         Target::Clipboard => clip.get_text(),
         #[cfg(target_os = "linux")]
         Target::Primary => clip.get().clipboard(LinuxClipboardKind::Primary).text(),
         #[cfg(not(target_os = "linux"))]
         Target::Primary => clip.get_text(),
-    };
-    match res {
-        Ok(s) => Some(s),
-        Err(arboard::Error::ContentNotAvailable) => None,
-        Err(e) => {
-            log::warn!("clipboard read ({:?}) failed: {e}", target);
-            None
-        },
+    })
+}
+
+/// Paths a file manager put on the clipboard.  Explorer's Cut advertises a move
+/// effect alongside the same list; reading the paths neither performs nor
+/// completes that move, so Cut and Copy paste identically.
+pub fn read_files() -> Probe<Vec<PathBuf>> {
+    with_clipboard(|clip| clip.get().file_list())
+}
+
+pub fn read_image() -> Probe<arboard::ImageData<'static>> {
+    with_clipboard(|clip| clip.get_image())
+}
+
+/// Resolve the clipboard in priority order, probing lazily: text outright, then
+/// copied paths, then a bitmap.  Each probe runs only once every earlier one
+/// came back absent, so an ordinary text paste never opens the image formats,
+/// and a format the config switched off is never probed at all.
+pub fn resolve(
+    cfg: &PasteConfig,
+    text: impl FnOnce() -> Probe<String>,
+    files: impl FnOnce() -> Probe<Vec<PathBuf>>,
+    image: impl FnOnce() -> Probe<arboard::ImageData<'static>>,
+) -> Payload {
+    match text() {
+        Probe::Found(text) => return Payload::Text(text),
+        Probe::Failed => return Payload::Nothing,
+        Probe::Absent => {},
+    }
+    if cfg.files {
+        match files() {
+            // An empty list is a degenerate CF_HDROP, not a decision to paste
+            // nothing; fall through rather than stopping here.
+            Probe::Found(paths) if !paths.is_empty() => return Payload::Paths(paths),
+            Probe::Failed => return Payload::Nothing,
+            _ => {},
+        }
+    }
+    if cfg.image {
+        match image() {
+            Probe::Found(image) => return Payload::Image(image),
+            Probe::Failed => return Payload::Nothing,
+            Probe::Absent => {},
+        }
+    }
+    Payload::Nothing
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::config::PasteConfig;
+
+    fn absent<T>() -> Probe<T> {
+        Probe::Absent
+    }
+
+    fn image() -> Probe<arboard::ImageData<'static>> {
+        Probe::Found(arboard::ImageData {
+            width: 1,
+            height: 1,
+            bytes: Cow::Owned(vec![0, 0, 0, 255]),
+        })
+    }
+
+    fn paths() -> Probe<Vec<PathBuf>> {
+        Probe::Found(vec![PathBuf::from("/a/one.png")])
+    }
+
+    #[test]
+    fn text_wins_over_every_other_format() {
+        let payload =
+            resolve(&PasteConfig::default(), || Probe::Found("hello".to_string()), paths, image);
+        assert!(matches!(payload, Payload::Text(t) if t == "hello"));
+    }
+
+    #[test]
+    fn a_file_list_is_used_when_there_is_no_text() {
+        let payload = resolve(&PasteConfig::default(), absent, paths, image);
+        assert!(matches!(payload, Payload::Paths(p) if p.len() == 1));
+    }
+
+    #[test]
+    fn a_bitmap_is_used_when_there_is_neither_text_nor_a_file_list() {
+        let payload = resolve(&PasteConfig::default(), absent, absent, image);
+        assert!(matches!(payload, Payload::Image(_)));
+    }
+
+    /// A failed read is not evidence of an absent format.  Pasting the image
+    /// because the *text* read failed would paste something the user never
+    /// asked for.
+    #[test]
+    fn a_failed_read_aborts_instead_of_falling_through() {
+        let payload = resolve(&PasteConfig::default(), || Probe::Failed, paths, image);
+        assert!(matches!(payload, Payload::Nothing));
+
+        let payload = resolve(&PasteConfig::default(), absent, || Probe::Failed, image);
+        assert!(matches!(payload, Payload::Nothing));
+    }
+
+    /// A degenerate CF_HDROP would otherwise stop resolution while pasting
+    /// nothing at all.
+    #[test]
+    fn an_empty_file_list_falls_through_to_the_bitmap() {
+        let payload = resolve(&PasteConfig::default(), absent, || Probe::Found(Vec::new()), image);
+        assert!(matches!(payload, Payload::Image(_)));
+    }
+
+    #[test]
+    fn each_fallback_can_be_switched_off_on_its_own() {
+        let no_files = PasteConfig { files: false, ..PasteConfig::default() };
+        let payload = resolve(&no_files, absent, paths, image);
+        assert!(matches!(payload, Payload::Image(_)), "files off must skip to the bitmap");
+
+        let no_image = PasteConfig { image: false, ..PasteConfig::default() };
+        let payload = resolve(&no_image, absent, absent, image);
+        assert!(matches!(payload, Payload::Nothing));
+    }
+
+    /// Both off is today's behavior exactly: no text, no paste.
+    #[test]
+    fn both_fallbacks_off_restores_the_original_behavior() {
+        let off = PasteConfig { files: false, image: false, ..PasteConfig::default() };
+        let payload = resolve(&off, absent, paths, image);
+        assert!(matches!(payload, Payload::Nothing));
+    }
+
+    /// A disabled format is never probed, so a clipboard whose image read would
+    /// hang or warn costs nothing when the user turned it off.
+    #[test]
+    fn a_disabled_format_is_never_probed() {
+        let off = PasteConfig { files: false, image: false, ..PasteConfig::default() };
+        resolve(
+            &off,
+            absent,
+            || panic!("file list probed while disabled"),
+            || panic!("image probed while disabled"),
+        );
+    }
+
+    #[test]
+    fn an_absent_format_maps_to_absent_and_other_errors_to_failed() {
+        assert!(matches!(
+            classify(Err::<(), _>(arboard::Error::ContentNotAvailable)),
+            Probe::Absent
+        ));
+        assert!(matches!(classify(Err::<(), _>(arboard::Error::ClipboardOccupied)), Probe::Failed));
+        assert!(matches!(classify(Ok::<_, arboard::Error>(7)), Probe::Found(7)));
     }
 }

--- a/alacritree/src/clipboard.rs
+++ b/alacritree/src/clipboard.rs
@@ -66,31 +66,38 @@ pub enum Payload {
     Nothing,
 }
 
-fn classify<T>(result: Result<T, arboard::Error>) -> Probe<T> {
+/// Turns an arboard result into a `Probe`, logging `label` (what was being
+/// read, e.g. "clipboard text") against any error that isn't a plain absence.
+fn classify<T>(label: &str, result: Result<T, arboard::Error>) -> Probe<T> {
     match result {
         Ok(value) => Probe::Found(value),
         Err(arboard::Error::ContentNotAvailable) => Probe::Absent,
         Err(e) => {
-            log::warn!("clipboard read failed: {e}");
+            log::warn!("clipboard read ({label}) failed: {e}");
             Probe::Failed
         },
     }
 }
 
 fn with_clipboard<T>(
+    label: &str,
     read: impl FnOnce(&mut arboard::Clipboard) -> Result<T, arboard::Error>,
 ) -> Probe<T> {
     match arboard::Clipboard::new() {
-        Ok(mut clip) => classify(read(&mut clip)),
+        Ok(mut clip) => classify(label, read(&mut clip)),
         Err(e) => {
-            log::warn!("clipboard unavailable: {e}");
+            log::warn!("clipboard unavailable ({label}): {e}");
             Probe::Failed
         },
     }
 }
 
 pub fn read_text(target: Target) -> Probe<String> {
-    with_clipboard(|clip| match target {
+    let label = match target {
+        Target::Clipboard => "clipboard text",
+        Target::Primary => "primary selection",
+    };
+    with_clipboard(label, |clip| match target {
         Target::Clipboard => clip.get_text(),
         #[cfg(target_os = "linux")]
         Target::Primary => clip.get().clipboard(LinuxClipboardKind::Primary).text(),
@@ -103,11 +110,11 @@ pub fn read_text(target: Target) -> Probe<String> {
 /// effect alongside the same list; reading the paths neither performs nor
 /// completes that move, so Cut and Copy paste identically.
 pub fn read_files() -> Probe<Vec<PathBuf>> {
-    with_clipboard(|clip| clip.get().file_list())
+    with_clipboard("file list", |clip| clip.get().file_list())
 }
 
 pub fn read_image() -> Probe<arboard::ImageData<'static>> {
-    with_clipboard(|clip| clip.get_image())
+    with_clipboard("image", |clip| clip.get_image())
 }
 
 /// Resolve the clipboard in priority order, probing lazily: text outright, then
@@ -242,10 +249,13 @@ mod tests {
     #[test]
     fn an_absent_format_maps_to_absent_and_other_errors_to_failed() {
         assert!(matches!(
-            classify(Err::<(), _>(arboard::Error::ContentNotAvailable)),
+            classify("test", Err::<(), _>(arboard::Error::ContentNotAvailable)),
             Probe::Absent
         ));
-        assert!(matches!(classify(Err::<(), _>(arboard::Error::ClipboardOccupied)), Probe::Failed));
-        assert!(matches!(classify(Ok::<_, arboard::Error>(7)), Probe::Found(7)));
+        assert!(matches!(
+            classify("test", Err::<(), _>(arboard::Error::ClipboardOccupied)),
+            Probe::Failed
+        ));
+        assert!(matches!(classify("test", Ok::<_, arboard::Error>(7)), Probe::Found(7)));
     }
 }

--- a/alacritree/src/clipboard_image.rs
+++ b/alacritree/src/clipboard_image.rs
@@ -4,8 +4,8 @@
 //! and it returns a path.  That is what keeps it testable without a window.
 
 use std::fmt;
-use std::fs::{self, File};
-use std::io;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
@@ -74,7 +74,11 @@ pub fn file_name(png: &[u8]) -> String {
 /// for a directory alacritree owns — a directory the user named may hold files
 /// alacritree never wrote, and a filename pattern is no proof of ownership.
 pub fn store(dir: &Path, png: &[u8], cap: Option<usize>) -> io::Result<PathBuf> {
-    fs::create_dir_all(dir)?;
+    if cap.is_some() {
+        prepare_managed_dir(dir)?;
+    } else {
+        fs::create_dir_all(dir)?;
+    }
     let path = dir.join(file_name(png));
     if !reusable(&path, png.len() as u64) {
         write_atomically(dir, &path, png)?;
@@ -85,50 +89,131 @@ pub fn store(dir: &Path, png: &[u8], cap: Option<usize>) -> io::Result<PathBuf> 
     Ok(path)
 }
 
+/// Create and revalidate the directory that alacritree owns.  The open uses
+/// `O_NOFOLLOW` on Unix so a fixed-name symlink in a shared cache parent cannot
+/// redirect screenshots into an attacker-controlled location.
+#[cfg(unix)]
+fn prepare_managed_dir(dir: &Path) -> io::Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+
+    fs::DirBuilder::new().recursive(true).mode(0o700).create(dir)?;
+    let handle = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(dir)?;
+    let metadata = handle.metadata()?;
+    // SAFETY: `geteuid` takes no arguments and has no safety preconditions.
+    let uid = unsafe { libc::geteuid() };
+    if !metadata.is_dir() || metadata.uid() != uid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("{} is not a directory owned by the current user", dir.display()),
+        ));
+    }
+    handle.set_permissions(fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn prepare_managed_dir(dir: &Path) -> io::Result<()> {
+    fs::create_dir_all(dir)
+}
+
+/// Create a new image or staging file without ever exposing its contents to
+/// other local users.  `create_new` also refuses pre-planted symlinks.
+fn create_private_file(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        let file = options.open(path)?;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+        Ok(file)
+    }
+    #[cfg(not(unix))]
+    options.open(path)
+}
+
+/// Open an existing generated image without following a replacement symlink,
+/// and repair files produced by an older permissive version.
+fn open_existing_private(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        options.custom_flags(libc::O_NOFOLLOW);
+        let file = options.open(path)?;
+        if !file.metadata()?.is_file() {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "not a regular file"));
+        }
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+        Ok(file)
+    }
+    #[cfg(not(unix))]
+    {
+        let file = options.open(path)?;
+        if !file.metadata()?.is_file() {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "not a regular file"));
+        }
+        Ok(file)
+    }
+}
+
 /// Whether the destination already holds these bytes *and* its timestamp was
 /// refreshed.  Content addressing makes equal names strong evidence of equal
 /// bytes, not proof, so the length is checked too; a link, a directory or a
 /// timestamp that would not move all mean "write it again".
 fn reusable(path: &Path, len: u64) -> bool {
-    let Ok(meta) = fs::symlink_metadata(path) else {
+    let Ok(file) = open_existing_private(path) else {
         return false;
     };
-    if !meta.is_file() || meta.len() != len {
+    let Ok(metadata) = file.metadata() else {
+        return false;
+    };
+    if metadata.len() != len {
         return false;
     }
-    File::options().write(true).open(path).and_then(|f| f.set_modified(SystemTime::now())).is_ok()
+    file.set_modified(SystemTime::now()).is_ok()
 }
 
 /// Write through a uniquely named temporary in the same directory so a reader
 /// never opens a half-written PNG.
 fn write_atomically(dir: &Path, path: &Path, png: &[u8]) -> io::Result<()> {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let tmp = dir.join(format!(
-        "{}.{}.{}.tmp",
-        path.file_name().unwrap_or_default().to_string_lossy(),
-        std::process::id(),
-        COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
-    match place(&tmp, path, png) {
-        Ok(()) => Ok(()),
-        Err(e) => {
+    loop {
+        let tmp = dir.join(format!(
+            "{}.{}.{}.tmp",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let mut file = match create_private_file(&tmp) {
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            result => result?,
+        };
+        if let Err(e) = file.write_all(png) {
+            drop(file);
             let _ = fs::remove_file(&tmp);
-            // Another instance writing the same content first is a success, not
-            // a collision — but only once the destination is checked the same
-            // way the reuse path checks it, since a racing writer can equally
-            // have left something of the wrong length behind.
-            if reusable(path, png.len() as u64) { Ok(()) } else { Err(e) }
-        },
-    }
-}
+            return Err(e);
+        }
+        drop(file);
 
-/// Every fallible step between creating `tmp` and it landing at `path`, kept
-/// in one function so `write_atomically` has a single place to clean up on
-/// any of their failures.
-fn place(tmp: &Path, path: &Path, png: &[u8]) -> io::Result<()> {
-    fs::write(tmp, png)?;
-    clear_directory_at(path);
-    fs::rename(tmp, path)
+        clear_directory_at(path);
+        match fs::rename(&tmp, path) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                let _ = fs::remove_file(&tmp);
+                // Another instance writing the same content first is a success,
+                // but only once the destination is checked like the reuse path.
+                if reusable(path, png.len() as u64) {
+                    return Ok(());
+                }
+                return Err(e);
+            },
+        }
+    }
 }
 
 /// `rename` replaces a file but cannot replace a directory, so a directory
@@ -177,7 +262,7 @@ fn apply_cap(dir: &Path, keep: usize, in_use: &Path) {
         if path == in_use {
             continue;
         }
-        match fs::metadata(&path).and_then(|meta| meta.modified()) {
+        match open_existing_private(&path).and_then(|file| file.metadata()?.modified()) {
             Ok(when) => generated.push((when, path)),
             // Unranked means unswept: a file whose age cannot be read is never
             // the one chosen for deletion.
@@ -281,6 +366,114 @@ mod tests {
 
         assert_eq!(path.file_name().unwrap(), file_name(b"png bytes").as_str());
         assert_eq!(fs::read(&path).unwrap(), b"png bytes");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_storage_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("clipboard");
+        let path = store(&dir, b"private", Some(20)).unwrap();
+
+        assert_eq!(fs::metadata(&dir).unwrap().permissions().mode() & 0o777, 0o700);
+        assert_eq!(fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_existing_managed_directory_is_tightened() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("clipboard");
+        fs::create_dir(&dir).unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o777)).unwrap();
+
+        store(&dir, b"private", Some(20)).unwrap();
+
+        assert_eq!(fs::metadata(dir).unwrap().permissions().mode() & 0o777, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_managed_directory_symlink_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("clipboard");
+        fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        assert!(store(&link, b"private", Some(20)).is_err());
+        assert_eq!(fs::read_dir(target).unwrap().count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_configured_directory_symlink_is_preserved() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("configured");
+        fs::create_dir(&target).unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let path = store(&link, b"private", None).unwrap();
+
+        assert_eq!(fs::metadata(&target).unwrap().permissions().mode() & 0o777, 0o755);
+        assert_eq!(fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_reused_image_is_tightened() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(file_name(b"private"));
+        fs::write(&path, b"private").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o666)).unwrap();
+
+        store(tmp.path(), b"private", None).unwrap();
+
+        assert_eq!(fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_cap_tightens_retained_images() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let retained = store(tmp.path(), b"retained", None).unwrap();
+        fs::set_permissions(&retained, fs::Permissions::from_mode(0o666)).unwrap();
+
+        store(tmp.path(), b"new", Some(2)).unwrap();
+
+        assert_eq!(fs::metadata(retained).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_destination_symlink_is_replaced_not_followed() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("outside");
+        let path = tmp.path().join(file_name(b"private"));
+        fs::write(&target, b"untouched").unwrap();
+        symlink(&target, &path).unwrap();
+
+        let stored = store(tmp.path(), b"private", None).unwrap();
+
+        assert_eq!(stored, path);
+        assert_eq!(fs::read(target).unwrap(), b"untouched");
+        assert_eq!(fs::read(stored).unwrap(), b"private");
     }
 
     #[test]

--- a/alacritree/src/clipboard_image.rs
+++ b/alacritree/src/clipboard_image.rs
@@ -1,0 +1,122 @@
+//! Turning a clipboard bitmap into a file on disk that something else can open.
+//!
+//! Nothing here knows about the clipboard or about sessions: it takes pixels,
+//! and it returns a path.  That is what keeps it testable without a window.
+
+use std::fmt;
+
+use arboard::ImageData;
+
+/// A clipboard owner can advertise any dimensions it likes, and encoding runs
+/// on the UI thread during a keystroke.  64 MP is far past any screenshot.
+const MAX_PIXELS: usize = 64 * 1024 * 1024;
+
+#[derive(Debug)]
+pub enum EncodeError {
+    TooLarge { pixels: usize },
+    Inconsistent { expected: usize, actual: usize },
+    Encoding(png::EncodingError),
+}
+
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooLarge { pixels } => {
+                write!(f, "{pixels} pixels is past the {MAX_PIXELS} limit")
+            },
+            Self::Inconsistent { expected, actual } => {
+                write!(f, "dimensions imply {expected} bytes, got {actual}")
+            },
+            Self::Encoding(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+/// `Compression::Fast` buys latency on a keypress at the cost of a larger file
+/// that nothing keeps.
+pub fn encode_png(image: &ImageData<'_>) -> Result<Vec<u8>, EncodeError> {
+    let pixels = image.width.saturating_mul(image.height);
+    if pixels > MAX_PIXELS {
+        return Err(EncodeError::TooLarge { pixels });
+    }
+    let expected = pixels.saturating_mul(4);
+    if image.bytes.len() != expected {
+        return Err(EncodeError::Inconsistent { expected, actual: image.bytes.len() });
+    }
+
+    let mut out = Vec::new();
+    let mut encoder = png::Encoder::new(&mut out, image.width as u32, image.height as u32);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    encoder.set_compression(png::Compression::Fast);
+    let mut writer = encoder.write_header().map_err(EncodeError::Encoding)?;
+    writer.write_image_data(&image.bytes).map_err(EncodeError::Encoding)?;
+    writer.finish().map_err(EncodeError::Encoding)?;
+    Ok(out)
+}
+
+/// The file a set of PNG bytes belongs in.  Content-addressed, so pasting the
+/// same screenshot twice reuses one file, and the full 64-bit digest rather
+/// than the scratchpad's truncated one, since here a collision would paste the
+/// wrong image instead of merely colliding a label.
+pub fn file_name(png: &[u8]) -> String {
+    format!("clipboard-{:016x}.png", crate::digest::stable_digest(png))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::*;
+
+    fn image(width: usize, height: usize) -> ImageData<'static> {
+        let bytes = (0..width * height * 4).map(|i| (i % 251) as u8).collect::<Vec<_>>();
+        ImageData { width, height, bytes: Cow::Owned(bytes) }
+    }
+
+    #[test]
+    fn an_image_survives_the_encode_round_trip() {
+        let source = image(7, 5);
+        let png = encode_png(&source).expect("encodes");
+
+        let decoder = png::Decoder::new(std::io::Cursor::new(&png));
+        let mut reader = decoder.read_info().expect("valid png");
+        let mut out = vec![0; reader.output_buffer_size()];
+        let info = reader.next_frame(&mut out).expect("one frame");
+
+        assert_eq!((info.width, info.height), (7, 5));
+        assert_eq!(info.color_type, png::ColorType::Rgba);
+        assert_eq!(&out[..info.buffer_size()], source.bytes.as_ref());
+    }
+
+    /// A clipboard owner can advertise any dimensions it likes.  Reject before
+    /// allocating, because this runs on the UI thread during a keystroke.
+    #[test]
+    fn an_absurdly_large_image_is_rejected_before_allocating() {
+        let huge = ImageData { width: usize::MAX, height: 4, bytes: Cow::Owned(Vec::new()) };
+        assert!(matches!(encode_png(&huge), Err(EncodeError::TooLarge { .. })));
+    }
+
+    #[test]
+    fn a_byte_count_disagreeing_with_the_dimensions_is_rejected() {
+        let lying = ImageData { width: 4, height: 4, bytes: Cow::Owned(vec![0; 8]) };
+        assert!(matches!(encode_png(&lying), Err(EncodeError::Inconsistent { .. })));
+    }
+
+    /// The name is the deduplication key: equal bytes must land on one file.
+    #[test]
+    fn the_file_name_is_a_function_of_the_content() {
+        assert_eq!(file_name(b"same"), file_name(b"same"));
+        assert_ne!(file_name(b"one"), file_name(b"two"));
+    }
+
+    #[test]
+    fn the_file_name_is_sixteen_hex_digits_and_inert() {
+        let name = file_name(b"payload");
+        let hex =
+            name.strip_prefix("clipboard-").and_then(|r| r.strip_suffix(".png")).expect("shape");
+        assert_eq!(hex.len(), 16);
+        assert!(hex.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert!(crate::file_drop::is_terminal_safe(&name));
+    }
+}

--- a/alacritree/src/clipboard_image.rs
+++ b/alacritree/src/clipboard_image.rs
@@ -4,6 +4,11 @@
 //! and it returns a path.  That is what keeps it testable without a window.
 
 use std::fmt;
+use std::fs::{self, File};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
 
 use arboard::ImageData;
 
@@ -63,11 +68,158 @@ pub fn file_name(png: &[u8]) -> String {
     format!("clipboard-{:016x}.png", crate::digest::stable_digest(png))
 }
 
+/// Write `png` into `dir` under its content-addressed name and return the path.
+///
+/// `cap` bounds the directory to that many generated files and is `Some` only
+/// for a directory alacritree owns — a directory the user named may hold files
+/// alacritree never wrote, and a filename pattern is no proof of ownership.
+pub fn store(dir: &Path, png: &[u8], cap: Option<usize>) -> io::Result<PathBuf> {
+    fs::create_dir_all(dir)?;
+    let path = dir.join(file_name(png));
+    if !reusable(&path, png.len() as u64) {
+        write_atomically(dir, &path, png)?;
+    }
+    if let Some(keep) = cap {
+        apply_cap(dir, keep, &path);
+    }
+    Ok(path)
+}
+
+/// Whether the destination already holds these bytes *and* its timestamp was
+/// refreshed.  Content addressing makes equal names strong evidence of equal
+/// bytes, not proof, so the length is checked too; a link, a directory or a
+/// timestamp that would not move all mean "write it again".
+fn reusable(path: &Path, len: u64) -> bool {
+    let Ok(meta) = fs::symlink_metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() || meta.len() != len {
+        return false;
+    }
+    File::options().write(true).open(path).and_then(|f| f.set_modified(SystemTime::now())).is_ok()
+}
+
+/// Write through a uniquely named temporary in the same directory so a reader
+/// never opens a half-written PNG.
+fn write_atomically(dir: &Path, path: &Path, png: &[u8]) -> io::Result<()> {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let tmp = dir.join(format!(
+        "{}.{}.{}.tmp",
+        path.file_name().unwrap_or_default().to_string_lossy(),
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    match place(&tmp, path, png) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_file(&tmp);
+            // Another instance writing the same content first is a success, not
+            // a collision — but only once the destination is checked the same
+            // way the reuse path checks it, since a racing writer can equally
+            // have left something of the wrong length behind.
+            if reusable(path, png.len() as u64) { Ok(()) } else { Err(e) }
+        },
+    }
+}
+
+/// Every fallible step between creating `tmp` and it landing at `path`, kept
+/// in one function so `write_atomically` has a single place to clean up on
+/// any of their failures.
+fn place(tmp: &Path, path: &Path, png: &[u8]) -> io::Result<()> {
+    fs::write(tmp, png)?;
+    clear_directory_at(path);
+    fs::rename(tmp, path)
+}
+
+/// `rename` replaces a file but cannot replace a directory, so a directory
+/// squatting on a generated name would fail that image's every paste forever.
+///
+/// Only an empty one is removed.  A populated directory is something this
+/// module did not create, and losing its contents to a name collision is a
+/// far worse outcome than the paste failing.
+fn clear_directory_at(path: &Path) {
+    let Ok(meta) = fs::symlink_metadata(path) else {
+        return;
+    };
+    if !meta.is_dir() {
+        return;
+    }
+    if let Err(e) = fs::remove_dir(path) {
+        log::debug!("could not clear the directory at {}: {e}", path.display());
+    }
+}
+
+/// Keep the `keep` newest generated files, `in_use` always among them.
+///
+/// Failures are logged and skipped: a file that outlives its turn costs a few
+/// hundred kilobytes, while giving up here would abandon the rest of the sweep.
+fn apply_cap(dir: &Path, keep: usize, in_use: &Path) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            log::debug!("cannot sweep {}: {e}", dir.display());
+            return;
+        },
+    };
+    let mut generated: Vec<(SystemTime, PathBuf)> = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                log::debug!("skipping an unreadable entry in {}: {e}", dir.display());
+                continue;
+            },
+        };
+        if !is_generated_name(&entry.file_name().to_string_lossy()) {
+            continue;
+        }
+        let path = entry.path();
+        if path == in_use {
+            continue;
+        }
+        match fs::metadata(&path).and_then(|meta| meta.modified()) {
+            Ok(when) => generated.push((when, path)),
+            // Unranked means unswept: a file whose age cannot be read is never
+            // the one chosen for deletion.
+            Err(e) => log::debug!("cannot age {}: {e}", path.display()),
+        }
+    }
+
+    let others = keep.saturating_sub(1);
+    if generated.len() <= others {
+        return;
+    }
+    generated.sort_by_key(|(when, _)| std::cmp::Reverse(*when));
+    for (_, stale) in generated.into_iter().skip(others) {
+        if let Err(e) = fs::remove_file(&stale) {
+            log::debug!("could not remove {}: {e}", stale.display());
+        }
+    }
+}
+
+/// Only names this module produces are ever deleted.  The `.tmp` suffix a
+/// half-finished write leaves behind fails this too, so a crashed process
+/// cannot have its leftovers swept by a later one — a trade for never
+/// deleting something a user put here.
+fn is_generated_name(name: &str) -> bool {
+    name.strip_prefix("clipboard-")
+        .and_then(|rest| rest.strip_suffix(".png"))
+        .is_some_and(|hex| hex.len() == 16 && hex.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
+    use std::fs;
+    use std::path::Path;
+    use std::time::{Duration, SystemTime};
 
     use super::*;
+
+    fn age(path: &Path, seconds: u64) {
+        let when = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000 - seconds);
+        fs::File::options().write(true).open(path).unwrap().set_modified(when).unwrap();
+    }
 
     fn image(width: usize, height: usize) -> ImageData<'static> {
         let bytes = (0..width * height * 4).map(|i| (i % 251) as u8).collect::<Vec<_>>();
@@ -118,5 +270,163 @@ mod tests {
         assert_eq!(hex.len(), 16);
         assert!(hex.bytes().all(|b| b.is_ascii_hexdigit()));
         assert!(crate::file_drop::is_terminal_safe(&name));
+    }
+
+    #[test]
+    fn store_creates_a_missing_directory_and_writes_the_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("nested").join("clipboard");
+
+        let path = store(&dir, b"png bytes", None).unwrap();
+
+        assert_eq!(path.file_name().unwrap(), file_name(b"png bytes").as_str());
+        assert_eq!(fs::read(&path).unwrap(), b"png bytes");
+    }
+
+    #[test]
+    fn storing_the_same_bytes_twice_leaves_one_file() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let first = store(tmp.path(), b"same", None).unwrap();
+        let second = store(tmp.path(), b"same", None).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(fs::read_dir(tmp.path()).unwrap().count(), 1);
+    }
+
+    /// Reuse must refresh the timestamp.  Without it a re-pasted old screenshot
+    /// keeps its original mtime, and the next sweep — by which time it is no
+    /// longer the returned path and so no longer exempt — deletes a file the
+    /// user pasted moments ago.
+    ///
+    /// The sweep therefore has to run against a *later* store, not the reusing
+    /// one: while `old` is the returned path `apply_cap` skips it outright, so
+    /// a cap applied there would pass with or without the refresh.
+    #[test]
+    fn reuse_refreshes_the_timestamp_so_a_later_sweep_spares_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = store(tmp.path(), b"old", None).unwrap();
+        age(&old, 9_000);
+        for i in 0..3u8 {
+            age(&store(tmp.path(), &[i], None).unwrap(), 1_000);
+        }
+
+        store(tmp.path(), b"old", None).unwrap();
+        store(tmp.path(), b"newest", Some(2)).unwrap();
+
+        assert!(old.is_file(), "a reused file was swept as though it were stale");
+    }
+
+    #[test]
+    fn the_cap_keeps_the_newest_and_always_the_returned_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        for i in 0..6u8 {
+            let path = store(tmp.path(), &[i], None).unwrap();
+            age(&path, u64::from(6 - i) * 100);
+        }
+
+        let path = store(tmp.path(), b"newest", Some(3)).unwrap();
+
+        assert!(path.is_file());
+        assert_eq!(fs::read_dir(tmp.path()).unwrap().count(), 3);
+    }
+
+    /// A cap smaller than one still has to return a usable path.
+    #[test]
+    fn a_cap_of_one_keeps_only_the_returned_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        for i in 0..4u8 {
+            store(tmp.path(), &[i], None).unwrap();
+        }
+
+        let path = store(tmp.path(), b"last", Some(1)).unwrap();
+
+        assert!(path.is_file());
+        assert_eq!(fs::read_dir(tmp.path()).unwrap().count(), 1);
+    }
+
+    /// The guarantee that makes pointing image_dir at a pictures folder safe.
+    #[test]
+    fn no_cap_deletes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        for i in 0..5u8 {
+            store(tmp.path(), &[i], None).unwrap();
+        }
+
+        store(tmp.path(), b"another", None).unwrap();
+
+        assert_eq!(fs::read_dir(tmp.path()).unwrap().count(), 6);
+    }
+
+    #[test]
+    fn the_cap_never_touches_a_file_it_did_not_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let keeper = tmp.path().join("holiday.png");
+        fs::write(&keeper, b"a real photo").unwrap();
+        age(&keeper, 9_000);
+        for i in 0..4u8 {
+            store(tmp.path(), &[i], None).unwrap();
+        }
+
+        store(tmp.path(), b"newest", Some(1)).unwrap();
+
+        assert!(keeper.is_file(), "a foreign file was deleted");
+    }
+
+    #[test]
+    fn a_destination_of_the_wrong_length_is_rewritten() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(file_name(b"payload"));
+        fs::write(&path, b"truncated").unwrap();
+
+        let stored = store(tmp.path(), b"payload", None).unwrap();
+
+        assert_eq!(stored, path);
+        assert_eq!(fs::read(&path).unwrap(), b"payload");
+    }
+
+    #[test]
+    fn a_destination_that_is_a_directory_is_replaced() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join(file_name(b"payload"))).unwrap();
+
+        let stored = store(tmp.path(), b"payload", None).unwrap();
+
+        assert_eq!(fs::read(&stored).unwrap(), b"payload");
+    }
+
+    /// The limit of that replacement.  Whatever a populated directory on this
+    /// name is, it is not something this module wrote, and its contents are
+    /// worth more than one paste succeeding.
+    #[test]
+    fn a_populated_directory_on_the_name_is_left_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let squatter = tmp.path().join(file_name(b"payload"));
+        fs::create_dir(&squatter).unwrap();
+        fs::write(squatter.join("precious.txt"), b"keep me").unwrap();
+
+        assert!(store(tmp.path(), b"payload", None).is_err());
+        assert_eq!(fs::read(squatter.join("precious.txt")).unwrap(), b"keep me");
+
+        let leftovers: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "{leftovers:?}");
+    }
+
+    #[test]
+    fn no_temp_file_survives_a_completed_store() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        store(tmp.path(), b"payload", None).unwrap();
+
+        let leftovers: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "{leftovers:?}");
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -326,6 +326,23 @@ fn parse_quoting(raw: Option<&str>) -> Quoting {
     }
 }
 
+/// How a path is written for the shell that receives it.  Separate from
+/// `DropConfig` because a paste spells paths too, and must not be handed flags
+/// about whether drops are accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PathSpelling {
+    pub quote: Quoting,
+    /// Rewrite a Windows path to its distro-side spelling before it reaches a
+    /// WSL shell, where a `C:\` path resolves to nothing.
+    pub wsl_translate: bool,
+}
+
+impl Default for PathSpelling {
+    fn default() -> Self {
+        Self { quote: Quoting::Auto, wsl_translate: true }
+    }
+}
+
 /// `[ui.drop]`: what dragging files onto the window does.  Every target
 /// accepts drops by default; each one can be switched off on its own, and
 /// `enabled` turns the lot off.
@@ -336,10 +353,7 @@ pub struct DropConfig {
     pub terminal: bool,
     pub sidebar: bool,
     pub scratchpad: bool,
-    pub quote: Quoting,
-    /// Rewrite a Windows path to its distro-side spelling before it reaches a
-    /// WSL shell, where a `C:\` path resolves to nothing.
-    pub wsl_translate: bool,
+    pub spelling: PathSpelling,
     /// Tint the region a drop would land on while files hover.
     pub highlight: bool,
 }
@@ -351,8 +365,7 @@ impl Default for DropConfig {
             terminal: true,
             sidebar: true,
             scratchpad: true,
-            quote: Quoting::Auto,
-            wsl_translate: true,
+            spelling: PathSpelling::default(),
             highlight: true,
         }
     }
@@ -1547,8 +1560,10 @@ impl RawConfig {
                 terminal: self.ui.drop.terminal.unwrap_or(true),
                 sidebar: self.ui.drop.sidebar.unwrap_or(true),
                 scratchpad: self.ui.drop.scratchpad.unwrap_or(true),
-                quote: parse_quoting(self.ui.drop.quote.as_deref()),
-                wsl_translate: self.ui.drop.wsl_translate.unwrap_or(true),
+                spelling: PathSpelling {
+                    quote: parse_quoting(self.ui.drop.quote.as_deref()),
+                    wsl_translate: self.ui.drop.wsl_translate.unwrap_or(true),
+                },
                 highlight: self.ui.drop.highlight.unwrap_or(true),
             },
             paste: PasteConfig {
@@ -2443,8 +2458,7 @@ program = "second"
                 terminal: true,
                 sidebar: true,
                 scratchpad: true,
-                quote: Quoting::Auto,
-                wsl_translate: true,
+                spelling: PathSpelling { quote: Quoting::Auto, wsl_translate: true },
                 highlight: true,
             }
         );
@@ -2469,8 +2483,7 @@ program = "second"
                 terminal: false,
                 sidebar: false,
                 scratchpad: false,
-                quote: Quoting::Posix,
-                wsl_translate: false,
+                spelling: PathSpelling { quote: Quoting::Posix, wsl_translate: false },
                 highlight: false,
             }
         );
@@ -2546,13 +2559,13 @@ program = "second"
             ("windows_always_quoted", Quoting::WindowsAlwaysQuoted),
         ] {
             let ui = ui_from_toml(&format!("[ui.drop]\nquote = \"{raw}\""));
-            assert_eq!(ui.drop.quote, expected, "{raw}");
+            assert_eq!(ui.drop.spelling.quote, expected, "{raw}");
         }
     }
 
     #[test]
     fn an_unknown_quoting_name_falls_back_to_auto() {
         let ui = ui_from_toml("[ui.drop]\nquote = \"shell\"");
-        assert_eq!(ui.drop.quote, Quoting::Auto);
+        assert_eq!(ui.drop.spelling.quote, Quoting::Auto);
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -407,8 +407,23 @@ impl PasteConfig {
     }
 }
 
-/// Disposable by nature, and reachable from a WSL session through the usual
-/// automount once `shell_payload` translates it.
+/// Disposable by nature.  Unix keeps captures in the user's cache rather than
+/// a shared fixed-name tmp directory; Windows' `%TEMP%` is already per-user and
+/// remains reachable from WSL through the usual automount.
+#[cfg(unix)]
+pub fn default_image_dir() -> PathBuf {
+    let cache_home = xdg::BaseDirectories::with_prefix("alacritree").get_cache_home();
+    // SAFETY: `geteuid` takes no arguments and has no safety preconditions.
+    let uid = unsafe { libc::geteuid() };
+    unix_default_image_dir(cache_home, &std::env::temp_dir(), uid)
+}
+
+#[cfg(unix)]
+fn unix_default_image_dir(cache_home: Option<PathBuf>, temp_dir: &Path, uid: u32) -> PathBuf {
+    cache_home.unwrap_or_else(|| temp_dir.join(format!("alacritree-{uid}")))
+}
+
+#[cfg(not(unix))]
 pub fn default_image_dir() -> PathBuf {
     std::env::temp_dir().join("alacritree").join("clipboard")
 }
@@ -2499,6 +2514,22 @@ program = "second"
         let (dir, owned) = ui.paste.image_target();
         assert_eq!(dir, default_image_dir());
         assert!(owned, "the default directory is alacritree's own");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_unix_image_default_prefers_the_user_cache() {
+        let cache = PathBuf::from("/home/example/.cache/alacritree");
+        assert_eq!(unix_default_image_dir(Some(cache.clone()), Path::new("/tmp"), 1234), cache);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_unix_image_fallback_is_namespaced_by_user() {
+        assert_eq!(
+            unix_default_image_dir(None, Path::new("/tmp"), 1234),
+            PathBuf::from("/tmp/alacritree-1234")
+        );
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -358,6 +358,48 @@ impl Default for DropConfig {
     }
 }
 
+/// `[ui.paste]`: what Paste does when the clipboard holds no text.  Both
+/// fallbacks are independent — one can be off without affecting the other, and
+/// both off leaves Paste exactly as it was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PasteConfig {
+    /// Paste the paths of files and folders copied in a file manager.
+    pub files: bool,
+    /// Write a clipboard bitmap to a PNG and paste its path.
+    pub image: bool,
+    /// Where those PNGs go.  `None` is the app-owned default, the only
+    /// directory the count cap is ever applied to.
+    pub image_dir: Option<PathBuf>,
+    /// How many generated PNGs the owned directory keeps.  At least one: the
+    /// file a paste just handed to the shell has to still be there when the
+    /// shell opens it, so zero is not a reachable state.
+    pub image_keep: usize,
+}
+
+impl Default for PasteConfig {
+    fn default() -> Self {
+        Self { files: true, image: true, image_dir: None, image_keep: 20 }
+    }
+}
+
+impl PasteConfig {
+    /// The directory to write into, and whether alacritree owns it.  Ownership
+    /// is what licenses deleting anything: a directory the user named may hold
+    /// files alacritree never wrote.
+    pub fn image_target(&self) -> (PathBuf, bool) {
+        match &self.image_dir {
+            Some(dir) => (dir.clone(), false),
+            None => (default_image_dir(), true),
+        }
+    }
+}
+
+/// Disposable by nature, and reachable from a WSL session through the usual
+/// automount once `shell_payload` translates it.
+pub fn default_image_dir() -> PathBuf {
+    std::env::temp_dir().join("alacritree").join("clipboard")
+}
+
 /// How the sidebar scroll areas draw their scrollbar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ScrollbarStyle {
@@ -619,6 +661,8 @@ pub struct UiTheme {
     pub path_style: PathStyleConfig,
     /// `[ui.drop]`: what a file dragged onto the window does.
     pub drop: DropConfig,
+    /// `[ui.paste]`: what Paste does with a clipboard that holds no text.
+    pub paste: PasteConfig,
 }
 
 impl Default for UiTheme {
@@ -644,6 +688,7 @@ impl Default for UiTheme {
             project_name: None,
             path_style: PathStyleConfig::default(),
             drop: DropConfig::default(),
+            paste: PasteConfig::default(),
         }
     }
 }
@@ -1277,6 +1322,15 @@ struct RawUiDrop {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
+struct RawUiPaste {
+    files: Option<bool>,
+    image: Option<bool>,
+    image_dir: Option<String>,
+    image_keep: Option<usize>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 struct RawUi {
     sidebar_background: Option<RgbStr>,
     sidebar_foreground: Option<RgbStr>,
@@ -1316,6 +1370,7 @@ struct RawUi {
     path_style: RawPathStyle,
     /// What a file dragged onto the window does.  Default: every target on.
     drop: RawUiDrop,
+    paste: RawUiPaste,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1495,6 +1550,17 @@ impl RawConfig {
                 quote: parse_quoting(self.ui.drop.quote.as_deref()),
                 wsl_translate: self.ui.drop.wsl_translate.unwrap_or(true),
                 highlight: self.ui.drop.highlight.unwrap_or(true),
+            },
+            paste: PasteConfig {
+                files: self.ui.paste.files.unwrap_or(true),
+                image: self.ui.paste.image.unwrap_or(true),
+                image_dir: self
+                    .ui
+                    .paste
+                    .image_dir
+                    .as_deref()
+                    .and_then(|raw| parse_config_path(raw, "ui.paste.image_dir")),
+                image_keep: self.ui.paste.image_keep.unwrap_or(20).max(1),
             },
         };
 
@@ -2408,6 +2474,65 @@ program = "second"
                 highlight: false,
             }
         );
+    }
+
+    #[test]
+    fn paste_options_default_to_on_with_the_owned_image_dir() {
+        let ui = ui_from_toml("");
+        assert_eq!(
+            ui.paste,
+            PasteConfig { files: true, image: true, image_dir: None, image_keep: 20 }
+        );
+        let (dir, owned) = ui.paste.image_target();
+        assert_eq!(dir, default_image_dir());
+        assert!(owned, "the default directory is alacritree's own");
+    }
+
+    #[test]
+    fn paste_options_parse_from_the_ui_paste_table() {
+        let home = home::home_dir().expect("a home directory");
+        let ui = ui_from_toml(
+            "[ui.paste]\n\
+             files = false\n\
+             image = false\n\
+             image_dir = \"~/shots\"\n\
+             image_keep = 5\n",
+        );
+        assert_eq!(
+            ui.paste,
+            PasteConfig {
+                files: false,
+                image: false,
+                image_dir: Some(home.join("shots")),
+                image_keep: 5,
+            }
+        );
+    }
+
+    /// A directory the user chose may hold files alacritree never wrote, so it is
+    /// never swept — that is what makes pointing this at a pictures folder safe.
+    #[test]
+    fn a_configured_image_dir_is_not_owned() {
+        let ui = ui_from_toml("[ui.paste]\nimage_dir = \"~/shots\"");
+        let (dir, owned) = ui.paste.image_target();
+        assert_eq!(dir, home::home_dir().expect("a home directory").join("shots"));
+        assert!(!owned);
+    }
+
+    /// A relative path is rejected by `parse_config_path`, which must leave the
+    /// owned default in place rather than writing somewhere arbitrary.
+    #[test]
+    fn an_unusable_image_dir_falls_back_to_the_owned_default() {
+        let ui = ui_from_toml("[ui.paste]\nimage_dir = \"relative/path\"");
+        assert_eq!(ui.paste.image_dir, None);
+        assert!(ui.paste.image_target().1);
+    }
+
+    /// The cap can never reach zero: a paste hands the shell a path, and the shell
+    /// opens it after the sweep has already run.
+    #[test]
+    fn an_image_keep_of_zero_is_raised_to_one() {
+        assert_eq!(ui_from_toml("[ui.paste]\nimage_keep = 0").paste.image_keep, 1);
     }
 
     #[test]

--- a/alacritree/src/digest.rs
+++ b/alacritree/src/digest.rs
@@ -1,0 +1,32 @@
+//! A stable content digest, shared by anything that names a file after what is
+//! in it.
+
+/// FNV-1a is small, deterministic across Rust versions, and sufficient here:
+/// the digest disambiguates file names rather than protecting an adversarial
+/// namespace.
+pub fn stable_digest(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The digest names files on disk, so a change to it silently orphans
+    /// every existing scratchpad. Pin the constant.
+    #[test]
+    fn the_digest_is_stable_across_builds() {
+        assert_eq!(stable_digest(b""), 0xcbf29ce484222325);
+        assert_eq!(stable_digest(b"a"), 0xaf63dc4c8601ec8c);
+    }
+
+    #[test]
+    fn different_inputs_give_different_digests() {
+        assert_ne!(stable_digest(b"one"), stable_digest(b"two"));
+    }
+}

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -8,7 +8,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::config::{DropConfig, ShellQuoting};
+use crate::config::{DropConfig, PathSpelling, ShellQuoting};
 use crate::wsl;
 
 /// Which region a drop landed on.
@@ -89,10 +89,10 @@ pub fn is_terminal_safe(path: &str) -> bool {
 ///
 /// `distro` names the WSL distro the receiving session runs in, `None` for a
 /// native session.  Paths that would act as terminal input are left out.
-pub fn shell_payload(paths: &[PathBuf], distro: Option<&str>, cfg: &DropConfig) -> String {
+pub fn shell_payload(paths: &[PathBuf], distro: Option<&str>, spelling: &PathSpelling) -> String {
     let mut out = String::new();
     for path in paths {
-        let (word, quoting) = shell_word(path, distro, cfg);
+        let (word, quoting) = shell_word(path, distro, spelling);
         if !is_terminal_safe(&word) {
             log::warn!("dropped path {word:?} carries terminal control characters, skipping it");
             continue;
@@ -107,14 +107,18 @@ pub fn shell_payload(paths: &[PathBuf], distro: Option<&str>, cfg: &DropConfig) 
 /// spelling implies.  A path rewritten for a distro is a POSIX shell word even
 /// when the configured mode says otherwise — `windows` quoting fed to `bash` is
 /// broken by construction.
-fn shell_word(path: &Path, distro: Option<&str>, cfg: &DropConfig) -> (String, ShellQuoting) {
-    if let Some(distro) = distro.filter(|_| cfg.wsl_translate) {
+fn shell_word(
+    path: &Path,
+    distro: Option<&str>,
+    spelling: &PathSpelling,
+) -> (String, ShellQuoting) {
+    if let Some(distro) = distro.filter(|_| spelling.wsl_translate) {
         if let Some(linux) = distro_path(path, distro) {
             return (linux, ShellQuoting::Posix);
         }
         log::debug!("no path in {distro} for {}, pasting it as-is", path.display());
     }
-    (path.to_string_lossy().into_owned(), cfg.quote.resolve(distro.is_some()))
+    (path.to_string_lossy().into_owned(), spelling.quote.resolve(distro.is_some()))
 }
 
 /// The path as `distro` resolves it, or `None` when it has no spelling there.
@@ -244,7 +248,7 @@ mod tests {
     use egui::{Rect, pos2};
 
     use super::*;
-    use crate::config::{DropConfig, Quoting};
+    use crate::config::{DropConfig, PathSpelling, Quoting};
 
     fn regions() -> Regions {
         Regions {
@@ -337,24 +341,31 @@ mod tests {
 
     #[test]
     fn a_shell_payload_joins_paths_with_spaces_and_ends_with_one() {
-        let cfg =
-            DropConfig { quote: Quoting::None, wsl_translate: false, ..DropConfig::default() };
+        let spelling = PathSpelling { quote: Quoting::None, wsl_translate: false };
         let paths = [PathBuf::from("/a/one.png"), PathBuf::from("/a/two.png")];
-        assert_eq!(shell_payload(&paths, None, &cfg), "/a/one.png /a/two.png ");
+        assert_eq!(shell_payload(&paths, None, &spelling), "/a/one.png /a/two.png ");
     }
 
     #[test]
     fn a_shell_payload_quotes_a_path_containing_spaces() {
-        let cfg =
-            DropConfig { quote: Quoting::Posix, wsl_translate: false, ..DropConfig::default() };
+        let spelling = PathSpelling { quote: Quoting::Posix, wsl_translate: false };
         let paths = [PathBuf::from("/a/my pic.png")];
-        assert_eq!(shell_payload(&paths, None, &cfg), "'/a/my pic.png' ");
+        assert_eq!(shell_payload(&paths, None, &spelling), "'/a/my pic.png' ");
+    }
+
+    /// A paste spells paths without ever holding a drop config, which is the
+    /// whole reason the spelling is its own type.
+    #[test]
+    fn a_path_is_spelled_without_a_drop_config() {
+        let spelling = PathSpelling { quote: Quoting::Posix, wsl_translate: false };
+        let paths = [PathBuf::from("/a/my pic.png")];
+        assert_eq!(shell_payload(&paths, None, &spelling), "'/a/my pic.png' ");
     }
 
     #[test]
     fn an_empty_drop_produces_no_payload() {
-        let cfg = DropConfig::default();
-        assert_eq!(shell_payload(&[], None, &cfg), "");
+        let spelling = PathSpelling::default();
+        assert_eq!(shell_payload(&[], None, &spelling), "");
     }
 
     /// `\x0f` is readline's `operate-and-get-next`, which accepts the line as
@@ -381,32 +392,30 @@ mod tests {
     /// still fires.
     #[test]
     fn an_unsafe_path_is_dropped_and_the_rest_of_the_batch_survives() {
-        let cfg =
-            DropConfig { quote: Quoting::None, wsl_translate: false, ..DropConfig::default() };
+        let spelling = PathSpelling { quote: Quoting::None, wsl_translate: false };
         let paths = [
             PathBuf::from("/a/one.png"),
             PathBuf::from("/a/evil\nrm -rf ~"),
             PathBuf::from("/a/two.png"),
         ];
-        assert_eq!(shell_payload(&paths, None, &cfg), "/a/one.png /a/two.png ");
+        assert_eq!(shell_payload(&paths, None, &spelling), "/a/one.png /a/two.png ");
     }
 
     /// The guard in `app.rs` skips the paste on an empty payload, so a batch
     /// where nothing survives the filter must produce exactly that.
     #[test]
     fn a_batch_of_only_unsafe_paths_produces_no_payload() {
-        let cfg =
-            DropConfig { quote: Quoting::None, wsl_translate: false, ..DropConfig::default() };
+        let spelling = PathSpelling { quote: Quoting::None, wsl_translate: false };
         let paths = [PathBuf::from("/a/evil\nrm -rf ~"), PathBuf::from("/a/accept\x0frm -rf ~")];
-        assert_eq!(shell_payload(&paths, None, &cfg), "");
+        assert_eq!(shell_payload(&paths, None, &spelling), "");
     }
 
     #[cfg(windows)]
     #[test]
     fn a_drive_path_becomes_a_distro_path_for_a_wsl_shell() {
-        let cfg = DropConfig::default();
+        let spelling = PathSpelling::default();
         let paths = [PathBuf::from(r"C:\pics\a.png")];
-        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "/mnt/c/pics/a.png ");
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &spelling), "/mnt/c/pics/a.png ");
     }
 
     /// Translation forces POSIX rules even under `quote = "windows"`: the
@@ -414,18 +423,17 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn a_translated_path_is_quoted_posix_style_whatever_the_mode_says() {
-        let cfg = DropConfig { quote: Quoting::Windows, ..DropConfig::default() };
+        let spelling = PathSpelling { quote: Quoting::Windows, wsl_translate: true };
         let paths = [PathBuf::from(r"C:\pics\my pic.png")];
-        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "'/mnt/c/pics/my pic.png' ");
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &spelling), "'/mnt/c/pics/my pic.png' ");
     }
 
     #[cfg(windows)]
     #[test]
     fn translation_off_leaves_the_windows_path_alone() {
-        let cfg =
-            DropConfig { wsl_translate: false, quote: Quoting::None, ..DropConfig::default() };
+        let spelling = PathSpelling { wsl_translate: false, quote: Quoting::None };
         let paths = [PathBuf::from(r"C:\pics\a.png")];
-        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "C:\\pics\\a.png ");
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &spelling), "C:\\pics\\a.png ");
     }
 
     /// `auto` follows the receiving shell, not the path: a WSL session gets
@@ -435,10 +443,9 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn an_untranslated_path_for_a_wsl_shell_is_still_quoted_posix_style() {
-        let cfg =
-            DropConfig { wsl_translate: false, quote: Quoting::Auto, ..DropConfig::default() };
+        let spelling = PathSpelling { wsl_translate: false, quote: Quoting::Auto };
         let paths = [PathBuf::from(r"C:\pics\my pic.png")];
-        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), r#""C:\\pics\\my pic.png" "#);
+        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &spelling), r#""C:\\pics\\my pic.png" "#);
     }
 
     /// A plain UNC share has no distro-side spelling.  Pasting the raw path is
@@ -446,18 +453,21 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn an_untranslatable_path_falls_back_to_the_raw_spelling() {
-        let cfg = DropConfig { quote: Quoting::None, ..DropConfig::default() };
+        let spelling = PathSpelling { quote: Quoting::None, wsl_translate: true };
         let paths = [PathBuf::from(r"\\fileserver\share\a.png")];
-        assert_eq!(shell_payload(&paths, Some("Ubuntu"), &cfg), "\\\\fileserver\\share\\a.png ");
+        assert_eq!(
+            shell_payload(&paths, Some("Ubuntu"), &spelling),
+            "\\\\fileserver\\share\\a.png "
+        );
     }
 
     /// The distro is compared the way Windows compares the UNC share name.
     #[cfg(windows)]
     #[test]
     fn a_unc_path_for_this_distro_strips_to_its_linux_form() {
-        let cfg = DropConfig { quote: Quoting::None, ..DropConfig::default() };
+        let spelling = PathSpelling { quote: Quoting::None, wsl_translate: true };
         let paths = [PathBuf::from(r"\\wsl.localhost\Ubuntu\home\lev\a.png")];
-        assert_eq!(shell_payload(&paths, Some("ubuntu"), &cfg), "/home/lev/a.png ");
+        assert_eq!(shell_payload(&paths, Some("ubuntu"), &spelling), "/home/lev/a.png ");
     }
 
     /// `windows_to_linux` throws the distro away (`wsl.rs:141`), so stripping a
@@ -466,10 +476,10 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn a_unc_path_for_another_distro_is_never_stripped() {
-        let cfg = DropConfig { quote: Quoting::None, ..DropConfig::default() };
+        let spelling = PathSpelling { quote: Quoting::None, wsl_translate: true };
         let paths = [PathBuf::from(r"\\wsl.localhost\Ubuntu\home\lev\a.png")];
         assert_eq!(
-            shell_payload(&paths, Some("kali-linux"), &cfg),
+            shell_payload(&paths, Some("kali-linux"), &spelling),
             "\\\\wsl.localhost\\Ubuntu\\home\\lev\\a.png "
         );
     }
@@ -565,10 +575,10 @@ mod tests {
         ];
 
         for quote in [Quoting::None, Quoting::Auto] {
-            let cfg = DropConfig { quote, wsl_translate: false, ..DropConfig::default() };
+            let spelling = PathSpelling { quote, wsl_translate: false };
 
             let on_the_pty =
-                crate::paste::paste_bytes(&shell_payload(&paths, None, &cfg), true, false);
+                crate::paste::paste_bytes(&shell_payload(&paths, None, &spelling), true, false);
 
             assert!(
                 !on_the_pty.contains(&b'\r'),

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -559,6 +559,7 @@ mod tests {
         assert_eq!(text, "/a/one.png");
     }
 
+    #[cfg(windows)]
     #[test]
     fn a_pasted_path_is_translated_for_a_wsl_shell() {
         let paths = [PathBuf::from(r"C:\pics\a.png")];

--- a/alacritree/src/file_drop.rs
+++ b/alacritree/src/file_drop.rs
@@ -174,6 +174,26 @@ pub fn document_payload(
     out
 }
 
+/// The text a pasted path list becomes for the sink that is about to receive
+/// it.
+///
+/// The shell form is a drop's, character for character.  The document form is
+/// deliberately not `document_payload`'s: a drop frames its paths as their own
+/// block, while a paste lands wherever the cursor is and must leave the
+/// surrounding line alone.
+pub fn paste_payload(
+    paths: &[PathBuf],
+    scratchpad: bool,
+    distro: Option<&str>,
+    spelling: &PathSpelling,
+) -> String {
+    if scratchpad {
+        paths.iter().map(|p| p.to_string_lossy()).collect::<Vec<_>>().join("\n")
+    } else {
+        shell_payload(paths, distro, spelling)
+    }
+}
+
 /// The project roots a set of dropped paths names.  A directory is its own
 /// root; a file means the directory holding it, which is what dragging a file
 /// out of a checkout is asking for.  Dragging several files from one folder is
@@ -511,6 +531,61 @@ mod tests {
         let paths = [PathBuf::from("/a/one.png")];
         assert_eq!(document_payload(&paths, None, Some('d')), "/a/one.png\n");
         assert_eq!(document_payload(&paths, Some('c'), None), "\n/a/one.png");
+    }
+
+    /// A pasted path reaches a shell exactly as a dropped one does.
+    #[test]
+    fn a_pasted_path_is_a_shell_word_for_a_terminal() {
+        let spelling = PathSpelling { quote: Quoting::Posix, wsl_translate: false };
+        let paths = [PathBuf::from("/a/my pic.png")];
+        assert_eq!(paste_payload(&paths, false, None, &spelling), "'/a/my pic.png' ");
+    }
+
+    /// A scratchpad is a text document: quoting a path into it would put
+    /// literal quote characters in the user's notes.
+    #[test]
+    fn a_pasted_path_is_bare_for_a_scratchpad() {
+        let spelling = PathSpelling { quote: Quoting::Posix, wsl_translate: false };
+        let paths = [PathBuf::from("/a/my pic.png"), PathBuf::from("/a/two.png")];
+        assert_eq!(paste_payload(&paths, true, None, &spelling), "/a/my pic.png\n/a/two.png");
+    }
+
+    /// Unlike `document_payload`, which frames a drop as its own block, a paste
+    /// lands at the cursor — so it adds no surrounding newline of its own.
+    #[test]
+    fn a_pasted_path_adds_no_newline_of_its_own() {
+        let text =
+            paste_payload(&[PathBuf::from("/a/one.png")], true, None, &PathSpelling::default());
+        assert_eq!(text, "/a/one.png");
+    }
+
+    #[test]
+    fn a_pasted_path_is_translated_for_a_wsl_shell() {
+        let paths = [PathBuf::from(r"C:\pics\a.png")];
+        assert_eq!(
+            paste_payload(&paths, false, Some("Ubuntu"), &PathSpelling::default()),
+            "/mnt/c/pics/a.png "
+        );
+    }
+
+    /// The scratchpad runs on the Windows side whatever the session's shell is,
+    /// so a path pasted into it keeps the spelling that opens it there.
+    #[test]
+    fn a_pasted_path_is_not_translated_for_a_scratchpad() {
+        let paths = [PathBuf::from(r"C:\pics\a.png")];
+        assert_eq!(
+            paste_payload(&paths, true, Some("Ubuntu"), &PathSpelling::default()),
+            r"C:\pics\a.png"
+        );
+    }
+
+    /// The control-character filter is what `shell_payload` is for; routing
+    /// through it is what keeps a pasted path from submitting a command.
+    #[test]
+    fn a_pasted_path_carrying_control_characters_is_filtered_for_a_terminal() {
+        let spelling = PathSpelling { quote: Quoting::None, wsl_translate: false };
+        let paths = [PathBuf::from("/a/evil\nrm -rf ~"), PathBuf::from("/a/ok.png")];
+        assert_eq!(paste_payload(&paths, false, None, &spelling), "/a/ok.png ");
     }
 
     #[test]

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -5,6 +5,7 @@ mod bindings;
 mod builtin_font;
 mod cli;
 mod clipboard;
+mod clipboard_image;
 mod color_glyph;
 mod colors;
 mod command_ext;

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -10,6 +10,7 @@ mod colors;
 mod command_ext;
 mod command_palette;
 mod config;
+mod digest;
 mod doppler;
 mod file_drop;
 mod fonts;

--- a/alacritree/src/scratchpad.rs
+++ b/alacritree/src/scratchpad.rs
@@ -16,6 +16,7 @@ use egui::{
 use serde_json::{Value, json};
 
 use crate::app::WorkspaceKey;
+use crate::digest::stable_digest;
 use crate::state;
 
 // A scratchpad is normally a few notes. Bounding an MCP response keeps an
@@ -227,18 +228,6 @@ fn slug(input: &str) -> String {
         }
     }
     out.trim_matches('-').to_string()
-}
-
-/// FNV-1a is small, deterministic across Rust versions, and sufficient here:
-/// the digest disambiguates human-readable file names rather than protecting
-/// an adversarial namespace.
-fn stable_digest(bytes: &[u8]) -> u64 {
-    let mut hash = 0xcbf29ce484222325_u64;
-    for byte in bytes {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    hash
 }
 
 pub fn read_json(workspace: &WorkspaceKey) -> Result<Value, String> {

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -392,6 +392,23 @@ quote         = "auto"      # "auto" (POSIX inside a distro, otherwise the host
 wsl_translate = true        # rewrite C:\x as /mnt/c/x for a WSL session
 highlight     = true        # tint the region a drop would land on
 
+[ui.paste]                  # what Paste does when the clipboard holds no text
+files       = true          # paste the paths of files and folders copied in a
+                            # file manager, as Windows Terminal does
+image       = true          # write a clipboard bitmap (a Win+Shift+S capture)
+                            # to a PNG and paste its path
+image_dir   = "~/shots"     # where those PNGs go (default: a temp subdirectory).
+                            # A directory you name here is never swept — set it
+                            # and you keep every image and clean up yourself
+image_keep  = 20            # how many PNGs the default directory keeps.
+                            # Minimum 1 — the image a paste just handed to the
+                            # shell always survives the sweep
+
+Text always wins: a clipboard carrying both text and an image pastes the text.
+Only the regular clipboard is checked for files and images — the X11 PRIMARY
+selection is text, so middle-click paste is unchanged. Both options `false`
+restores the original behavior exactly, where a paste with no text does nothing.
+
 [workspace]
 worktree_dir = "~/dev/worktrees"   # base dir for new worktrees (default ~/.alacritree/worktrees)
 

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -404,11 +404,6 @@ image_keep  = 20            # how many PNGs the default directory keeps.
                             # Minimum 1 — the image a paste just handed to the
                             # shell always survives the sweep
 
-Text always wins: a clipboard carrying both text and an image pastes the text.
-Only the regular clipboard is checked for files and images — the X11 PRIMARY
-selection is text, so middle-click paste is unchanged. Both options `false`
-restores the original behavior exactly, where a paste with no text does nothing.
-
 [workspace]
 worktree_dir = "~/dev/worktrees"   # base dir for new worktrees (default ~/.alacritree/worktrees)
 
@@ -431,6 +426,16 @@ automount_root = "/mnt"     # distro-side mount point for Windows drives,
 [window]
 opacity = 0.92   # restart required — transparency is a ViewportBuilder flag
 ```
+
+Text always wins: a clipboard carrying both text and an image pastes the text.
+Only the regular clipboard is checked for files and images — the X11 PRIMARY
+selection is text, so middle-click paste is unchanged. Both options `false`
+restores the original behavior exactly, where a paste with no text does nothing.
+A pasted path is quoted and, inside a WSL session, translated exactly as a
+dropped one — both follow `[ui.drop]`'s `quote` and `wsl_translate`, so those
+keys still apply even with `[ui.drop] enabled = false`. `quote = "posix"` is
+the only mode that makes an arbitrary filename inert; see the comment on
+`[ui.drop] quote` above for why.
 
 The sidebar cursor used to drop to the first row whenever its own row stopped
 being rendered — by a filter, or by deleting a session or worktree. It now

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -397,7 +397,8 @@ files       = true          # paste the paths of files and folders copied in a
                             # file manager, as Windows Terminal does
 image       = true          # write a clipboard bitmap (a Win+Shift+S capture)
                             # to a PNG and paste its path
-image_dir   = "~/shots"     # where those PNGs go (default: a temp subdirectory).
+image_dir   = "~/shots"     # where those PNGs go (default: the per-user cache
+                            # on Unix; %TEMP%/alacritree/clipboard on Windows).
                             # A directory you name here is never swept — set it
                             # and you keep every image and clean up yourself
 image_keep  = 20            # how many PNGs the default directory keeps.
@@ -431,6 +432,9 @@ Text always wins: a clipboard carrying both text and an image pastes the text.
 Only the regular clipboard is checked for files and images — the X11 PRIMARY
 selection is text, so middle-click paste is unchanged. Both options `false`
 restores the original behavior exactly, where a paste with no text does nothing.
+A default Unix image directory is private to its owner (`0700`), and generated
+files are `0600`. A directory named with `image_dir` keeps its existing sharing
+permissions and is never swept, while the generated image files remain `0600`.
 A pasted path is quoted and, inside a WSL session, translated exactly as a
 dropped one — both follow `[ui.drop]`'s `quote` and `wsl_translate`, so those
 keys still apply even with `[ui.drop] enabled = false`. `quote = "posix"` is


### PR DESCRIPTION
On Windows, `Win+Shift+S` puts a screenshot *bitmap* on the clipboard, and Paste did nothing with it. Paste now falls back, when the clipboard holds no text, to inserting a **path** — either the paths of files copied in a file manager, or the bitmap written out as a PNG. A program running in the terminal then sees a path it can open; Claude Code renders it as `[Image #N]`.

Three probes in priority order (text → `CF_HDROP` file list → bitmap), resolved lazily by a pure function. Whatever wins becomes either text (the existing path) or a `Vec<PathBuf>` that goes through the *existing* drop payload machinery — so a pasted path is spelled exactly as a dropped one, WSL translation included. Only the bitmap branch writes anything.

```toml
[ui.paste]
files      = true   # paste the paths of files and folders copied in a file manager
image      = true   # write a clipboard bitmap to a PNG and paste its path
image_dir  = "..."  # where those PNGs go (default: a temp subdirectory)
image_keep = 20     # how many PNGs the default directory keeps; minimum 1
```

Both options `false` restores the previous behavior exactly: a paste with no text does nothing, and neither extra format is ever probed. Only the regular clipboard is checked for files and images — the X11 PRIMARY selection is text, so middle-click paste is unchanged.

### Notes

- **Nothing the user put somewhere is ever deleted.** A directory named in `image_dir` is never swept; the count cap applies only to the app-owned default directory, and only files matching the generated `clipboard-<16 hex>.png` name are candidates. PNGs are content-addressed, so pasting the same capture twice reuses one file.
- **`quote` and `wsl_translate` are shared with `[ui.drop]`** rather than duplicated — a pasted path is spelled as a dropped one. Documented in `docs/alacritree.md`.
- **`arboard`'s `image-data` feature is enabled.** `Cargo.lock` is unchanged: `image` was already in the resolve graph via `eframe`.
- 705 tests passing. The logic deciding *what text a path list becomes* lives in `file_drop::paste_payload` and is unit-tested there; `app.rs` keeps only plumbing.

### Open question for @mathix420

`files` and `image` default to **on**. Both are no-ops today (a clipboard with no text pastes nothing), so this adds behavior rather than changing existing behavior — but it does mean that after this lands, copying an image in a browser and pressing paste writes a file to `%TEMP%` and puts a path in your shell where nothing happened before. Happy to flip either default to `false` if you would rather have it opt-in; it is a one-line change.

### Why draft

The automated suite is green, and the WSL path translation is verified end to end (a file written under `%TEMP%` reads back from a distro at `/mnt/c/...`). The manual clipboard checks — a real `Win+Shift+S` capture pasted into a terminal, into Claude Code, and into a WSL session — are still outstanding. Marking ready once those pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
