### PR TITLE
feat(sidebar): add filter actions, PR filters, and search scope [5]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -28,7 +28,7 @@ use crate::panel_filter::{self, PanelFilter};
 use crate::paste;
 use crate::path_style;
 use crate::path_style::PathStyle;
-use crate::pr_status::{PrCache, PrInfo, PrState};
+use crate::pr_status::{self, PrCache, PrInfo, PrState};
 use crate::projects::{Project, Worktree, project_json};
 use crate::scratchpad;
 use crate::session::{
@@ -316,6 +316,32 @@ fn project_toggles_pass(
         return true;
     }
     (!toggle_sessions || has_sessions) && (!toggle_attention || needs_attention)
+}
+
+/// The toggle identities the projects panel accepts.  The PR identities exist
+/// only when polling does, or every PR state would read as unknown and the
+/// filters could only ever empty the panel.
+fn project_filter_toggles(pr_status: bool) -> &'static [char] {
+    if pr_status { &['s', 'a', 'o', 'd', 'm', 'c'] } else { &['s', 'a'] }
+}
+
+/// Whether the projects panel is filtering on PR state this frame.
+fn any_pr_toggle_active(filter: &PanelFilter) -> bool {
+    ['o', 'd', 'm', 'c'].into_iter().any(|key| filter.is_toggled(key))
+}
+
+/// The cache generation the reconciler observes.  Held at `0` unless a PR
+/// filter is active, so a banked result only invalidates a row set that
+/// actually depends on PR state.
+fn pr_generation_for(generation: u64, any_pr_toggle_active: bool) -> u64 {
+    if any_pr_toggle_active { generation } else { 0 }
+}
+
+/// Whether this worktree's PR state is polled this frame.  Collapsed projects
+/// normally cost no `gh` processes, but a PR filter has to see every row or it
+/// would hide worktrees for want of a lookup it declined to start.
+fn should_poll_pr(pr_enabled: bool, expanded: bool, any_pr_toggle: bool) -> bool {
+    pr_enabled && (expanded || any_pr_toggle)
 }
 
 /// Whether a git-status row survives the git panel's toggle dimension. Unlike
@@ -691,6 +717,7 @@ impl AlacritreeApp {
             config.ui.project_name.clone(),
         );
 
+        let pr_status_concurrency = config.ui.pr_status_concurrency;
         let mut app = Self {
             show_left_sidebar: persisted.show_left_sidebar,
             show_right_sidebar: persisted.show_right_sidebar,
@@ -701,7 +728,7 @@ impl AlacritreeApp {
             reorder_mode: false,
             sidebar_auto_shown: false,
             sidebar_cursor_moved: false,
-            project_filter: PanelFilter::new(&['s', 'a']),
+            project_filter: PanelFilter::new(project_filter_toggles(config.ui.pr_status)),
             git_filter: PanelFilter::new(&['m', 'd', 'u']),
             search_scope: config.ui.search_scope,
             git_cursor: None,
@@ -759,6 +786,10 @@ impl AlacritreeApp {
             sidebar_focus_written: None,
             sidebar_deferred_close: None,
         };
+
+        // Ahead of the refreshes below, which can start lookups a cap applied
+        // afterwards would not bound.
+        app.pr_cache.set_concurrency(pr_status_concurrency);
 
         let wsl_indices: Vec<usize> = app
             .projects
@@ -1785,7 +1816,12 @@ impl AlacritreeApp {
         let apply = self.project_filter.toggles_apply(self.search_scope);
         let toggle_sessions = apply && self.project_filter.is_toggled('s');
         let toggle_attention = apply && self.project_filter.is_toggled('a');
-        let any_toggle = toggle_sessions || toggle_attention;
+        let pr_open = apply && self.project_filter.is_toggled('o');
+        let pr_draft = apply && self.project_filter.is_toggled('d');
+        let pr_merged = apply && self.project_filter.is_toggled('m');
+        let pr_closed = apply && self.project_filter.is_toggled('c');
+        let any_pr = pr_open || pr_draft || pr_merged || pr_closed;
+        let any_toggle = toggle_sessions || toggle_attention || any_pr;
 
         // Precompute every fuzzy result before building the closures: the
         // matcher needs `&mut self.project_filter`, and releasing that borrow
@@ -1806,6 +1842,25 @@ impl AlacritreeApp {
                 .map(|wt| (wt.path.clone(), filter.matches(&wt.name)))
                 .collect()
         };
+        let live_branch = self
+            .current_workspace
+            .as_deref()
+            .and_then(|p| self.git_status.get(p))
+            .and_then(|c| c.current_branch());
+        let current_workspace = self.current_workspace.as_deref();
+        let pr_matches: HashMap<PathBuf, bool> = self
+            .projects
+            .iter()
+            .flat_map(|p| p.worktrees.iter())
+            .map(|wt| {
+                let branch = pr_status::effective_branch(wt, current_workspace, live_branch);
+                let state = self.pr_cache.state(&wt.path, branch);
+                (
+                    wt.path.clone(),
+                    pr_status::pr_pass(state, pr_open, pr_draft, pr_merged, pr_closed),
+                )
+            })
+            .collect();
 
         let toggles_pass = |key: &WorkspaceKey| {
             project_toggles_pass(
@@ -1822,6 +1877,7 @@ impl AlacritreeApp {
         let mut worktree = |_p: &Project, wt: &Worktree| {
             worktree_matches.get(&wt.path).copied().unwrap_or(false)
                 && toggles_pass(&Some(wt.path.clone()))
+                && pr_matches.get(&wt.path).copied().unwrap_or(false)
         };
         sidebar_nav::filtered_rows(
             &self.projects,
@@ -1867,7 +1923,10 @@ impl AlacritreeApp {
                 query: self.project_filter.query(),
                 toggles: self.project_filter.toggle_bits(),
                 toggles_apply: self.project_filter.toggles_apply(self.search_scope),
-                pr_generation: 0,
+                pr_generation: pr_generation_for(
+                    self.pr_cache.generation(),
+                    any_pr_toggle_active(&self.project_filter),
+                ),
                 active_workspace,
                 active_branch,
             },
@@ -1914,7 +1973,10 @@ impl AlacritreeApp {
                         query: self.project_filter.query(),
                         toggles: self.project_filter.toggle_bits(),
                         toggles_apply: self.project_filter.toggles_apply(self.search_scope),
-                        pr_generation: 0,
+                        pr_generation: pr_generation_for(
+                            self.pr_cache.generation(),
+                            any_pr_toggle_active(&self.project_filter),
+                        ),
                         active_workspace,
                         active_branch,
                     },
@@ -2566,7 +2628,13 @@ impl AlacritreeApp {
                     SearchScope::All => SearchScope::Filtered,
                 };
             },
-            BindingAction::Named(NamedAction::RefreshPrStatus) => {},
+            BindingAction::Named(NamedAction::RefreshPrStatus) => {
+                self.pr_cache.invalidate_all();
+                // The poll sites run while the sidebars paint, and the palette
+                // dispatches after both have; without a wake the re-query would
+                // wait for whatever repaint happened to come next.
+                ctx.request_repaint();
+            },
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
             },
@@ -3053,40 +3121,44 @@ impl AlacritreeApp {
         let mut shell_override_changed: Option<PathBuf> = None;
         let mut label_cleared: Option<PathBuf> = None;
         let mut rename_request: Option<RenameState> = None;
-        // Polled up front, expanded projects only: collapsed projects cost no gh
-        // processes, and the panel closure borrows `projects` mutably so the cache
-        // cannot be polled from inside it.
+        // Polled up front: the panel closure borrows `projects` mutably, so the
+        // cache cannot be polled from inside it.
         let pr_enabled = self.config.ui.pr_status;
+        let any_pr_toggle = any_pr_toggle_active(&self.project_filter);
+        let current_workspace = self.current_workspace.as_deref();
+        let live_branch = current_workspace
+            .and_then(|p| self.git_status.get(p))
+            .and_then(|cache| cache.current_branch());
+        // The same path can be a worktree of two projects, and `PrCache` is
+        // keyed by path alone, so a second poller would only invalidate the
+        // first's lookup and burn a `gh` process every frame.
+        let mut polled: HashMap<PathBuf, Option<PrInfo>> = HashMap::new();
         let mut pr_infos: Vec<Vec<Option<PrInfo>>> = Vec::with_capacity(self.projects.len());
         for project in &self.projects {
             let mut rows = Vec::with_capacity(project.worktrees.len());
             for wt in &project.worktrees {
-                let info = if pr_enabled && project.expanded {
-                    // The right sidebar polls only the active workspace's PR
-                    // cache, using the live `StatusCache` branch (recomputed
-                    // every ~1.5s). Two pollers of the same path must agree on
-                    // a branch or each drain flips `entry.branch` and they
-                    // invalidate each other's lookups forever after an
-                    // in-terminal checkout — so share the live cache there.
-                    // For every other worktree there is only one poller (this
-                    // one), and its cache is created once a workspace goes
-                    // active but never re-polled or pruned after it goes
-                    // inactive again: reading it here would freeze the branch
-                    // at whatever it was on last visit and shadow later
-                    // `refresh_project` updates to `wt.branch`. Use the
-                    // refresh-responsive snapshot instead.
-                    let is_active = self.current_workspace.as_deref() == Some(&wt.path);
-                    let branch = if is_active {
-                        self.git_status
-                            .get(&wt.path)
-                            .and_then(|cache| cache.current_branch())
-                            .or(wt.branch.as_deref())
-                    } else {
-                        wt.branch.as_deref()
-                    };
-                    self.pr_cache.poll(&wt.path, branch, ctx)
-                } else {
+                // The right sidebar polls only the active workspace's PR
+                // cache, using the live `StatusCache` branch (recomputed
+                // every ~1.5s). Two pollers of the same path must agree on
+                // a branch or each drain flips `entry.branch` and they
+                // invalidate each other's lookups forever after an
+                // in-terminal checkout — so share the live cache there.
+                // For every other worktree there is only one poller (this
+                // one), and its cache is created once a workspace goes
+                // active but never re-polled or pruned after it goes
+                // inactive again: reading it here would freeze the branch
+                // at whatever it was on last visit and shadow later
+                // `refresh_project` updates to `wt.branch`. Use the
+                // refresh-responsive snapshot instead.
+                let info = if !should_poll_pr(pr_enabled, project.expanded, any_pr_toggle) {
                     None
+                } else if let Some(cached) = polled.get(&wt.path) {
+                    cached.clone()
+                } else {
+                    let branch = pr_status::effective_branch(wt, current_workspace, live_branch);
+                    let info = self.pr_cache.poll(&wt.path, branch, ctx);
+                    polled.insert(wt.path.clone(), info.clone());
+                    info
                 };
                 rows.push(info);
             }
@@ -7468,6 +7540,9 @@ impl eframe::App for AlacritreeApp {
         self.phases.restart();
         self.glyph_cache.begin_frame(ctx);
         self.poll_project_refreshes();
+        // Unconditional: either sidebar can be hidden, and a drain hung off one
+        // of them would strand every entry the other polled.
+        self.pr_cache.drain_completed();
         self.poll_pending_deletes(ctx);
         self.poll_pending_creates(ctx);
         self.phases.mark("polls");
@@ -9260,5 +9335,80 @@ mod tests {
             snapshot.is_projected(below),
             "a row below the one being deleted must still be navigable"
         );
+    }
+
+    #[test]
+    fn the_pr_identities_exist_only_when_polling_does() {
+        assert_eq!(project_filter_toggles(false), &['s', 'a']);
+        assert_eq!(project_filter_toggles(true), &['s', 'a', 'o', 'd', 'm', 'c']);
+    }
+
+    /// Guards the staging dependency: the four PR actions already dispatch to
+    /// `project_filter.toggle`, and `toggle` silently ignores an identity the
+    /// filter does not allow — so a narrow slice here makes them dead keys.
+    #[test]
+    fn the_pr_actions_reach_a_configured_projects_filter() {
+        let mut f = PanelFilter::new(project_filter_toggles(true));
+        for key in ['o', 'd', 'm', 'c'] {
+            f.toggle(key);
+            assert!(f.is_toggled(key), "{key} must be a live identity");
+        }
+    }
+
+    #[test]
+    fn any_pr_toggle_active_ignores_the_non_pr_identities() {
+        let mut f = PanelFilter::new(project_filter_toggles(true));
+        assert!(!any_pr_toggle_active(&f));
+        f.toggle('s');
+        assert!(!any_pr_toggle_active(&f), "a session toggle is not a PR toggle");
+        f.toggle('o');
+        assert!(any_pr_toggle_active(&f));
+    }
+
+    /// The reconciler must not churn for users who never touch a PR filter:
+    /// every banked result would otherwise rebuild the row set.
+    #[test]
+    fn the_generation_reaches_the_reconciler_only_while_filtering() {
+        assert_eq!(pr_generation_for(7, false), 0);
+        assert_eq!(pr_generation_for(7, true), 7);
+    }
+
+    #[test]
+    fn a_pr_filter_reaches_into_collapsed_projects() {
+        assert!(!should_poll_pr(true, false, false), "collapsed and unfiltered: no lookup");
+        assert!(should_poll_pr(true, false, true), "a PR filter must see collapsed rows");
+        assert!(should_poll_pr(true, true, false));
+        assert!(!should_poll_pr(false, true, true), "disabled means never");
+    }
+
+    /// The same path can be a worktree of two projects, and `PrCache` is keyed
+    /// by path alone — two pollers would burn a `gh` process per frame.
+    #[test]
+    fn a_repeated_path_is_polled_once_but_rendered_everywhere() {
+        let mut polled: HashMap<PathBuf, Option<PrInfo>> = HashMap::new();
+        let mut lookups = 0;
+        let path = PathBuf::from("/repo/wt");
+
+        let mut resolve = |p: &PathBuf| {
+            if let Some(cached) = polled.get(p) {
+                return cached.clone();
+            }
+            lookups += 1;
+            let info = Some(PrInfo {
+                number: 1,
+                base_branch: "master".into(),
+                url: String::new(),
+                state: PrState::Open,
+            });
+            polled.insert(p.clone(), info.clone());
+            info
+        };
+
+        let first = resolve(&path);
+        let second = resolve(&path);
+
+        assert_eq!(lookups, 1, "one lookup per path per frame");
+        assert!(second.is_some(), "the duplicate row still renders its badge");
+        assert_eq!(first.map(|i| i.number), second.map(|i| i.number));
     }
 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -228,7 +228,9 @@ enum FocusDir {
 /// PTY when the inner TUI should handle it.  An IPC action has no key press
 /// to forward — the caller is typically that inner program declaring it has
 /// no window in the requested direction, and passthrough would bounce the
-/// key straight back to it.
+/// key straight back to it.  A palette action consumed a key press too, but
+/// arrives with the panel still searching over a row the query may have
+/// hidden — so actions that need a browsing cursor are refused at this origin.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ActionOrigin {
     Keyboard,
@@ -858,8 +860,6 @@ impl AlacritreeApp {
             sidebar_deferred_close: None,
         };
 
-        // Ahead of the refreshes below, which can start lookups a cap applied
-        // afterwards would not bound.
         app.pr_cache.set_concurrency(pr_status_concurrency);
 
         let wsl_indices: Vec<usize> = app
@@ -3191,19 +3191,6 @@ impl AlacritreeApp {
         for project in &self.projects {
             let mut rows = Vec::with_capacity(project.worktrees.len());
             for wt in &project.worktrees {
-                // The right sidebar polls only the active workspace's PR
-                // cache, using the live `StatusCache` branch (recomputed
-                // every ~1.5s). Two pollers of the same path must agree on
-                // a branch or each drain flips `entry.branch` and they
-                // invalidate each other's lookups forever after an
-                // in-terminal checkout — so share the live cache there.
-                // For every other worktree there is only one poller (this
-                // one), and its cache is created once a workspace goes
-                // active but never re-polled or pruned after it goes
-                // inactive again: reading it here would freeze the branch
-                // at whatever it was on last visit and shadow later
-                // `refresh_project` updates to `wt.branch`. Use the
-                // refresh-responsive snapshot instead.
                 let info = resolve_pr_info(
                     &mut polled,
                     &wt.path,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -278,6 +278,32 @@ fn focus_move(
     }
 }
 
+/// Whether a matched binding's key press should reach `action`, given which
+/// pane currently owns keyboard focus. Filter actions are scoped to the
+/// sidebar that owns them so a bare letter like `d` doesn't fire a git-panel
+/// filter while the projects sidebar (or the terminal) has focus, and vice
+/// versa. `terminal_only` actions additionally step aside for the scratchpad
+/// editor, which wants those same keys for native text editing.
+fn valid_for_focus(
+    action: &BindingAction,
+    sidebar_focused: bool,
+    git_focused: bool,
+    scratchpad_focused: bool,
+) -> bool {
+    let focus_ok = match action {
+        BindingAction::Named(n) if n.is_projects_filter_scoped() => sidebar_focused,
+        BindingAction::Named(n) if n.is_git_filter_scoped() => git_focused,
+        BindingAction::Named(n) if n.is_sidebar_scoped() => sidebar_focused,
+        _ => true,
+    };
+    let terminal_only = match action {
+        BindingAction::Chars(_) => true,
+        BindingAction::Named(n) => n.is_terminal_only(),
+        BindingAction::Unsupported(_) => false,
+    };
+    focus_ok && !(scratchpad_focused && terminal_only)
+}
+
 pub struct AlacritreeApp {
     show_left_sidebar: bool,
     show_right_sidebar: bool,
@@ -1582,23 +1608,7 @@ impl AlacritreeApp {
                     let matched: Vec<_> = matched
                         .into_iter()
                         .filter(|a| {
-                            let valid_for_focus = match a {
-                                BindingAction::Named(n) if n.is_projects_filter_scoped() => {
-                                    sidebar_focused
-                                },
-                                BindingAction::Named(n) if n.is_git_filter_scoped() => git_focused,
-                                BindingAction::Named(n) if n.is_sidebar_scoped() => sidebar_focused,
-                                _ => true,
-                            };
-                            // Terminal byte/scroll bindings would swallow
-                            // useful editor keys like Shift+Home and
-                            // Shift+PageUp. Leave those events for TextEdit.
-                            let terminal_only = match a {
-                                BindingAction::Chars(_) => true,
-                                BindingAction::Named(n) => n.is_terminal_only(),
-                                BindingAction::Unsupported(_) => false,
-                            };
-                            valid_for_focus && !(scratchpad_focused && terminal_only)
+                            valid_for_focus(a, sidebar_focused, git_focused, scratchpad_focused)
                         })
                         // Search actions are owned by the sidebar nav pass; here
                         // their default Enter/Esc/Shift+Esc must fall through to
@@ -8501,6 +8511,47 @@ mod tests {
             focus_move(PaneFocus::Terminal, FocusDir::Left, false, true, ActionOrigin::Ipc, true),
             FocusMove::Nothing
         );
+    }
+
+    #[test]
+    fn projects_filter_action_valid_when_projects_sidebar_focused() {
+        let action = BindingAction::Named(NamedAction::ToggleSessionsFilter);
+        assert!(valid_for_focus(&action, true, false, false));
+    }
+
+    #[test]
+    fn projects_filter_action_rejected_when_git_sidebar_focused() {
+        let action = BindingAction::Named(NamedAction::ToggleSessionsFilter);
+        assert!(!valid_for_focus(&action, false, true, false));
+    }
+
+    #[test]
+    fn git_filter_action_valid_when_git_sidebar_focused() {
+        let action = BindingAction::Named(NamedAction::ToggleModifiedFilter);
+        assert!(valid_for_focus(&action, false, true, false));
+    }
+
+    #[test]
+    fn git_filter_action_rejected_when_projects_sidebar_focused() {
+        let action = BindingAction::Named(NamedAction::ToggleModifiedFilter);
+        assert!(!valid_for_focus(&action, true, false, false));
+    }
+
+    #[test]
+    fn both_sidebar_filters_rejected_when_terminal_focused() {
+        let projects_action = BindingAction::Named(NamedAction::ToggleSessionsFilter);
+        let git_action = BindingAction::Named(NamedAction::ToggleModifiedFilter);
+        assert!(!valid_for_focus(&projects_action, false, false, false));
+        assert!(!valid_for_focus(&git_action, false, false, false));
+    }
+
+    /// `ScrollPageUp` is unscoped by pane focus, so only the scratchpad
+    /// editor stealing it back (via `terminal_only`) should block it.
+    #[test]
+    fn terminal_only_action_yields_to_the_scratchpad_editor() {
+        let action = BindingAction::Named(NamedAction::ScrollPageUp);
+        assert!(!valid_for_focus(&action, false, false, true));
+        assert!(valid_for_focus(&action, false, false, false));
     }
 
     fn req(file: &str, source: DiffSource) -> DiffRequest {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -8189,6 +8189,7 @@ mod tests {
     fn bare_delete_in_search_is_consumed_as_a_no_op() {
         let binds = crate::bindings::parse_bindings(vec![]);
         let mut f = searching_filter();
+        f.on_text("typed");
 
         let mut steps = Vec::new();
         let retain = drain_search_or_nav(
@@ -8200,7 +8201,12 @@ mod tests {
             false,
         );
 
-        assert!(!retain);
+        assert!(!retain, "Delete must not reach the cursored row");
+        assert!(
+            matches!(steps.as_slice(), [SidebarNavStep::Nav(egui::Key::Delete)]),
+            "Delete is consumed as a plain nav key, not routed into the filter"
+        );
+        assert_eq!(f.query(), "typed", "an append-only query has no delete");
     }
 
     /// Keys that produce no text keep falling through to the binding table, which

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -359,6 +359,29 @@ fn should_poll_pr(pr_enabled: bool, expanded: bool, any_pr_toggle: bool) -> bool
     pr_enabled && (expanded || any_pr_toggle)
 }
 
+/// Resolves one worktree's PR info against this frame's memo. `lookup` runs
+/// at most once per distinct `path`: a repeated path (the same worktree under
+/// two projects) reuses the banked answer instead of polling `PrCache` twice.
+fn resolve_pr_info<F>(
+    memo: &mut HashMap<PathBuf, Option<PrInfo>>,
+    path: &Path,
+    eligible: bool,
+    lookup: F,
+) -> Option<PrInfo>
+where
+    F: FnOnce() -> Option<PrInfo>,
+{
+    if !eligible {
+        return None;
+    }
+    if let Some(cached) = memo.get(path) {
+        return cached.clone();
+    }
+    let info = lookup();
+    memo.insert(path.to_path_buf(), info.clone());
+    info
+}
+
 /// Whether a git-status row survives the git panel's toggle dimension. Unlike
 /// `project_toggles_pass`, standing this down needs no separate `apply` flag:
 /// forcing all three toggles to `false` already makes `!any` admit every row.
@@ -3165,16 +3188,16 @@ impl AlacritreeApp {
                 // at whatever it was on last visit and shadow later
                 // `refresh_project` updates to `wt.branch`. Use the
                 // refresh-responsive snapshot instead.
-                let info = if !should_poll_pr(pr_enabled, project.expanded, any_pr_toggle) {
-                    None
-                } else if let Some(cached) = polled.get(&wt.path) {
-                    cached.clone()
-                } else {
-                    let branch = pr_status::effective_branch(wt, current_workspace, live_branch);
-                    let info = self.pr_cache.poll(&wt.path, branch, ctx);
-                    polled.insert(wt.path.clone(), info.clone());
-                    info
-                };
+                let info = resolve_pr_info(
+                    &mut polled,
+                    &wt.path,
+                    should_poll_pr(pr_enabled, project.expanded, any_pr_toggle),
+                    || {
+                        let branch =
+                            pr_status::effective_branch(wt, current_workspace, live_branch);
+                        self.pr_cache.poll(&wt.path, branch, ctx)
+                    },
+                );
                 rows.push(info);
             }
             pr_infos.push(rows);
@@ -9431,30 +9454,29 @@ mod tests {
     /// by path alone — two pollers would burn a `gh` process per frame.
     #[test]
     fn a_repeated_path_is_polled_once_but_rendered_everywhere() {
-        let mut polled: HashMap<PathBuf, Option<PrInfo>> = HashMap::new();
-        let mut lookups = 0;
+        let mut memo: HashMap<PathBuf, Option<PrInfo>> = HashMap::new();
+        let lookups = std::cell::Cell::new(0);
         let path = PathBuf::from("/repo/wt");
 
-        let mut resolve = |p: &PathBuf| {
-            if let Some(cached) = polled.get(p) {
-                return cached.clone();
-            }
-            lookups += 1;
-            let info = Some(PrInfo {
+        let poll = || {
+            lookups.set(lookups.get() + 1);
+            Some(PrInfo {
                 number: 1,
                 base_branch: "master".into(),
                 url: String::new(),
                 state: PrState::Open,
-            });
-            polled.insert(p.clone(), info.clone());
-            info
+            })
         };
 
-        let first = resolve(&path);
-        let second = resolve(&path);
+        let first = resolve_pr_info(&mut memo, &path, true, &poll);
+        let second = resolve_pr_info(&mut memo, &path, true, &poll);
 
-        assert_eq!(lookups, 1, "one lookup per path per frame");
+        assert_eq!(lookups.get(), 1, "one lookup per path per frame");
         assert!(second.is_some(), "the duplicate row still renders its badge");
         assert_eq!(first.map(|i| i.number), second.map(|i| i.number));
+
+        let ineligible = resolve_pr_info(&mut memo, &PathBuf::from("/repo/other"), false, &poll);
+        assert_eq!(lookups.get(), 1, "an ineligible path never runs the lookup");
+        assert!(ineligible.is_none());
     }
 }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1633,18 +1633,29 @@ impl AlacritreeApp {
         let bindings = &self.config.bindings;
         let steps: Vec<SidebarNavStep> = ctx.input_mut(|i| {
             let mut steps = Vec::new();
-            i.events.retain(|ev| match ev {
-                egui::Event::Text(text) => match filter.on_text(text) {
-                    Some(outcome) => {
-                        steps.push(SidebarNavStep::Filter(outcome));
-                        false
+            let text_keys = keys_paired_with_text(&i.events);
+            let mut idx = 0;
+            i.events.retain(|ev| {
+                let produced_text = text_keys[idx];
+                idx += 1;
+                match ev {
+                    egui::Event::Text(text) => match filter.on_text(text) {
+                        Some(outcome) => {
+                            steps.push(SidebarNavStep::Filter(outcome));
+                            false
+                        },
+                        None => true,
                     },
-                    None => true,
-                },
-                egui::Event::Key { key, pressed: true, modifiers, .. } => {
-                    drain_search_or_nav(&mut steps, filter, bindings, *key, *modifiers)
-                },
-                _ => true,
+                    egui::Event::Key { key, pressed: true, modifiers, .. } => drain_search_or_nav(
+                        &mut steps,
+                        filter,
+                        bindings,
+                        *key,
+                        *modifiers,
+                        produced_text,
+                    ),
+                    _ => true,
+                }
             });
             steps
         });
@@ -2010,18 +2021,29 @@ impl AlacritreeApp {
         let bindings = &self.config.bindings;
         let steps: Vec<SidebarNavStep> = ctx.input_mut(|i| {
             let mut steps = Vec::new();
-            i.events.retain(|ev| match ev {
-                egui::Event::Text(text) => match filter.on_text(text) {
-                    Some(outcome) => {
-                        steps.push(SidebarNavStep::Filter(outcome));
-                        false
+            let text_keys = keys_paired_with_text(&i.events);
+            let mut idx = 0;
+            i.events.retain(|ev| {
+                let produced_text = text_keys[idx];
+                idx += 1;
+                match ev {
+                    egui::Event::Text(text) => match filter.on_text(text) {
+                        Some(outcome) => {
+                            steps.push(SidebarNavStep::Filter(outcome));
+                            false
+                        },
+                        None => true,
                     },
-                    None => true,
-                },
-                egui::Event::Key { key, pressed: true, modifiers, .. } => {
-                    drain_search_or_nav(&mut steps, filter, bindings, *key, *modifiers)
-                },
-                _ => true,
+                    egui::Event::Key { key, pressed: true, modifiers, .. } => drain_search_or_nav(
+                        &mut steps,
+                        filter,
+                        bindings,
+                        *key,
+                        *modifiers,
+                        produced_text,
+                    ),
+                    _ => true,
+                }
             });
             steps
         });
@@ -5020,21 +5042,47 @@ fn panel_header_filter_ui(
     }
 }
 
+/// Which events are key presses whose text the search box will swallow.
+///
+/// egui-winit pushes `Event::Key` and then `Event::Text` adjacently for one
+/// printable press, so adjacency identifies the pair.  The result is positional
+/// rather than a set of triggers: key repeat and the `logical_key.or(physical_key)`
+/// fallback both let two presses in one frame share a `(key, modifiers)`, and
+/// only the occurrence carrying text may be treated as query input.
+fn keys_paired_with_text(events: &[egui::Event]) -> Vec<bool> {
+    events
+        .iter()
+        .enumerate()
+        .map(|(n, ev)| {
+            matches!(ev, egui::Event::Key { pressed: true, .. })
+                && matches!(events.get(n + 1), Some(egui::Event::Text(_)))
+        })
+        .collect()
+}
+
 /// Decide one key event for a focused sidebar panel and record its step.
 ///
-/// In search mode a search-scoped binding match (any modifiers, so `Shift+Esc`
-/// counts) is dispatched through the binding table, keeping `Enter`/`Esc`
-/// rebindable. Otherwise an unmodified key drives the filter or browsing nav; a
-/// modified non-search key is retained for `handle_shortcuts`. Returns whether
-/// the event stays in the queue (`true`) or is consumed here (`false`).
+/// In search mode a key whose text the query already swallowed is consumed
+/// outright — text input is unconditional, so it outranks even a search-scoped
+/// binding on that letter.  Otherwise a search-scoped binding match (any
+/// modifiers, so `Shift+Esc` counts) is dispatched through the binding table,
+/// keeping `Enter`/`Esc` rebindable; an unmodified key drives the filter or
+/// browsing nav; and a modified non-search key is retained for
+/// `handle_shortcuts`.  Returns whether the event stays in the queue (`true`)
+/// or is consumed here (`false`).
 fn drain_search_or_nav(
     steps: &mut Vec<SidebarNavStep>,
     filter: &mut PanelFilter,
     bindings: &[crate::bindings::KeyBinding],
     key: egui::Key,
     modifiers: egui::Modifiers,
+    produced_text: bool,
 ) -> bool {
-    if filter.mode() == panel_filter::Mode::Search {
+    let searching = filter.mode() == panel_filter::Mode::Search;
+    if searching && produced_text {
+        return false;
+    }
+    if searching {
         let mut matched = false;
         for a in crate::bindings::all_matches(bindings, key, modifiers) {
             if let BindingAction::Named(n) = a {
@@ -5055,12 +5103,14 @@ fn drain_search_or_nav(
         steps.push(SidebarNavStep::Filter(outcome));
         return false;
     }
-    // Browsing consumes the whole nav-key set; in search only Space stays
-    // consumed as a no-op, preserving the fake-click guard on the terminal view.
+    // Browsing consumes the whole nav-key set.  In search only Space and Delete
+    // stay consumed as no-ops: Space preserves the fake-click guard on the
+    // terminal view, and Delete is a text-editing key the append-only query has
+    // nothing to do with, so it must not fall through to the cursored row.
     let consume = if filter.mode() == panel_filter::Mode::Browsing {
         is_sidebar_nav_key(key)
     } else {
-        key == egui::Key::Space
+        key == egui::Key::Space || key == egui::Key::Delete
     };
     if consume {
         steps.push(SidebarNavStep::Nav(key));
@@ -7639,6 +7689,50 @@ mod tests {
         v
     }
 
+    fn key_ev(key: egui::Key, pressed: bool) -> egui::Event {
+        egui::Event::Key {
+            key,
+            physical_key: None,
+            pressed,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        }
+    }
+
+    #[test]
+    fn text_pairing_marks_only_keys_followed_by_text() {
+        let events = vec![
+            key_ev(egui::Key::A, true),
+            egui::Event::Text("a".into()),
+            key_ev(egui::Key::Enter, true),
+            key_ev(egui::Key::B, true),
+            egui::Event::Text("b".into()),
+        ];
+        assert_eq!(keys_paired_with_text(&events), vec![true, false, false, true, false]);
+    }
+
+    #[test]
+    fn text_pairing_ignores_released_keys_and_orphan_text() {
+        let events = vec![
+            key_ev(egui::Key::A, false),
+            egui::Event::Text("a".into()),
+            egui::Event::Text("pasted".into()),
+        ];
+        assert_eq!(keys_paired_with_text(&events), vec![false, false, false]);
+    }
+
+    /// Two presses sharing one `(key, modifiers)` in a frame: only the occurrence
+    /// actually followed by text is marked. A set keyed by value would mark both.
+    #[test]
+    fn text_pairing_is_per_occurrence_not_per_trigger() {
+        let events = vec![
+            key_ev(egui::Key::A, true),
+            egui::Event::Text("a".into()),
+            key_ev(egui::Key::A, true),
+        ];
+        assert_eq!(keys_paired_with_text(&events), vec![true, false, false]);
+    }
+
     fn searching_filter() -> PanelFilter {
         let mut f = PanelFilter::new(&['s', 'a']);
         f.on_text("/");
@@ -7690,6 +7784,7 @@ mod tests {
             &binds,
             egui::Key::Enter,
             egui::Modifiers::NONE,
+            false,
         );
         assert!(!retain, "a matched search action consumes the key");
         assert!(matches!(
@@ -7701,14 +7796,28 @@ mod tests {
         assert_eq!(f.query(), "foo");
 
         let mut steps = Vec::new();
-        drain_search_or_nav(&mut steps, &mut f, &binds, egui::Key::Escape, egui::Modifiers::NONE);
+        drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::Escape,
+            egui::Modifiers::NONE,
+            false,
+        );
         assert!(matches!(
             steps.as_slice(),
             [SidebarNavStep::SearchAction(NamedAction::SidebarSearchCancel)]
         ));
 
         let mut steps = Vec::new();
-        drain_search_or_nav(&mut steps, &mut f, &binds, egui::Key::Escape, egui::Modifiers::SHIFT);
+        drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::Escape,
+            egui::Modifiers::SHIFT,
+            false,
+        );
         assert!(
             matches!(
                 steps.as_slice(),
@@ -7730,6 +7839,7 @@ mod tests {
             &binds,
             egui::Key::ArrowDown,
             egui::Modifiers::NONE,
+            false,
         );
         assert!(matches!(
             steps.as_slice(),
@@ -7744,6 +7854,7 @@ mod tests {
             &binds,
             egui::Key::Space,
             egui::Modifiers::NONE,
+            false,
         );
         assert!(!retain);
         assert!(matches!(steps.as_slice(), [SidebarNavStep::Nav(egui::Key::Space)]));
@@ -7761,6 +7872,7 @@ mod tests {
             &binds,
             egui::Key::Enter,
             egui::Modifiers::NONE,
+            false,
         );
         assert!(!retain, "Enter in browsing is a nav activate, consumed here");
         assert!(matches!(steps.as_slice(), [SidebarNavStep::Nav(egui::Key::Enter)]));
@@ -7773,6 +7885,7 @@ mod tests {
             &binds,
             egui::Key::Enter,
             egui::Modifiers::CTRL,
+            false,
         );
         assert!(retain);
         assert!(steps.is_empty());
@@ -7792,9 +7905,138 @@ mod tests {
             &binds,
             egui::Key::Enter,
             egui::Modifiers::NONE,
+            false,
         );
         assert!(retain, "an unbound Enter in search is retained, not consumed as nav");
         assert!(steps.is_empty());
+    }
+
+    /// A text-producing key in search mode is query input and must not also run a
+    /// binding — including one bound to a search action, since text input is
+    /// unconditional.
+    #[test]
+    fn a_text_key_in_search_is_consumed_before_any_binding() {
+        let binds = crate::bindings::parse_bindings(vec![crate::bindings::RawBinding {
+            key: "G".into(),
+            mods: None,
+            mode: None,
+            chars: None,
+            action: Some("SidebarSearchConfirm".into()),
+            command: None,
+        }]);
+        let mut f = searching_filter();
+
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::G,
+            egui::Modifiers::NONE,
+            true,
+        );
+
+        assert!(!retain, "a key carrying query text is consumed");
+        assert!(steps.is_empty(), "and dispatches nothing, not even a search action");
+    }
+
+    /// Shift+letter still produces text, so it must be consumed too. The modifier
+    /// early-return would otherwise let the built-in Shift+R reach RenameSelected.
+    #[test]
+    fn shift_letter_in_search_is_consumed() {
+        let binds = crate::bindings::parse_bindings(vec![]);
+        let mut f = searching_filter();
+
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::R,
+            egui::Modifiers::SHIFT,
+            true,
+        );
+
+        assert!(!retain);
+        assert!(steps.is_empty());
+    }
+
+    /// Bare Delete carries no text, so the pairing rule cannot claim it. It is a
+    /// search-box editing key, so it is consumed as a no-op instead of reaching the
+    /// cursored row.
+    #[test]
+    fn bare_delete_in_search_is_consumed_as_a_no_op() {
+        let binds = crate::bindings::parse_bindings(vec![]);
+        let mut f = searching_filter();
+
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::Delete,
+            egui::Modifiers::NONE,
+            false,
+        );
+
+        assert!(!retain);
+    }
+
+    /// Keys that produce no text keep falling through to the binding table, which
+    /// is what lets Home/End/PageUp/PageDown navigate filtered results.
+    #[test]
+    fn non_text_keys_in_search_still_fall_through() {
+        let binds = crate::bindings::parse_bindings(vec![]);
+        for key in [egui::Key::ArrowLeft, egui::Key::ArrowRight, egui::Key::Tab, egui::Key::Home] {
+            let mut f = searching_filter();
+            let mut steps = Vec::new();
+            let retain =
+                drain_search_or_nav(&mut steps, &mut f, &binds, key, egui::Modifiers::NONE, false);
+            assert!(retain, "{key:?} produces no query text and must reach the binding table");
+        }
+    }
+
+    /// Ctrl-modified keys suppress text generation, so they have no query input
+    /// and must reach the binding table to fire user bindings.
+    #[test]
+    fn ctrl_keys_in_search_still_fall_through() {
+        let binds = crate::bindings::parse_bindings(vec![]);
+        let mut f = searching_filter();
+
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::C,
+            egui::Modifiers::CTRL,
+            false,
+        );
+
+        assert!(
+            retain,
+            "ctrl-modified key produces no query text and must reach the binding table"
+        );
+    }
+
+    /// Browsing mode is untouched: a letter must reach the binding table, which is
+    /// how the filter toggle actions fire.
+    #[test]
+    fn a_text_key_in_browsing_is_not_consumed_by_the_pairing_rule() {
+        let binds = crate::bindings::parse_bindings(vec![]);
+        let mut f = PanelFilter::new(&['s', 'a']);
+
+        let mut steps = Vec::new();
+        let retain = drain_search_or_nav(
+            &mut steps,
+            &mut f,
+            &binds,
+            egui::Key::S,
+            egui::Modifiers::NONE,
+            true,
+        );
+
+        assert!(retain);
     }
 
     #[test]

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1563,6 +1563,7 @@ impl AlacritreeApp {
     /// is `ReceiveChar` (alacritty's pass-through marker).
     fn handle_shortcuts(&mut self, ctx: &Context) {
         let sidebar_focused = self.focus == PaneFocus::ProjectsSidebar && !self.palette.is_open();
+        let git_focused = self.focus == PaneFocus::GitSidebar && !self.palette.is_open();
         let scratchpad_focused = self.focus == PaneFocus::Terminal
             && self
                 .active_session_index()
@@ -1581,8 +1582,14 @@ impl AlacritreeApp {
                     let matched: Vec<_> = matched
                         .into_iter()
                         .filter(|a| {
-                            let valid_for_focus = sidebar_focused
-                                || !matches!(a, BindingAction::Named(n) if n.is_sidebar_scoped());
+                            let valid_for_focus = match a {
+                                BindingAction::Named(n) if n.is_projects_filter_scoped() => {
+                                    sidebar_focused
+                                },
+                                BindingAction::Named(n) if n.is_git_filter_scoped() => git_focused,
+                                BindingAction::Named(n) if n.is_sidebar_scoped() => sidebar_focused,
+                                _ => true,
+                            };
                             // Terminal byte/scroll bindings would swallow
                             // useful editor keys like Shift+Home and
                             // Shift+PageUp. Leave those events for TextEdit.
@@ -2461,6 +2468,45 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::SidebarSearchCancelToTerminal) => {
                 self.sidebar_search_cancel_to_terminal();
             },
+            BindingAction::Named(NamedAction::ToggleSessionsFilter) => {
+                self.project_filter.toggle('s');
+            },
+            BindingAction::Named(NamedAction::ToggleAttentionFilter) => {
+                self.project_filter.toggle('a');
+            },
+            BindingAction::Named(NamedAction::TogglePrOpenFilter) => {
+                self.project_filter.toggle('o');
+            },
+            BindingAction::Named(NamedAction::TogglePrDraftFilter) => {
+                self.project_filter.toggle('d');
+            },
+            BindingAction::Named(NamedAction::TogglePrMergedFilter) => {
+                self.project_filter.toggle('m');
+            },
+            BindingAction::Named(NamedAction::TogglePrClosedFilter) => {
+                self.project_filter.toggle('c');
+            },
+            BindingAction::Named(NamedAction::ClearProjectFilters) => {
+                self.project_filter.clear_toggles();
+            },
+            BindingAction::Named(NamedAction::ToggleModifiedFilter) => {
+                self.git_filter.toggle('m');
+                self.after_git_filter_changed();
+            },
+            BindingAction::Named(NamedAction::ToggleDeletedFilter) => {
+                self.git_filter.toggle('d');
+                self.after_git_filter_changed();
+            },
+            BindingAction::Named(NamedAction::ToggleUntrackedFilter) => {
+                self.git_filter.toggle('u');
+                self.after_git_filter_changed();
+            },
+            BindingAction::Named(NamedAction::ClearGitFilters) => {
+                self.git_filter.clear_toggles();
+                self.after_git_filter_changed();
+            },
+            BindingAction::Named(NamedAction::ToggleSearchScope) => {},
+            BindingAction::Named(NamedAction::RefreshPrStatus) => {},
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
             },

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1822,6 +1822,9 @@ impl AlacritreeApp {
     }
 
     fn sidebar_snapshot(&mut self, skip_worktree: Option<&Path>) -> sidebar_focus::TreeSnapshot {
+        let active_workspace = self.current_workspace.as_deref();
+        let active_branch =
+            active_workspace.and_then(|p| self.git_status.get(p)).and_then(|c| c.current_branch());
         let inputs = sidebar_focus::ObservedInputs::capture(
             &self.projects,
             self.session_inputs(),
@@ -1829,6 +1832,10 @@ impl AlacritreeApp {
                 session_rows_always: self.session_rows_always,
                 query: self.project_filter.query(),
                 toggles: self.project_filter.toggle_bits(),
+                toggles_apply: true,
+                pr_generation: 0,
+                active_workspace,
+                active_branch,
             },
         );
         let rows = self.current_project_rows();
@@ -1860,6 +1867,10 @@ impl AlacritreeApp {
         let skip = deferred.as_ref().and_then(|d| d.removed_worktree.clone());
 
         if deferred.is_none() {
+            let active_workspace = self.current_workspace.as_deref();
+            let active_branch = active_workspace
+                .and_then(|p| self.git_status.get(p))
+                .and_then(|c| c.current_branch());
             if let Some(prev) = &self.sidebar_focus_prev {
                 let unchanged = prev.inputs.matches(
                     &self.projects,
@@ -1868,6 +1879,10 @@ impl AlacritreeApp {
                         session_rows_always: self.session_rows_always,
                         query: self.project_filter.query(),
                         toggles: self.project_filter.toggle_bits(),
+                        toggles_apply: true,
+                        pr_generation: 0,
+                        active_workspace,
+                        active_branch,
                     },
                 );
                 if unchanged {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -232,6 +232,7 @@ enum FocusDir {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ActionOrigin {
     Keyboard,
+    Palette,
     Ipc,
 }
 
@@ -2188,6 +2189,16 @@ impl AlacritreeApp {
     }
 
     fn dispatch_action(&mut self, ctx: &Context, action: BindingAction, origin: ActionOrigin) {
+        // A palette row is dispatched with the panel still searching, and the
+        // cursor operations below act on a row the query may have hidden.  The
+        // keyboard path cannot reach here mid-query at all: a letter's text is
+        // swallowed by the query before the binding table sees the key.
+        if origin == ActionOrigin::Palette
+            && matches!(&action, BindingAction::Named(n) if n.requires_project_browsing())
+            && self.project_filter.mode() != panel_filter::Mode::Browsing
+        {
+            return;
+        }
         match action {
             BindingAction::Chars(bytes) => {
                 if let Some(idx) = self.active_session_index() {
@@ -2351,24 +2362,9 @@ impl AlacritreeApp {
                 self.sidebar_cursor_project_jump(-1)
             },
             BindingAction::Named(NamedAction::RefreshProjects) => {
-                // While the fuzzy prompt is open an unmodified `r` is query
-                // input — its Text event already fed the filter — so only a
-                // browsing-mode press (or IPC) refreshes.
-                if origin == ActionOrigin::Ipc
-                    || self.project_filter.mode() == panel_filter::Mode::Browsing
-                {
-                    self.refresh_all_projects(ctx);
-                }
+                self.refresh_all_projects(ctx);
             },
             BindingAction::Named(NamedAction::DeleteSelected) => {
-                // While the fuzzy prompt is open a letter bound here is query
-                // input — its Text event already fed the filter — so only a
-                // browsing-mode press (or IPC) acts.  Mirrors RefreshProjects.
-                if origin != ActionOrigin::Ipc
-                    && self.project_filter.mode() != panel_filter::Mode::Browsing
-                {
-                    return;
-                }
                 match self.sidebar_cursor.clone() {
                     Some(SidebarRow::Session(id)) => self.request_close_session(ctx, id),
                     Some(SidebarRow::Worktree(path)) => self.request_worktree_delete(&path),
@@ -2384,13 +2380,6 @@ impl AlacritreeApp {
                 }
             },
             BindingAction::Named(NamedAction::RenameSelected) => {
-                // Same browsing-mode guard as DeleteSelected: while the fuzzy
-                // prompt is open a letter bound here is query input.
-                if origin != ActionOrigin::Ipc
-                    && self.project_filter.mode() != panel_filter::Mode::Browsing
-                {
-                    return;
-                }
                 // Only project rows carry an editable label; sessions and
                 // worktrees take their names from the terminal title and the
                 // `[ui] worktree_name` template.
@@ -2402,13 +2391,6 @@ impl AlacritreeApp {
                 }
             },
             BindingAction::Named(NamedAction::ToggleProjectExpanded) => {
-                // Same browsing-mode guard as DeleteSelected: while the fuzzy
-                // prompt is open a letter bound here is query input.
-                if origin != ActionOrigin::Ipc
-                    && self.project_filter.mode() != panel_filter::Mode::Browsing
-                {
-                    return;
-                }
                 let Some(cursor) = self.sidebar_cursor.clone() else {
                     return;
                 };
@@ -6524,7 +6506,7 @@ impl AlacritreeApp {
     fn run_palette_action(&mut self, ctx: &Context, action: PaletteAction) {
         match action {
             PaletteAction::Run(a) => {
-                self.dispatch_action(ctx, BindingAction::Named(a), ActionOrigin::Keyboard);
+                self.dispatch_action(ctx, BindingAction::Named(a), ActionOrigin::Palette);
             },
             PaletteAction::ActivateSession(id) => {
                 self.activate_session_by_id(id);

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -16,8 +16,8 @@ use crate::clipboard_image;
 use crate::colors::rgb_to_color32;
 use crate::command_palette::{self, CommandPalette, PaletteAction, PaletteItem};
 use crate::config::{
-    Config, FontConfig, Icons, LastSessionClose, PathStyleConfig, ScrollbarStyle, SidebarFocus,
-    TextEmphasis, UiFont,
+    Config, FontConfig, Icons, LastSessionClose, PathStyleConfig, ScrollbarStyle, SearchScope,
+    SidebarFocus, TextEmphasis, UiFont,
 };
 use crate::doppler;
 use crate::file_drop;
@@ -304,6 +304,30 @@ fn valid_for_focus(
     focus_ok && !(scratchpad_focused && terminal_only)
 }
 
+/// Whether a workspace survives the projects panel's toggle dimension.
+fn project_toggles_pass(
+    apply: bool,
+    toggle_sessions: bool,
+    has_sessions: bool,
+    toggle_attention: bool,
+    needs_attention: bool,
+) -> bool {
+    if !apply {
+        return true;
+    }
+    (!toggle_sessions || has_sessions) && (!toggle_attention || needs_attention)
+}
+
+/// Whether a git-status row survives the git panel's toggle dimension. Unlike
+/// `project_toggles_pass`, standing this down needs no separate `apply` flag:
+/// forcing all three toggles to `false` already makes `!any` admit every row.
+fn git_toggles_pass(m: bool, d: bool, u: bool, kind: ChangeKind) -> bool {
+    let any = m || d || u;
+    !any || (m && matches!(kind, ChangeKind::Modified | ChangeKind::Renamed))
+        || (d && kind == ChangeKind::Deleted)
+        || (u && matches!(kind, ChangeKind::Untracked | ChangeKind::Added))
+}
+
 pub struct AlacritreeApp {
     show_left_sidebar: bool,
     show_right_sidebar: bool,
@@ -328,6 +352,9 @@ pub struct AlacritreeApp {
     /// Fuzzy-search query and `m`/`d`/`u` change-kind toggle state for the git
     /// panel.  Transient: never persisted.
     git_filter: PanelFilter,
+    /// `[ui] search_scope`: whether a live query stands down both panels'
+    /// toggle filters.  Toggled at runtime, never persisted.
+    search_scope: SearchScope,
     /// Git-panel cursor, identified by `(section, path)`.  Rebuilt every render
     /// pass from `git_rows`, so it survives the 1.5 s status refresh.
     git_cursor: Option<git_nav::GitRow>,
@@ -676,6 +703,7 @@ impl AlacritreeApp {
             sidebar_cursor_moved: false,
             project_filter: PanelFilter::new(&['s', 'a']),
             git_filter: PanelFilter::new(&['m', 'd', 'u']),
+            search_scope: config.ui.search_scope,
             git_cursor: None,
             git_cursor_moved: false,
             git_rows: Vec::new(),
@@ -1754,8 +1782,9 @@ impl AlacritreeApp {
             return sidebar_nav::visible_rows(&self.projects, &listed_sessions);
         }
 
-        let toggle_sessions = self.project_filter.is_toggled('s');
-        let toggle_attention = self.project_filter.is_toggled('a');
+        let apply = self.project_filter.toggles_apply(self.search_scope);
+        let toggle_sessions = apply && self.project_filter.is_toggled('s');
+        let toggle_attention = apply && self.project_filter.is_toggled('a');
         let any_toggle = toggle_sessions || toggle_attention;
 
         // Precompute every fuzzy result before building the closures: the
@@ -1779,8 +1808,13 @@ impl AlacritreeApp {
         };
 
         let toggles_pass = |key: &WorkspaceKey| {
-            (!toggle_sessions || self.workspace_has_sessions(key))
-                && (!toggle_attention || self.workspace_needs_attention(key))
+            project_toggles_pass(
+                apply,
+                toggle_sessions,
+                self.workspace_has_sessions(key),
+                toggle_attention,
+                self.workspace_needs_attention(key),
+            )
         };
         let home = home_matches && toggles_pass(&None);
         let project_self =
@@ -1832,7 +1866,7 @@ impl AlacritreeApp {
                 session_rows_always: self.session_rows_always,
                 query: self.project_filter.query(),
                 toggles: self.project_filter.toggle_bits(),
-                toggles_apply: true,
+                toggles_apply: self.project_filter.toggles_apply(self.search_scope),
                 pr_generation: 0,
                 active_workspace,
                 active_branch,
@@ -1879,7 +1913,7 @@ impl AlacritreeApp {
                         session_rows_always: self.session_rows_always,
                         query: self.project_filter.query(),
                         toggles: self.project_filter.toggle_bits(),
-                        toggles_apply: true,
+                        toggles_apply: self.project_filter.toggles_apply(self.search_scope),
                         pr_generation: 0,
                         active_workspace,
                         active_branch,
@@ -2150,15 +2184,11 @@ impl AlacritreeApp {
     /// toggles union (`m`: Modified/Renamed, `d`: Deleted, `u`: Untracked/Added).
     /// Conflicted rows and the branch-diff section are handled by `visible_rows`.
     fn filtered_git_rows(&mut self, status: &GitStatus) -> git_nav::GitRows {
-        let m = self.git_filter.is_toggled('m');
-        let d = self.git_filter.is_toggled('d');
-        let u = self.git_filter.is_toggled('u');
-        let any = m || d || u;
-        let kind_pass = move |k: ChangeKind| {
-            !any || (m && matches!(k, ChangeKind::Modified | ChangeKind::Renamed))
-                || (d && k == ChangeKind::Deleted)
-                || (u && matches!(k, ChangeKind::Untracked | ChangeKind::Added))
-        };
+        let apply = self.git_filter.toggles_apply(self.search_scope);
+        let m = apply && self.git_filter.is_toggled('m');
+        let d = apply && self.git_filter.is_toggled('d');
+        let u = apply && self.git_filter.is_toggled('u');
+        let kind_pass = move |k: ChangeKind| git_toggles_pass(m, d, u, k);
         let filter = &mut self.git_filter;
         let mut query_pass = |path: &str| filter.matches(path);
         git_nav::visible_rows(
@@ -2530,7 +2560,12 @@ impl AlacritreeApp {
                 self.git_filter.clear_toggles();
                 self.after_git_filter_changed();
             },
-            BindingAction::Named(NamedAction::ToggleSearchScope) => {},
+            BindingAction::Named(NamedAction::ToggleSearchScope) => {
+                self.search_scope = match self.search_scope {
+                    SearchScope::Filtered => SearchScope::All,
+                    SearchScope::All => SearchScope::Filtered,
+                };
+            },
             BindingAction::Named(NamedAction::RefreshPrStatus) => {},
             BindingAction::Named(other) => {
                 self.dispatch_scroll_or_other(other);
@@ -3088,6 +3123,7 @@ impl AlacritreeApp {
                         &self.project_filter,
                         &self.config.ui.icons.search,
                         &theme,
+                        self.project_filter.toggles_apply(self.search_scope),
                     );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         if icon_button(ui, "+", theme.text_dim, &theme)
@@ -3624,6 +3660,7 @@ impl AlacritreeApp {
                         &self.git_filter,
                         &self.config.ui.icons.search,
                         &theme,
+                        self.git_filter.toggles_apply(self.search_scope),
                     );
                 });
                 ui.separator();
@@ -5071,10 +5108,12 @@ fn panel_header_filter_ui(
     filter: &PanelFilter,
     search_icon: &str,
     theme: &Theme,
+    toggles_apply: bool,
 ) {
     ui.label(RichText::new(title).color(theme.text).strong());
+    let chip = if toggles_apply { theme.accent } else { theme.text_muted };
     for key in filter.active_toggles() {
-        ui.label(RichText::new(format!("[{key}]")).color(theme.accent).monospace().small());
+        ui.label(RichText::new(format!("[{key}]")).color(chip).monospace().small());
     }
     if filter.mode() == panel_filter::Mode::Search || !filter.query().is_empty() {
         let s = theme.ui_scale;
@@ -8567,6 +8606,22 @@ mod tests {
         let action = BindingAction::Named(NamedAction::ScrollPageUp);
         assert!(!valid_for_focus(&action, false, false, true));
         assert!(valid_for_focus(&action, false, false, false));
+    }
+
+    #[test]
+    fn a_wide_search_stands_down_the_project_toggles() {
+        // Toggled on, workspace fails both: excluded while the toggles apply,
+        // included once a wide search stands them down.
+        assert!(!project_toggles_pass(true, true, false, true, false));
+        assert!(project_toggles_pass(false, true, false, true, false));
+    }
+
+    #[test]
+    fn a_wide_search_stands_down_the_git_toggles() {
+        // Toggled on for "modified" only, an untracked row fails while the
+        // toggle applies and passes once a wide search stands it down.
+        assert!(!git_toggles_pass(true, false, false, ChangeKind::Untracked));
+        assert!(git_toggles_pass(false, false, false, ChangeKind::Untracked));
     }
 
     fn req(file: &str, source: DiffSource) -> DiffRequest {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -370,9 +370,12 @@ fn worktree_pr_passes(any_pr: bool, pr_matches: &HashMap<PathBuf, bool>, path: &
     !any_pr || pr_matches.get(path).copied().unwrap_or(false)
 }
 
-/// Whether the projects panel is filtering on PR state this frame.
-fn any_pr_toggle_active(filter: &PanelFilter) -> bool {
-    ['o', 'd', 'm', 'c'].into_iter().any(|key| filter.is_toggled(key))
+/// Whether the projects panel is filtering on PR state this frame.  A toggle
+/// the scope has stood down narrows nothing, so it must not pull the cache
+/// generation into the reconciler or reach `gh` for a collapsed project.
+fn any_pr_toggle_active(filter: &PanelFilter, scope: SearchScope) -> bool {
+    filter.toggles_apply(scope)
+        && ['o', 'd', 'm', 'c'].into_iter().any(|key| filter.is_toggled(key))
 }
 
 /// The cache generation the reconciler observes.  Held at `0` unless a PR
@@ -1916,19 +1919,25 @@ impl AlacritreeApp {
             .and_then(|p| self.git_status.get(p))
             .and_then(|c| c.current_branch());
         let current_workspace = self.current_workspace.as_deref();
-        let pr_matches: HashMap<PathBuf, bool> = self
-            .projects
-            .iter()
-            .flat_map(|p| p.worktrees.iter())
-            .map(|wt| {
-                let branch = pr_status::effective_branch(wt, current_workspace, live_branch);
-                let state = self.pr_cache.state(&wt.path, branch);
-                (
-                    wt.path.clone(),
-                    pr_status::pr_pass(state, pr_open, pr_draft, pr_merged, pr_closed),
-                )
-            })
-            .collect();
+        // Skipped outright while the PR dimension is inert: `worktree_pr_passes`
+        // would not read the map, and building it costs a path clone per
+        // worktree on a call that runs whenever the panel is filtering at all.
+        let pr_matches: HashMap<PathBuf, bool> = if any_pr {
+            self.projects
+                .iter()
+                .flat_map(|p| p.worktrees.iter())
+                .map(|wt| {
+                    let branch = pr_status::effective_branch(wt, current_workspace, live_branch);
+                    let state = self.pr_cache.state(&wt.path, branch);
+                    (
+                        wt.path.clone(),
+                        pr_status::pr_pass(state, pr_open, pr_draft, pr_merged, pr_closed),
+                    )
+                })
+                .collect()
+        } else {
+            HashMap::new()
+        };
 
         let toggles_pass = |key: &WorkspaceKey| {
             project_toggles_pass(
@@ -1993,7 +2002,7 @@ impl AlacritreeApp {
                 toggles_apply: self.project_filter.toggles_apply(self.search_scope),
                 pr_generation: pr_generation_for(
                     self.pr_cache.generation(),
-                    any_pr_toggle_active(&self.project_filter),
+                    any_pr_toggle_active(&self.project_filter, self.search_scope),
                 ),
                 active_workspace,
                 active_branch,
@@ -2043,7 +2052,7 @@ impl AlacritreeApp {
                         toggles_apply: self.project_filter.toggles_apply(self.search_scope),
                         pr_generation: pr_generation_for(
                             self.pr_cache.generation(),
-                            any_pr_toggle_active(&self.project_filter),
+                            any_pr_toggle_active(&self.project_filter, self.search_scope),
                         ),
                         active_workspace,
                         active_branch,
@@ -3169,7 +3178,7 @@ impl AlacritreeApp {
         // Polled up front: the panel closure borrows `projects` mutably, so the
         // cache cannot be polled from inside it.
         let pr_enabled = self.config.ui.pr_status;
-        let any_pr_toggle = any_pr_toggle_active(&self.project_filter);
+        let any_pr_toggle = any_pr_toggle_active(&self.project_filter, self.search_scope);
         let current_workspace = self.current_workspace.as_deref();
         let live_branch = current_workspace
             .and_then(|p| self.git_status.get(p))
@@ -9489,11 +9498,28 @@ mod tests {
     #[test]
     fn any_pr_toggle_active_ignores_the_non_pr_identities() {
         let mut f = PanelFilter::new(project_filter_toggles(true));
-        assert!(!any_pr_toggle_active(&f));
+        assert!(!any_pr_toggle_active(&f, SearchScope::Filtered));
         f.toggle('s');
-        assert!(!any_pr_toggle_active(&f), "a session toggle is not a PR toggle");
+        assert!(
+            !any_pr_toggle_active(&f, SearchScope::Filtered),
+            "a session toggle is not a PR toggle"
+        );
         f.toggle('o');
-        assert!(any_pr_toggle_active(&f));
+        assert!(any_pr_toggle_active(&f, SearchScope::Filtered));
+    }
+
+    /// A search under `All` stands the toggles down for row selection, so the
+    /// PR dimension narrows nothing — polling collapsed projects for it and
+    /// rebuilding on every banked result would both be pure cost.
+    #[test]
+    fn a_stood_down_pr_toggle_does_not_read_as_active() {
+        let mut f = PanelFilter::new(project_filter_toggles(true));
+        f.toggle('o');
+        f.on_text("/");
+        f.on_text("a");
+
+        assert!(any_pr_toggle_active(&f, SearchScope::Filtered));
+        assert!(!any_pr_toggle_active(&f, SearchScope::All));
     }
 
     /// The reconciler must not churn for users who never touch a PR filter:

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -325,6 +325,21 @@ fn project_filter_toggles(pr_status: bool) -> &'static [char] {
     if pr_status { &['s', 'a', 'o', 'd', 'm', 'c'] } else { &['s', 'a'] }
 }
 
+/// Whether any toggle dimension narrows the projects panel this frame —
+/// session presence, attention, or PR state. `project_self` falls back to
+/// plain fuzzy matching only when this is false.
+fn any_project_toggle_active(toggle_sessions: bool, toggle_attention: bool, any_pr: bool) -> bool {
+    toggle_sessions || toggle_attention || any_pr
+}
+
+/// Whether a worktree survives the projects panel's PR dimension. Inert
+/// when no PR toggle is active, so a worktree passes regardless of what
+/// `pr_matches` holds for it. Once a PR toggle is active, a worktree
+/// missing from `pr_matches` is excluded — its PR lookup hasn't landed.
+fn worktree_pr_passes(any_pr: bool, pr_matches: &HashMap<PathBuf, bool>, path: &Path) -> bool {
+    !any_pr || pr_matches.get(path).copied().unwrap_or(false)
+}
+
 /// Whether the projects panel is filtering on PR state this frame.
 fn any_pr_toggle_active(filter: &PanelFilter) -> bool {
     ['o', 'd', 'm', 'c'].into_iter().any(|key| filter.is_toggled(key))
@@ -1821,7 +1836,7 @@ impl AlacritreeApp {
         let pr_merged = apply && self.project_filter.is_toggled('m');
         let pr_closed = apply && self.project_filter.is_toggled('c');
         let any_pr = pr_open || pr_draft || pr_merged || pr_closed;
-        let any_toggle = toggle_sessions || toggle_attention || any_pr;
+        let any_toggle = any_project_toggle_active(toggle_sessions, toggle_attention, any_pr);
 
         // Precompute every fuzzy result before building the closures: the
         // matcher needs `&mut self.project_filter`, and releasing that borrow
@@ -1877,7 +1892,7 @@ impl AlacritreeApp {
         let mut worktree = |_p: &Project, wt: &Worktree| {
             worktree_matches.get(&wt.path).copied().unwrap_or(false)
                 && toggles_pass(&Some(wt.path.clone()))
-                && pr_matches.get(&wt.path).copied().unwrap_or(false)
+                && worktree_pr_passes(any_pr, &pr_matches, &wt.path)
         };
         sidebar_nav::filtered_rows(
             &self.projects,
@@ -8697,6 +8712,37 @@ mod tests {
         // toggle applies and passes once a wide search stands it down.
         assert!(!git_toggles_pass(true, false, false, ChangeKind::Untracked));
         assert!(git_toggles_pass(false, false, false, ChangeKind::Untracked));
+    }
+
+    #[test]
+    fn a_pr_toggle_alone_makes_any_toggle_active() {
+        assert!(!any_project_toggle_active(false, false, false));
+        assert!(any_project_toggle_active(false, false, true));
+    }
+
+    #[test]
+    fn worktree_pr_passes_is_inert_without_a_pr_toggle() {
+        let path = PathBuf::from("/worktree");
+        let mut pr_matches = HashMap::new();
+        pr_matches.insert(path.clone(), false);
+        assert!(worktree_pr_passes(false, &pr_matches, &path));
+    }
+
+    #[test]
+    fn worktree_pr_passes_follows_the_map_once_a_pr_toggle_is_active() {
+        let path = PathBuf::from("/worktree");
+        let mut pr_matches = HashMap::new();
+        pr_matches.insert(path.clone(), true);
+        assert!(worktree_pr_passes(true, &pr_matches, &path));
+        pr_matches.insert(path.clone(), false);
+        assert!(!worktree_pr_passes(true, &pr_matches, &path));
+    }
+
+    #[test]
+    fn worktree_pr_passes_excludes_a_worktree_missing_from_the_map() {
+        let path = PathBuf::from("/worktree");
+        let pr_matches: HashMap<PathBuf, bool> = HashMap::new();
+        assert!(!worktree_pr_passes(true, &pr_matches, &path));
     }
 
     fn req(file: &str, source: DiffSource) -> DiffRequest {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -262,7 +262,7 @@ fn focus_move(
     origin: ActionOrigin,
     tui_running: bool,
 ) -> FocusMove {
-    if origin == ActionOrigin::Keyboard && focus == PaneFocus::Terminal && tui_running {
+    if origin != ActionOrigin::Ipc && focus == PaneFocus::Terminal && tui_running {
         return FocusMove::Passthrough;
     }
     let target = match (focus, dir) {
@@ -8416,6 +8416,23 @@ mod tests {
     fn running_tui_keeps_the_key() {
         assert_eq!(mv(PaneFocus::Terminal, FocusDir::Left, true), FocusMove::Passthrough);
         assert_eq!(mv(PaneFocus::Terminal, FocusDir::Right, true), FocusMove::Passthrough);
+    }
+
+    /// A palette-dispatched Focus Left/Right is a binding stand-in, so a
+    /// running TUI must see the same passthrough a real keypress would.
+    #[test]
+    fn palette_origin_keeps_the_key_for_a_running_tui() {
+        assert_eq!(
+            focus_move(
+                PaneFocus::Terminal,
+                FocusDir::Left,
+                true,
+                true,
+                ActionOrigin::Palette,
+                true
+            ),
+            FocusMove::Passthrough
+        );
     }
 
     #[test]

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -325,6 +325,36 @@ fn project_filter_toggles(pr_status: bool) -> &'static [char] {
     if pr_status { &['s', 'a', 'o', 'd', 'm', 'c'] } else { &['s', 'a'] }
 }
 
+/// The toggle identities the git panel accepts: modified, deleted, untracked.
+const GIT_FILTER_TOGGLES: &[char] = &['m', 'd', 'u'];
+
+/// The projects-panel toggle a named action flips, or `None` for an action that
+/// is not one of its filters.  `PanelFilter::toggle` ignores an identity it does
+/// not allow and dispatch falls through on an unmatched action, so nothing at
+/// the call site can catch a wrong pairing — assert it here instead.
+fn project_filter_identity(action: NamedAction) -> Option<char> {
+    match action {
+        NamedAction::ToggleSessionsFilter => Some('s'),
+        NamedAction::ToggleAttentionFilter => Some('a'),
+        NamedAction::TogglePrOpenFilter => Some('o'),
+        NamedAction::TogglePrDraftFilter => Some('d'),
+        NamedAction::TogglePrMergedFilter => Some('m'),
+        NamedAction::TogglePrClosedFilter => Some('c'),
+        _ => None,
+    }
+}
+
+/// The git-panel toggle a named action flips, or `None` for an action that is
+/// not one of its filters.
+fn git_filter_identity(action: NamedAction) -> Option<char> {
+    match action {
+        NamedAction::ToggleModifiedFilter => Some('m'),
+        NamedAction::ToggleDeletedFilter => Some('d'),
+        NamedAction::ToggleUntrackedFilter => Some('u'),
+        _ => None,
+    }
+}
+
 /// Whether any toggle dimension narrows the projects panel this frame —
 /// session presence, attention, or PR state. `project_self` falls back to
 /// plain fuzzy matching only when this is false.
@@ -767,7 +797,7 @@ impl AlacritreeApp {
             sidebar_auto_shown: false,
             sidebar_cursor_moved: false,
             project_filter: PanelFilter::new(project_filter_toggles(config.ui.pr_status)),
-            git_filter: PanelFilter::new(&['m', 'd', 'u']),
+            git_filter: PanelFilter::new(GIT_FILTER_TOGGLES),
             search_scope: config.ui.search_scope,
             git_cursor: None,
             git_cursor_moved: false,
@@ -2623,38 +2653,8 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::SidebarSearchCancelToTerminal) => {
                 self.sidebar_search_cancel_to_terminal();
             },
-            BindingAction::Named(NamedAction::ToggleSessionsFilter) => {
-                self.project_filter.toggle('s');
-            },
-            BindingAction::Named(NamedAction::ToggleAttentionFilter) => {
-                self.project_filter.toggle('a');
-            },
-            BindingAction::Named(NamedAction::TogglePrOpenFilter) => {
-                self.project_filter.toggle('o');
-            },
-            BindingAction::Named(NamedAction::TogglePrDraftFilter) => {
-                self.project_filter.toggle('d');
-            },
-            BindingAction::Named(NamedAction::TogglePrMergedFilter) => {
-                self.project_filter.toggle('m');
-            },
-            BindingAction::Named(NamedAction::TogglePrClosedFilter) => {
-                self.project_filter.toggle('c');
-            },
             BindingAction::Named(NamedAction::ClearProjectFilters) => {
                 self.project_filter.clear_toggles();
-            },
-            BindingAction::Named(NamedAction::ToggleModifiedFilter) => {
-                self.git_filter.toggle('m');
-                self.after_git_filter_changed();
-            },
-            BindingAction::Named(NamedAction::ToggleDeletedFilter) => {
-                self.git_filter.toggle('d');
-                self.after_git_filter_changed();
-            },
-            BindingAction::Named(NamedAction::ToggleUntrackedFilter) => {
-                self.git_filter.toggle('u');
-                self.after_git_filter_changed();
             },
             BindingAction::Named(NamedAction::ClearGitFilters) => {
                 self.git_filter.clear_toggles();
@@ -2674,7 +2674,14 @@ impl AlacritreeApp {
                 ctx.request_repaint();
             },
             BindingAction::Named(other) => {
-                self.dispatch_scroll_or_other(other);
+                if let Some(key) = project_filter_identity(other) {
+                    self.project_filter.toggle(key);
+                } else if let Some(key) = git_filter_identity(other) {
+                    self.git_filter.toggle(key);
+                    self.after_git_filter_changed();
+                } else {
+                    self.dispatch_scroll_or_other(other);
+                }
             },
             BindingAction::Unsupported(name) => {
                 log::debug!("unsupported keyboard binding action: {name}");
@@ -9404,6 +9411,61 @@ mod tests {
             snapshot.is_projected(below),
             "a row below the one being deleted must still be navigable"
         );
+    }
+
+    /// Dispatch cannot catch a wrong pairing: `toggle` drops an identity the
+    /// panel does not allow, and an action with no arm falls through to the
+    /// scroll handler.  Swapping two identities here is otherwise invisible.
+    #[test]
+    fn the_projects_filter_actions_map_to_their_identities() {
+        for (action, identity) in [
+            (NamedAction::ToggleSessionsFilter, Some('s')),
+            (NamedAction::ToggleAttentionFilter, Some('a')),
+            (NamedAction::TogglePrOpenFilter, Some('o')),
+            (NamedAction::TogglePrDraftFilter, Some('d')),
+            (NamedAction::TogglePrMergedFilter, Some('m')),
+            (NamedAction::TogglePrClosedFilter, Some('c')),
+            (NamedAction::ClearProjectFilters, None),
+            (NamedAction::ToggleModifiedFilter, None),
+            (NamedAction::ToggleDeletedFilter, None),
+            (NamedAction::ToggleUntrackedFilter, None),
+            (NamedAction::ToggleSearchScope, None),
+            (NamedAction::RefreshPrStatus, None),
+            (NamedAction::Paste, None),
+        ] {
+            assert_eq!(project_filter_identity(action), identity, "{action:?}");
+            if let Some(key) = identity {
+                assert!(
+                    project_filter_toggles(true).contains(&key),
+                    "{action:?} maps to {key}, which the panel would drop"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_git_filter_actions_map_to_their_identities() {
+        for (action, identity) in [
+            (NamedAction::ToggleModifiedFilter, Some('m')),
+            (NamedAction::ToggleDeletedFilter, Some('d')),
+            (NamedAction::ToggleUntrackedFilter, Some('u')),
+            (NamedAction::ClearGitFilters, None),
+            (NamedAction::ToggleSessionsFilter, None),
+            (NamedAction::ToggleAttentionFilter, None),
+            (NamedAction::TogglePrOpenFilter, None),
+            (NamedAction::TogglePrDraftFilter, None),
+            (NamedAction::TogglePrMergedFilter, None),
+            (NamedAction::TogglePrClosedFilter, None),
+            (NamedAction::Paste, None),
+        ] {
+            assert_eq!(git_filter_identity(action), identity, "{action:?}");
+            if let Some(key) = identity {
+                assert!(
+                    GIT_FILTER_TOGGLES.contains(&key),
+                    "{action:?} maps to {key}, which the panel would drop"
+                );
+            }
+        }
     }
 
     #[test]

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -144,6 +144,29 @@ pub enum NamedAction {
     SidebarSearchCancel,
     /// Cancel the focused sidebar's fuzzy search and return focus to the terminal.
     SidebarSearchCancelToTerminal,
+    /// Narrow the projects sidebar to workspaces with a live session.
+    ToggleSessionsFilter,
+    /// Narrow the projects sidebar to workspaces whose session wants attention.
+    ToggleAttentionFilter,
+    /// PR-state filters.  One dimension: the active states union, and the
+    /// result ANDs with the session and attention filters.
+    TogglePrOpenFilter,
+    TogglePrDraftFilter,
+    TogglePrMergedFilter,
+    TogglePrClosedFilter,
+    /// Drop every projects-sidebar toggle.  Reachable without knowing which are
+    /// set, which `Esc` cannot offer a caller that has no view of the state.
+    ClearProjectFilters,
+    /// Git sidebar change-kind filters.  The active kinds union.
+    ToggleModifiedFilter,
+    ToggleDeletedFilter,
+    ToggleUntrackedFilter,
+    ClearGitFilters,
+    /// Switch between a query confined by the active toggles and one evaluated
+    /// against every row.  Session-only; restarting returns to `[ui] search_scope`.
+    ToggleSearchScope,
+    /// Re-query `gh` for every cached worktree.
+    RefreshPrStatus,
 }
 
 impl NamedAction {
@@ -162,6 +185,7 @@ impl NamedAction {
                 | Self::DeleteSelected
                 | Self::RenameSelected
                 | Self::ToggleProjectExpanded
+                | Self::RefreshPrStatus
         )
     }
 
@@ -176,6 +200,34 @@ impl NamedAction {
                 | Self::DeleteSelected
                 | Self::RenameSelected
                 | Self::ToggleProjectExpanded
+        )
+    }
+
+    /// Valid only while the projects sidebar owns focus: the default triggers
+    /// are bare letters that belong to the PTY anywhere else.  No mode
+    /// component is needed — a letter typed into the search box never reaches
+    /// the binding table, because its text is swallowed first.
+    pub fn is_projects_filter_scoped(&self) -> bool {
+        matches!(
+            self,
+            Self::ToggleSessionsFilter
+                | Self::ToggleAttentionFilter
+                | Self::TogglePrOpenFilter
+                | Self::TogglePrDraftFilter
+                | Self::TogglePrMergedFilter
+                | Self::TogglePrClosedFilter
+                | Self::ClearProjectFilters
+        )
+    }
+
+    /// The git sidebar's equivalent.
+    pub fn is_git_filter_scoped(&self) -> bool {
+        matches!(
+            self,
+            Self::ToggleModifiedFilter
+                | Self::ToggleDeletedFilter
+                | Self::ToggleUntrackedFilter
+                | Self::ClearGitFilters
         )
     }
 
@@ -308,6 +360,23 @@ impl NamedAction {
             Self::SidebarSearchCancelToTerminal => {
                 "Cancel the sidebar search and focus the terminal".into()
             },
+            Self::ToggleSessionsFilter => "Filter the sidebar to workspaces with a session".into(),
+            Self::ToggleAttentionFilter => {
+                "Filter the sidebar to workspaces wanting attention".into()
+            },
+            Self::TogglePrOpenFilter => "Filter the sidebar to worktrees with an open PR".into(),
+            Self::TogglePrDraftFilter => "Filter the sidebar to worktrees with a draft PR".into(),
+            Self::TogglePrMergedFilter => "Filter the sidebar to worktrees with a merged PR".into(),
+            Self::TogglePrClosedFilter => "Filter the sidebar to worktrees with a closed PR".into(),
+            Self::ClearProjectFilters => "Clear every projects-sidebar filter".into(),
+            Self::ToggleModifiedFilter => "Filter git changes to modified and renamed files".into(),
+            Self::ToggleDeletedFilter => "Filter git changes to deleted files".into(),
+            Self::ToggleUntrackedFilter => "Filter git changes to untracked and added files".into(),
+            Self::ClearGitFilters => "Clear every git-sidebar filter".into(),
+            Self::ToggleSearchScope => {
+                "Search inside the active filters or across every row".into()
+            },
+            Self::RefreshPrStatus => "Re-query GitHub for every worktree's PR".into(),
             Self::NoOp | Self::ReceiveChar => String::new(),
         }
     }
@@ -482,6 +551,31 @@ fn default_bindings() -> Vec<KeyBinding> {
             key: Key::O,
             mods: Modifiers::NONE,
             action: BindingAction::Named(ToggleProjectExpanded),
+        },
+        KeyBinding {
+            key: Key::S,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(ToggleSessionsFilter),
+        },
+        KeyBinding {
+            key: Key::A,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(ToggleAttentionFilter),
+        },
+        KeyBinding {
+            key: Key::M,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(ToggleModifiedFilter),
+        },
+        KeyBinding {
+            key: Key::D,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(ToggleDeletedFilter),
+        },
+        KeyBinding {
+            key: Key::U,
+            mods: Modifiers::NONE,
+            action: BindingAction::Named(ToggleUntrackedFilter),
         },
         KeyBinding { key: Key::K, mods: ctrl, action: BindingAction::Named(TogglePalette) },
         KeyBinding { key: Key::G, mods: ctrl_shift, action: BindingAction::Named(FocusGitSidebar) },
@@ -892,6 +986,19 @@ pub fn parse_action(name: &str) -> BindingAction {
         "SidebarSearchConfirm" => BindingAction::Named(SidebarSearchConfirm),
         "SidebarSearchCancel" => BindingAction::Named(SidebarSearchCancel),
         "SidebarSearchCancelToTerminal" => BindingAction::Named(SidebarSearchCancelToTerminal),
+        "ToggleSessionsFilter" => BindingAction::Named(ToggleSessionsFilter),
+        "ToggleAttentionFilter" => BindingAction::Named(ToggleAttentionFilter),
+        "TogglePrOpenFilter" => BindingAction::Named(TogglePrOpenFilter),
+        "TogglePrDraftFilter" => BindingAction::Named(TogglePrDraftFilter),
+        "TogglePrMergedFilter" => BindingAction::Named(TogglePrMergedFilter),
+        "TogglePrClosedFilter" => BindingAction::Named(TogglePrClosedFilter),
+        "ClearProjectFilters" => BindingAction::Named(ClearProjectFilters),
+        "ToggleModifiedFilter" => BindingAction::Named(ToggleModifiedFilter),
+        "ToggleDeletedFilter" => BindingAction::Named(ToggleDeletedFilter),
+        "ToggleUntrackedFilter" => BindingAction::Named(ToggleUntrackedFilter),
+        "ClearGitFilters" => BindingAction::Named(ClearGitFilters),
+        "ToggleSearchScope" => BindingAction::Named(ToggleSearchScope),
+        "RefreshPrStatus" => BindingAction::Named(RefreshPrStatus),
         other => BindingAction::Unsupported(other.to_string()),
     }
 }
@@ -1537,5 +1644,130 @@ mod tests {
             parse_action("OpenScratchpad"),
             BindingAction::Named(NamedAction::OpenScratchpad)
         ));
+    }
+
+    const PROJECT_FILTER_ACTIONS: [NamedAction; 7] = [
+        NamedAction::ToggleSessionsFilter,
+        NamedAction::ToggleAttentionFilter,
+        NamedAction::TogglePrOpenFilter,
+        NamedAction::TogglePrDraftFilter,
+        NamedAction::TogglePrMergedFilter,
+        NamedAction::TogglePrClosedFilter,
+        NamedAction::ClearProjectFilters,
+    ];
+
+    const GIT_FILTER_ACTIONS: [NamedAction; 4] = [
+        NamedAction::ToggleModifiedFilter,
+        NamedAction::ToggleDeletedFilter,
+        NamedAction::ToggleUntrackedFilter,
+        NamedAction::ClearGitFilters,
+    ];
+
+    #[test]
+    fn every_new_action_round_trips_and_is_described() {
+        let mut all = PROJECT_FILTER_ACTIONS.to_vec();
+        all.extend(GIT_FILTER_ACTIONS);
+        all.push(NamedAction::ToggleSearchScope);
+        all.push(NamedAction::RefreshPrStatus);
+        for a in all {
+            let name = a.config_name();
+            assert!(
+                matches!(parse_action(&name), BindingAction::Named(p) if p == a),
+                "{name} does not parse back"
+            );
+            assert!(!a.description().is_empty(), "{name} has no description");
+        }
+    }
+
+    #[test]
+    fn filter_actions_are_scoped_to_their_own_panel() {
+        for a in PROJECT_FILTER_ACTIONS {
+            assert!(a.is_projects_filter_scoped(), "{a:?}");
+            assert!(!a.is_git_filter_scoped(), "{a:?}");
+        }
+        for a in GIT_FILTER_ACTIONS {
+            assert!(a.is_git_filter_scoped(), "{a:?}");
+            assert!(!a.is_projects_filter_scoped(), "{a:?}");
+        }
+    }
+
+    /// The filter actions own their own focus predicates and must not leak into
+    /// the ones that already gate other dispatch paths.
+    #[test]
+    fn filter_actions_carry_no_other_scope() {
+        let mut all = PROJECT_FILTER_ACTIONS.to_vec();
+        all.extend(GIT_FILTER_ACTIONS);
+        for a in all {
+            assert!(!a.is_sidebar_scoped(), "{a:?}");
+            assert!(!a.is_search_scoped(), "{a:?}");
+            assert!(!a.is_palette_scoped(), "{a:?}");
+            assert!(!a.requires_project_browsing(), "{a:?}");
+        }
+    }
+
+    #[test]
+    fn refresh_pr_status_is_sidebar_scoped_and_toggle_search_scope_is_unscoped() {
+        assert!(NamedAction::RefreshPrStatus.is_sidebar_scoped());
+        assert!(!NamedAction::RefreshPrStatus.requires_project_browsing());
+        assert!(!NamedAction::ToggleSearchScope.is_sidebar_scoped());
+        assert!(!NamedAction::ToggleSearchScope.is_projects_filter_scoped());
+        assert!(!NamedAction::ToggleSearchScope.is_git_filter_scoped());
+    }
+
+    /// The five filters that exist today keep their keys; the four PR filters
+    /// introduce no new bare-letter default for anyone.
+    #[test]
+    fn default_bindings_cover_the_existing_filters_and_no_pr_filter() {
+        let binds = parse_bindings(vec![]);
+        let bound = |a: NamedAction| {
+            binds.iter().find(|b| matches!(&b.action, BindingAction::Named(n) if *n == a))
+        };
+        for (key, action) in [
+            (Key::S, NamedAction::ToggleSessionsFilter),
+            (Key::A, NamedAction::ToggleAttentionFilter),
+            (Key::M, NamedAction::ToggleModifiedFilter),
+            (Key::D, NamedAction::ToggleDeletedFilter),
+            (Key::U, NamedAction::ToggleUntrackedFilter),
+        ] {
+            let b = bound(action).unwrap_or_else(|| panic!("{action:?} has no default"));
+            assert_eq!(b.key, key);
+            assert_eq!(b.mods, Modifiers::NONE);
+        }
+        for a in [
+            NamedAction::TogglePrOpenFilter,
+            NamedAction::TogglePrDraftFilter,
+            NamedAction::TogglePrMergedFilter,
+            NamedAction::TogglePrClosedFilter,
+            NamedAction::RefreshPrStatus,
+            NamedAction::ToggleSearchScope,
+        ] {
+            assert!(bound(a).is_none(), "{a:?} must ship without a default key");
+        }
+    }
+
+    /// Two user bindings on one trigger both survive and both come back from
+    /// `all_matches`, which is how a user who claimed a letter recovers the
+    /// default it displaced. Only the *default* is dropped.
+    #[test]
+    fn two_user_bindings_on_one_trigger_both_survive() {
+        let raw = |action: &str| RawBinding {
+            key: "D".into(),
+            mods: None,
+            mode: None,
+            chars: None,
+            action: Some(action.into()),
+            command: None,
+        };
+        let binds = parse_bindings(vec![raw("DeleteSelected"), raw("ToggleDeletedFilter")]);
+
+        let matched: Vec<_> = all_matches(&binds, Key::D, Modifiers::NONE);
+        assert!(
+            matched.iter().any(|a| matches!(a, BindingAction::Named(NamedAction::DeleteSelected)))
+        );
+        assert!(
+            matched
+                .iter()
+                .any(|a| matches!(a, BindingAction::Named(NamedAction::ToggleDeletedFilter)))
+        );
     }
 }

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -364,15 +364,23 @@ impl NamedAction {
             Self::ToggleAttentionFilter => {
                 "Filter the sidebar to workspaces wanting attention".into()
             },
-            Self::TogglePrOpenFilter => "Filter the sidebar to worktrees with an open PR".into(),
-            Self::TogglePrDraftFilter => "Filter the sidebar to worktrees with a draft PR".into(),
-            Self::TogglePrMergedFilter => "Filter the sidebar to worktrees with a merged PR".into(),
-            Self::TogglePrClosedFilter => "Filter the sidebar to worktrees with a closed PR".into(),
-            Self::ClearProjectFilters => "Clear every projects-sidebar filter".into(),
+            Self::TogglePrOpenFilter => {
+                "Filter to worktrees with an open PR (requires [ui] pr_status)".into()
+            },
+            Self::TogglePrDraftFilter => {
+                "Filter to worktrees with a draft PR (requires [ui] pr_status)".into()
+            },
+            Self::TogglePrMergedFilter => {
+                "Filter to worktrees with a merged PR (requires [ui] pr_status)".into()
+            },
+            Self::TogglePrClosedFilter => {
+                "Filter to worktrees with a closed PR (requires [ui] pr_status)".into()
+            },
+            Self::ClearProjectFilters => "Clear every projects-sidebar toggle".into(),
             Self::ToggleModifiedFilter => "Filter git changes to modified and renamed files".into(),
             Self::ToggleDeletedFilter => "Filter git changes to deleted files".into(),
             Self::ToggleUntrackedFilter => "Filter git changes to untracked and added files".into(),
-            Self::ClearGitFilters => "Clear every git-sidebar filter".into(),
+            Self::ClearGitFilters => "Clear every git-sidebar toggle".into(),
             Self::ToggleSearchScope => {
                 "Search inside the active filters or across every row".into()
             },

--- a/alacritree/src/bindings.rs
+++ b/alacritree/src/bindings.rs
@@ -165,6 +165,20 @@ impl NamedAction {
         )
     }
 
+    /// Sidebar-cursor actions whose meaning depends on the project panel
+    /// browsing rather than searching.  Narrower than `is_sidebar_scoped`: the
+    /// four cursor *moves* stay valid mid-query, because navigating filtered
+    /// results is the point of filtering.
+    pub fn requires_project_browsing(&self) -> bool {
+        matches!(
+            self,
+            Self::RefreshProjects
+                | Self::DeleteSelected
+                | Self::RenameSelected
+                | Self::ToggleProjectExpanded
+        )
+    }
+
     /// Actions whose keys should remain native text-editing input while the
     /// scratchpad owns focus. For example, Shift+Home selects to the start of
     /// a line in the editor instead of trying to scroll a terminal grid.
@@ -1401,6 +1415,27 @@ mod tests {
         }
         for a in [CloseSession, ScrollToTop, ScrollPageUp, ToggleSidebarFocus, Quit] {
             assert!(!a.is_sidebar_scoped(), "{a:?}");
+        }
+    }
+
+    /// Exactly the four actions that carry a browsing-mode guard at dispatch. It
+    /// must not be widened to `is_sidebar_scoped`, whose four extra actions run
+    /// from the palette during search today.
+    #[test]
+    fn requires_project_browsing_is_exactly_the_four_guarded_actions() {
+        use NamedAction::*;
+        for a in [RefreshProjects, DeleteSelected, RenameSelected, ToggleProjectExpanded] {
+            assert!(a.requires_project_browsing(), "{a:?}");
+        }
+        for a in [
+            SidebarTop,
+            SidebarBottom,
+            SidebarNextProject,
+            SidebarPreviousProject,
+            CloseSession,
+            Quit,
+        ] {
+            assert!(!a.requires_project_browsing(), "{a:?}");
         }
     }
 

--- a/alacritree/src/command_palette.rs
+++ b/alacritree/src/command_palette.rs
@@ -43,6 +43,7 @@ pub enum PaletteSection {
     Sessions,
     Workspaces,
     Sidebar,
+    Filters,
     Window,
     OpenSessions,
     SwitchWorkspace,
@@ -57,6 +58,7 @@ impl PaletteSection {
             Self::Sessions => "Sessions",
             Self::Workspaces => "Workspaces & projects",
             Self::Sidebar => "Sidebar & focus",
+            Self::Filters => "Filters",
             Self::Window => "Window & application",
             Self::OpenSessions => "Open sessions",
             Self::SwitchWorkspace => "Switch workspace",
@@ -86,6 +88,12 @@ fn section_of(a: NamedAction) -> PaletteSection {
         FocusProjectsSidebar | FocusGitSidebar | FocusTerminal => Sidebar,
         FocusLeft | FocusRight => Sidebar,
         SidebarSearchConfirm | SidebarSearchCancel | SidebarSearchCancelToTerminal => Sidebar,
+        ToggleSessionsFilter | ToggleAttentionFilter | ClearProjectFilters => Filters,
+        TogglePrOpenFilter | TogglePrDraftFilter => Filters,
+        TogglePrMergedFilter | TogglePrClosedFilter => Filters,
+        ToggleModifiedFilter | ToggleDeletedFilter => Filters,
+        ToggleUntrackedFilter | ClearGitFilters | ToggleSearchScope => Filters,
+        RefreshPrStatus => Sidebar,
         _ => Window,
     }
 }
@@ -215,7 +223,7 @@ pub fn group(items: &[PaletteItem], ranked: &[usize]) -> Vec<(PaletteSection, Ve
 /// Every simple (non-parametrized) `NamedAction`, kept in sync with the enum by
 /// hand. Mirrors the old shortcuts window's bindable list; `SelectTab`/
 /// `SpawnProfile` are excluded here because they carry an index.
-fn bindable_actions() -> [NamedAction; 50] {
+fn bindable_actions() -> [NamedAction; 63] {
     use NamedAction::*;
     [
         Paste,
@@ -268,6 +276,19 @@ fn bindable_actions() -> [NamedAction; 50] {
         SidebarSearchCancelToTerminal,
         Quit,
         TogglePalette,
+        ToggleSessionsFilter,
+        ToggleAttentionFilter,
+        TogglePrOpenFilter,
+        TogglePrDraftFilter,
+        TogglePrMergedFilter,
+        TogglePrClosedFilter,
+        ClearProjectFilters,
+        ToggleModifiedFilter,
+        ToggleDeletedFilter,
+        ToggleUntrackedFilter,
+        ClearGitFilters,
+        ToggleSearchScope,
+        RefreshPrStatus,
     ]
 }
 
@@ -546,5 +567,38 @@ mod tests {
         // Editing the query jumps back to the top match.
         palette.reseed(true, 2);
         assert_eq!(palette.selected(), 0);
+    }
+
+    #[test]
+    fn filter_actions_are_listed_under_their_own_section() {
+        let items = action_items(&parse_bindings(vec![]));
+        for name in [
+            "ToggleSessionsFilter",
+            "ToggleAttentionFilter",
+            "TogglePrOpenFilter",
+            "TogglePrDraftFilter",
+            "TogglePrMergedFilter",
+            "TogglePrClosedFilter",
+            "ClearProjectFilters",
+            "ToggleModifiedFilter",
+            "ToggleDeletedFilter",
+            "ToggleUntrackedFilter",
+            "ClearGitFilters",
+            "ToggleSearchScope",
+        ] {
+            let item = find(&items, name).unwrap_or_else(|| panic!("{name} is not in the palette"));
+            assert_eq!(item.section, PaletteSection::Filters, "{name}");
+        }
+        let refresh = find(&items, "RefreshPrStatus").expect("RefreshPrStatus missing");
+        assert_eq!(refresh.section, PaletteSection::Sidebar);
+    }
+
+    /// The PR filters ship keyless, so the palette is the only place they are
+    /// discoverable until a user binds them.
+    #[test]
+    fn pr_filter_actions_are_listed_without_keys() {
+        let items = action_items(&parse_bindings(vec![]));
+        assert_eq!(find(&items, "TogglePrOpenFilter").unwrap().keys, "");
+        assert_eq!(find(&items, "ToggleSessionsFilter").unwrap().keys, "S");
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -533,6 +533,30 @@ fn parse_sidebar_focus(raw: Option<&str>) -> SidebarFocus {
     }
 }
 
+/// `[ui] search_scope`: whether a fuzzy query is confined by the panel's active
+/// toggle filters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SearchScope {
+    /// A query narrows the rows the toggles already allow.
+    #[default]
+    Filtered,
+    /// A query is evaluated against every row; the toggles stand aside until it
+    /// empties.
+    All,
+}
+
+fn parse_search_scope(raw: Option<&str>) -> SearchScope {
+    match raw {
+        None => SearchScope::default(),
+        Some("filtered") => SearchScope::Filtered,
+        Some("all") => SearchScope::All,
+        Some(other) => {
+            log::warn!("unknown ui.search_scope value {other:?}, using \"filtered\"");
+            SearchScope::default()
+        },
+    }
+}
+
 /// Whether per-session UI (sidebar session rows, tab-strip segments) renders
 /// for a single-session workspace instead of waiting for the two-session
 /// threshold.  These are startup defaults only: the app copies them into
@@ -654,6 +678,8 @@ pub struct UiTheme {
     pub last_session_close: LastSessionClose,
     /// How the projects sidebar repairs a cursor whose row stopped rendering.
     pub sidebar_focus: SidebarFocus,
+    /// Whether a fuzzy query is confined by the panel's active toggle filters.
+    pub search_scope: SearchScope,
     /// Show single-session sidebar rows / tab segments ([`SessionDisplay`]).
     pub session_display: SessionDisplay,
     /// Paint PR-status badges on worktree rows (and poll `gh` for expanded
@@ -705,6 +731,7 @@ impl Default for UiTheme {
             confirm_session_close: ConfirmSessionClose::Never,
             last_session_close: LastSessionClose::Respawn,
             sidebar_focus: SidebarFocus::default(),
+            search_scope: SearchScope::default(),
             session_display: SessionDisplay::default(),
             pr_status: false,
             icons: Icons::default(),
@@ -1377,6 +1404,9 @@ struct RawUi {
     /// How far the projects sidebar goes when the cursor's row stops being
     /// rendered: "preserve" (default) | "follow".
     sidebar_focus: Option<String>,
+    /// Whether a fuzzy query is confined by the panel's active toggle filters:
+    /// "filtered" (default) | "all".
+    search_scope: Option<String>,
     session_display: RawSessionDisplay,
     delta_path: Option<String>,
     icons: RawIcons,
@@ -1546,6 +1576,7 @@ impl RawConfig {
             ),
             last_session_close: parse_last_session_close(self.ui.last_session_close.as_deref()),
             sidebar_focus: parse_sidebar_focus(self.ui.sidebar_focus.as_deref()),
+            search_scope: parse_search_scope(self.ui.search_scope.as_deref()),
             session_display: SessionDisplay {
                 sidebar_always: self.ui.session_display.sidebar_always.unwrap_or(false),
                 tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
@@ -2030,6 +2061,26 @@ mod tests {
     fn only_follow_moves_the_terminal() {
         assert!(!SidebarFocus::Preserve.follows());
         assert!(SidebarFocus::Follow.follows());
+    }
+
+    #[test]
+    fn search_scope_defaults_to_filtered() {
+        let ui = ui_from_toml("");
+        assert_eq!(ui.search_scope, SearchScope::Filtered);
+    }
+
+    #[test]
+    fn search_scope_parses_both_values() {
+        for (raw, expected) in [("filtered", SearchScope::Filtered), ("all", SearchScope::All)] {
+            let ui = ui_from_toml(&format!("[ui]\nsearch_scope = \"{raw}\""));
+            assert_eq!(ui.search_scope, expected, "value {raw:?}");
+        }
+    }
+
+    #[test]
+    fn search_scope_invalid_falls_back_to_filtered() {
+        let ui = ui_from_toml("[ui]\nsearch_scope = \"everywhere\"");
+        assert_eq!(ui.search_scope, SearchScope::Filtered);
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -23,6 +23,7 @@ use serde::Deserialize;
 
 use crate::bindings::{self, KeyBinding};
 use crate::path_style::PathStyle;
+use crate::pr_status::DEFAULT_CONCURRENCY;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -739,7 +740,7 @@ impl Default for UiTheme {
             search_scope: SearchScope::default(),
             session_display: SessionDisplay::default(),
             pr_status: false,
-            pr_status_concurrency: 8,
+            pr_status_concurrency: DEFAULT_CONCURRENCY,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
             scrollbar: ScrollbarStyle::Floating,
@@ -1590,7 +1591,7 @@ impl RawConfig {
                 tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
             },
             pr_status: self.ui.pr_status.unwrap_or(false),
-            pr_status_concurrency: self.ui.pr_status_concurrency.unwrap_or(8).max(1),
+            pr_status_concurrency: self.ui.pr_status_concurrency.unwrap_or(DEFAULT_CONCURRENCY).max(1),
             icons: build_icons(self.ui.icons),
             focus_outline: FocusOutline {
                 sidebar: self.ui.focus_outline.sidebar.unwrap_or(false),

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -687,6 +687,10 @@ pub struct UiTheme {
     /// no `gh` processes; when enabled it is best-effort like the diff-base
     /// lookup: no `gh`, no auth, or no PR silently paints nothing.
     pub pr_status: bool,
+    /// `[ui] pr_status_concurrency`: max `gh` lookups in flight at once.
+    /// `0` (default) is unlimited, which is how many a cold cache already
+    /// forks in one frame — one per eligible worktree.
+    pub pr_status_concurrency: usize,
     pub icons: Icons,
     pub focus_outline: FocusOutline,
     /// `[ui] scrollbar`: sidebar scrollbar style, "floating" (default) or
@@ -734,6 +738,7 @@ impl Default for UiTheme {
             search_scope: SearchScope::default(),
             session_display: SessionDisplay::default(),
             pr_status: false,
+            pr_status_concurrency: 0,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
             scrollbar: ScrollbarStyle::Floating,
@@ -1413,6 +1418,8 @@ struct RawUi {
     /// Sidebar scrollbar style: "floating" (default) | "solid".
     scrollbar: Option<String>,
     pr_status: Option<bool>,
+    /// Max `gh` lookups in flight at once.  `0` (default) is unlimited.
+    pr_status_concurrency: Option<usize>,
     font: RawUiFont,
     worktree_name: Option<String>,
     project_name: Option<String>,
@@ -1582,6 +1589,7 @@ impl RawConfig {
                 tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
             },
             pr_status: self.ui.pr_status.unwrap_or(false),
+            pr_status_concurrency: self.ui.pr_status_concurrency.unwrap_or(0),
             icons: build_icons(self.ui.icons),
             focus_outline: FocusOutline {
                 sidebar: self.ui.focus_outline.sidebar.unwrap_or(false),
@@ -2393,6 +2401,12 @@ program = "second"
     fn pr_status_defaults_off_and_parses_on() {
         assert!(!ui_from_toml("").pr_status);
         assert!(ui_from_toml("[ui]\npr_status = true").pr_status);
+    }
+
+    #[test]
+    fn pr_status_concurrency_defaults_to_unlimited() {
+        assert_eq!(ui_from_toml("").pr_status_concurrency, 0);
+        assert_eq!(ui_from_toml("[ui]\npr_status_concurrency = 4").pr_status_concurrency, 4);
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -688,8 +688,9 @@ pub struct UiTheme {
     /// lookup: no `gh`, no auth, or no PR silently paints nothing.
     pub pr_status: bool,
     /// `[ui] pr_status_concurrency`: max `gh` lookups in flight at once.
-    /// `0` (default) is unlimited, which is how many a cold cache already
-    /// forks in one frame — one per eligible worktree.
+    /// Defaults to 8; clamped to ≥ 1, since a cold cache spawns one lookup
+    /// per eligible worktree in a single frame and an unbounded cap would
+    /// fork a thread and a `gh` process for every one of them at once.
     pub pr_status_concurrency: usize,
     pub icons: Icons,
     pub focus_outline: FocusOutline,
@@ -738,7 +739,7 @@ impl Default for UiTheme {
             search_scope: SearchScope::default(),
             session_display: SessionDisplay::default(),
             pr_status: false,
-            pr_status_concurrency: 0,
+            pr_status_concurrency: 8,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
             scrollbar: ScrollbarStyle::Floating,
@@ -1418,7 +1419,7 @@ struct RawUi {
     /// Sidebar scrollbar style: "floating" (default) | "solid".
     scrollbar: Option<String>,
     pr_status: Option<bool>,
-    /// Max `gh` lookups in flight at once.  `0` (default) is unlimited.
+    /// Max `gh` lookups in flight at once.  Defaults to 8; clamped to ≥ 1.
     pr_status_concurrency: Option<usize>,
     font: RawUiFont,
     worktree_name: Option<String>,
@@ -1589,7 +1590,7 @@ impl RawConfig {
                 tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
             },
             pr_status: self.ui.pr_status.unwrap_or(false),
-            pr_status_concurrency: self.ui.pr_status_concurrency.unwrap_or(0),
+            pr_status_concurrency: self.ui.pr_status_concurrency.unwrap_or(8).max(1),
             icons: build_icons(self.ui.icons),
             focus_outline: FocusOutline {
                 sidebar: self.ui.focus_outline.sidebar.unwrap_or(false),
@@ -2404,9 +2405,14 @@ program = "second"
     }
 
     #[test]
-    fn pr_status_concurrency_defaults_to_unlimited() {
-        assert_eq!(ui_from_toml("").pr_status_concurrency, 0);
+    fn pr_status_concurrency_defaults_to_eight() {
+        assert_eq!(ui_from_toml("").pr_status_concurrency, 8);
         assert_eq!(ui_from_toml("[ui]\npr_status_concurrency = 4").pr_status_concurrency, 4);
+    }
+
+    #[test]
+    fn pr_status_concurrency_clamps_to_one() {
+        assert_eq!(ui_from_toml("[ui]\npr_status_concurrency = 0").pr_status_concurrency, 1);
     }
 
     #[test]

--- a/alacritree/src/panel_filter.rs
+++ b/alacritree/src/panel_filter.rs
@@ -32,6 +32,8 @@ pub enum Outcome {
 
 /// Search/toggle state for one sidebar panel.
 pub struct PanelFilter {
+    /// Render/bit order of this panel's toggle filters, not a set of keys:
+    /// `active_toggles` renders in this order and `toggle_bits` indexes it.
     allowed_toggles: &'static [char],
     mode: Mode,
     query: String,
@@ -64,6 +66,21 @@ impl PanelFilter {
 
     pub fn is_toggled(&self, key: char) -> bool {
         self.toggles.contains(&key)
+    }
+
+    /// Flip one toggle by its identity char.  A char outside `allowed_toggles`
+    /// names no filter on this panel and is ignored.
+    pub fn toggle(&mut self, key: char) {
+        if !self.allowed_toggles.contains(&key) {
+            return;
+        }
+        if !self.toggles.remove(&key) {
+            self.toggles.insert(key);
+        }
+    }
+
+    pub fn clear_toggles(&mut self) {
+        self.toggles.clear();
     }
 
     /// Active toggles in `allowed_toggles` order (render order).
@@ -121,17 +138,7 @@ impl PanelFilter {
                     self.mode = Mode::Search;
                     return Some(Outcome::Consumed);
                 }
-                let mut chars = text.chars();
-                let (Some(c), None) = (chars.next(), chars.next()) else {
-                    return None;
-                };
-                if !self.allowed_toggles.contains(&c) {
-                    return None;
-                }
-                if !self.toggles.remove(&c) {
-                    self.toggles.insert(c);
-                }
-                Some(Outcome::FilterChanged)
+                None
             },
             Mode::Search => {
                 self.query.push_str(text);
@@ -221,7 +228,7 @@ mod tests {
     #[test]
     fn exit_search_clears_query_and_returns_to_browsing_keeping_toggles() {
         let mut f = PanelFilter::new(TOGGLES);
-        f.on_text("s");
+        f.toggle('s');
         f.on_text("/");
         f.on_text("foo");
         assert!(f.is_toggled('s'));
@@ -241,25 +248,49 @@ mod tests {
     }
 
     #[test]
-    fn toggle_keys_flip_in_browsing_and_are_inert_in_search() {
+    fn toggle_flips_an_allowed_identity_and_ignores_an_unknown_one() {
         let mut f = PanelFilter::new(TOGGLES);
-        assert_eq!(f.on_text("s"), Some(Outcome::FilterChanged));
+        f.toggle('s');
         assert!(f.is_toggled('s'));
         assert_eq!(f.active_toggles(), vec!['s']);
 
-        assert_eq!(f.on_text("s"), Some(Outcome::FilterChanged));
+        f.toggle('s');
         assert!(!f.is_toggled('s'));
 
+        f.toggle('z');
+        assert!(!f.is_toggled('z'), "a char outside allowed_toggles is not a filter");
+        assert_eq!(f.toggle_bits(), 0);
+    }
+
+    #[test]
+    fn clear_toggles_empties_the_set_and_leaves_the_query() {
+        let mut f = PanelFilter::new(TOGGLES);
+        f.toggle('s');
+        f.toggle('a');
         f.on_text("/");
-        assert_eq!(f.on_text("s"), Some(Outcome::FilterChanged));
+        f.on_text("foo");
+
+        f.clear_toggles();
+        assert_eq!(f.toggle_bits(), 0);
+        assert_eq!(f.query(), "foo", "the query is a separate dimension");
+    }
+
+    /// Browsing recognizes only `/`; every other char falls through so the
+    /// binding table can act on the paired key event.
+    #[test]
+    fn browsing_text_other_than_slash_is_not_consumed() {
+        let mut f = PanelFilter::new(TOGGLES);
+        assert_eq!(f.on_text("s"), None);
+        assert_eq!(f.on_text("x"), None);
+        assert_eq!(f.on_text("/"), Some(Outcome::Consumed));
+        assert_eq!(f.on_text("s"), Some(Outcome::FilterChanged), "in search it is query input");
         assert_eq!(f.query(), "s");
-        assert!(!f.is_toggled('s'));
     }
 
     #[test]
     fn esc_in_browsing_clears_toggles_before_leaving_the_panel() {
         let mut f = PanelFilter::new(TOGGLES);
-        f.on_text("s");
+        f.toggle('s');
         assert!(f.is_toggled('s'));
 
         assert_eq!(f.on_key(egui::Key::Escape), Some(Outcome::FilterChanged));
@@ -281,13 +312,13 @@ mod tests {
         let mut f = PanelFilter::new(TOGGLES);
         assert_eq!(f.toggle_bits(), 0);
 
-        f.on_text("s");
+        f.toggle('s');
         assert_eq!(f.toggle_bits(), 0b01, "'s' is index 0 in TOGGLES");
 
-        f.on_text("a");
+        f.toggle('a');
         assert_eq!(f.toggle_bits(), 0b11);
 
-        f.on_text("s");
+        f.toggle('s');
         assert_eq!(f.toggle_bits(), 0b10, "'a' alone is index 1");
     }
 
@@ -296,9 +327,9 @@ mod tests {
         let mut f = PanelFilter::new(TOGGLES);
         assert!(!f.is_filtering());
 
-        f.on_text("s");
+        f.toggle('s');
         assert!(f.is_filtering());
-        f.on_text("s");
+        f.toggle('s');
         assert!(!f.is_filtering());
 
         f.on_text("/");

--- a/alacritree/src/panel_filter.rs
+++ b/alacritree/src/panel_filter.rs
@@ -105,6 +105,12 @@ impl PanelFilter {
         !self.query.is_empty() || !self.toggles.is_empty()
     }
 
+    /// Whether the toggle filters apply this frame.  Under `All` a live query
+    /// stands them down, so a search reaches rows the toggles hide.
+    pub fn toggles_apply(&self, scope: crate::config::SearchScope) -> bool {
+        scope == crate::config::SearchScope::Filtered || self.query.is_empty()
+    }
+
     pub fn on_key(&mut self, key: egui::Key) -> Option<Outcome> {
         match self.mode {
             Mode::Browsing => match key {
@@ -355,5 +361,19 @@ mod tests {
         f.on_text("/");
         f.on_text("Read");
         assert!(!f.matches("readme"));
+    }
+
+    #[test]
+    fn toggles_apply_only_stands_down_for_a_live_query_under_all() {
+        use crate::config::SearchScope;
+        let mut f = PanelFilter::new(TOGGLES);
+
+        assert!(f.toggles_apply(SearchScope::Filtered));
+        assert!(f.toggles_apply(SearchScope::All), "an empty query narrows nothing");
+
+        f.on_text("/");
+        f.on_text("foo");
+        assert!(f.toggles_apply(SearchScope::Filtered));
+        assert!(!f.toggles_apply(SearchScope::All));
     }
 }

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -276,6 +276,16 @@ pub fn pr_pass(
 /// The branch a worktree's PR lookup is keyed to.  The active worktree prefers
 /// its live status branch; every other worktree, and an active one whose
 /// `StatusCache` has not produced a branch yet, uses the stored snapshot.
+///
+/// The split is what keeps two pollers of one path from fighting.  [`PrCache`]
+/// is keyed by path alone, so the right sidebar — which polls the active
+/// workspace with its live `StatusCache` branch, recomputed every ~1.5 s — and
+/// the projects sidebar must agree on a branch, or each drain flips
+/// `entry.branch` and they invalidate each other's lookups forever after an
+/// in-terminal checkout.  Every other worktree has a single poller, and an
+/// inactive workspace's `StatusCache` is created once and then never re-polled
+/// or pruned: reading it would freeze the branch at whatever it was on the last
+/// visit and shadow later `refresh_project` updates to `wt.branch`.
 pub fn effective_branch<'a>(
     wt: &'a Worktree,
     current_workspace: Option<&Path>,
@@ -295,9 +305,13 @@ fn spawn_lookup(path: PathBuf, branch: String, ctx: egui::Context) -> Receiver<L
         // concurrency slot only runs on a frame, so an exit without a repaint
         // can stall polling for good.
         let _wake = RepaintOnDrop(ctx);
-        let _tx = tx;
+        // A body local rather than a capture: locals drop in reverse
+        // declaration order, so a panicking unwind disconnects the channel
+        // before the guard requests the repaint that observes it.  Closure
+        // capture drop order is unspecified and would not guarantee that.
+        let sender = tx;
         let info = query_gh(&path, &branch);
-        let _ = _tx.send(LookupResult { branch, info });
+        let _ = sender.send(LookupResult { branch, info });
     });
     rx
 }
@@ -1068,7 +1082,7 @@ mod tests {
             let ctx = ctx.clone();
             thread::spawn(move || {
                 let _wake = RepaintOnDrop(ctx);
-                let _tx = tx;
+                let _sender = tx;
                 panic!("worker died");
             })
         };

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -321,9 +321,10 @@ fn pr_state(state: &str, is_draft: bool) -> PrState {
 /// the head ref name alone, which both layouts share, and `--state all` keeps
 /// the merged and closed badges that `pr list` would otherwise drop.
 fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
-    const PR_JSON_FIELDS: &str = "number,baseRefName,url,state,isDraft";
+    const PR_JSON_FIELDS: &str = "number,baseRefName,url,state,isDraft,headRepositoryOwner";
     match wsl::classify(path) {
         wsl::Location::Windows(p) => {
+            let owner = local_origin_owner(&p);
             let output = Command::new("gh")
                 .hide_console()
                 .current_dir(p)
@@ -336,7 +337,7 @@ fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
             if !output.status.success() {
                 return None;
             }
-            parse_gh_output(&output.stdout)
+            parse_gh_output(&output.stdout, owner.as_deref())
         },
         // `gh` must be installed and authenticated *inside* the distro; any
         // failure falls back to the default branch, same as a missing
@@ -346,28 +347,133 @@ fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
         // `--exec` PATH lacks.
         wsl::Location::Wsl { distro, linux_path } => {
             let gh = crate::wsl_helper::capability_gh(&distro).unwrap_or_else(|| "gh".to_string());
-            let script = r#"cd "$1" && exec "$2" pr list --head "$3" --state all --json "$4""#;
+            // The `origin` URL rides along on the first line: git2 cannot read
+            // a repository that lives inside the distro, and a second round
+            // trip would double the cost of a badge that already forks `gh`.
+            // The substitution collapses a missing remote to a blank line, so
+            // the JSON always starts after exactly one newline.
+            let script = r#"cd "$1" || exit 1
+printf '%s\n' "$(git config --get remote.origin.url 2>/dev/null)"
+exec "$2" pr list --head "$3" --state all --json "$4""#;
             let stdout =
                 wsl::run_batch(&distro, script, &[&linux_path, &gh, branch, PR_JSON_FIELDS])
                     .ok()?;
-            parse_gh_output(&stdout)
+            let (origin_url, json) = split_origin_url_line(&stdout);
+            let owner = origin_url.and_then(github_owner_from_url);
+            parse_gh_output(json, owner.as_deref())
         },
     }
 }
 
-/// Pick the PR a head branch's badge should show.  `gh pr list` answers newest
-/// first, and a branch accumulates PRs over its life; an open one is the live
-/// PR, so it outranks a newer abandoned attempt.  Drafts report `OPEN` too, so
-/// this covers them.  Mirrors how `gh pr view` orders its own candidates.
-fn select_pr(prs: &[serde_json::Value]) -> Option<&serde_json::Value> {
-    prs.iter()
-        .find(|pr| pr.get("state").and_then(|s| s.as_str()) == Some("OPEN"))
-        .or_else(|| prs.first())
+/// Split the WSL batch's leading `origin` URL off the JSON that follows it.
+/// An empty first line means the worktree has no readable `origin`.
+fn split_origin_url_line(stdout: &[u8]) -> (Option<&str>, &[u8]) {
+    let Some(end) = stdout.iter().position(|b| *b == b'\n') else {
+        // Nothing ran far enough to emit the line; hand the payload to the
+        // JSON parser, which rejects it the way it rejects any non-JSON.
+        return (None, stdout);
+    };
+    let url = std::str::from_utf8(&stdout[..end]).ok().map(str::trim).filter(|u| !u.is_empty());
+    (url, &stdout[end + 1..])
 }
 
-fn parse_gh_output(stdout: &[u8]) -> Option<PrInfo> {
+/// The GitHub owner of this worktree's `origin`, read straight from the
+/// repository config so the badge still costs exactly one `gh` process.
+fn local_origin_owner(path: &Path) -> Option<String> {
+    let repo = git2::Repository::open(path).ok()?;
+    let remote = repo.find_remote("origin").ok()?;
+    github_owner_from_url(remote.url()?)
+}
+
+/// Owner of a GitHub remote URL, for the shapes git accepts:
+/// `https://github.com/owner/repo.git`, `git@github.com:owner/repo.git`, and
+/// the scp-style host alias `gh:owner/repo.git`.  `None` for anything else —
+/// the owner only breaks ties, so an unreadable remote costs nothing.
+fn github_owner_from_url(url: &str) -> Option<String> {
+    let (host, path) = split_remote_url(url.trim())?;
+    if !is_github_host(host) {
+        return None;
+    }
+    let (owner, repo) = path.trim_start_matches('/').split_once('/')?;
+    (!owner.is_empty() && !repo.is_empty()).then(|| owner.to_string())
+}
+
+/// Host and path of a remote URL, covering both the scheme form and the
+/// scp-style `[user@]host:path` one that git reads whenever the colon comes
+/// before any slash.
+fn split_remote_url(url: &str) -> Option<(&str, &str)> {
+    if let Some((_, rest)) = url.split_once("://") {
+        let (authority, path) = rest.split_once('/')?;
+        return Some((remote_host(authority), path));
+    }
+    let (authority, path) = url.split_once(':')?;
+    // A leading slash means an absolute local path (`C:/repos/x`), which git
+    // does not read as scp-style however much it looks like one.
+    if authority.contains('/') || path.starts_with('/') {
+        return None;
+    }
+    Some((remote_host(authority), path))
+}
+
+fn remote_host(authority: &str) -> &str {
+    let host = authority.rsplit_once('@').map_or(authority, |(_, host)| host);
+    host.split(':').next().unwrap_or(host)
+}
+
+/// `github.com`, or any host with no dot in it.  A dotless host is an
+/// `~/.ssh/config` alias whose real target we cannot see, and aliases are how
+/// fork checkouts pick an SSH identity — refusing them would blind the owner
+/// preference to the layout it exists for.  Guessing wrong on one just yields
+/// an owner no PR matches.
+fn is_github_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("github.com") || !host.contains('.')
+}
+
+/// Pick the PR a head branch's badge should show.  Two rules, in order:
+///
+/// `--head` matches the ref name across *every* head repository, so a generic
+/// branch name ("dev", "patch-1") also collects PRs strangers opened from their
+/// own forks.  A head repo owned by the same account as this worktree's
+/// `origin` is the one this checkout actually pushed, so it outranks a
+/// stranger's however live that one is.  Without a readable owner, or with no
+/// candidate matching it, every PR stays in the running.
+///
+/// Among what survives, `gh pr list` answers newest first and a branch
+/// accumulates PRs over its life; an open one is the live PR, so it outranks a
+/// newer abandoned attempt.  Drafts report `OPEN` too, so this covers them.
+/// Mirrors how `gh pr view` orders its own candidates.
+fn select_pr<'a>(
+    prs: &'a [serde_json::Value],
+    origin_owner: Option<&str>,
+) -> Option<&'a serde_json::Value> {
+    origin_owner
+        .and_then(|owner| open_or_newest(prs.iter().filter(|pr| head_owner_is(pr, owner))))
+        .or_else(|| open_or_newest(prs.iter()))
+}
+
+fn open_or_newest<'a>(
+    prs: impl Iterator<Item = &'a serde_json::Value>,
+) -> Option<&'a serde_json::Value> {
+    let mut newest = None;
+    for pr in prs {
+        if pr.get("state").and_then(|s| s.as_str()) == Some("OPEN") {
+            return Some(pr);
+        }
+        newest = newest.or(Some(pr));
+    }
+    newest
+}
+
+fn head_owner_is(pr: &serde_json::Value, owner: &str) -> bool {
+    pr.get("headRepositoryOwner")
+        .and_then(|o| o.get("login"))
+        .and_then(|l| l.as_str())
+        .is_some_and(|login| login.eq_ignore_ascii_case(owner))
+}
+
+fn parse_gh_output(stdout: &[u8], origin_owner: Option<&str>) -> Option<PrInfo> {
     let list: serde_json::Value = serde_json::from_slice(stdout).ok()?;
-    let value = select_pr(list.as_array()?)?;
+    let value = select_pr(list.as_array()?, origin_owner)?;
     let number = value.get("number")?.as_u64()?;
     let base = value.get("baseRefName")?.as_str()?.to_string();
     let url = value.get("url")?.as_str()?.to_string();
@@ -384,7 +490,7 @@ mod tests {
     fn parses_gh_json() {
         let stdout =
             br#"[{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}]"#;
-        let info = parse_gh_output(stdout).unwrap();
+        let info = parse_gh_output(stdout, None).unwrap();
         assert_eq!(info.number, 42);
         assert_eq!(info.base_branch, "main");
         assert_eq!(info.url, "https://github.com/o/r/pull/42");
@@ -392,12 +498,12 @@ mod tests {
 
     #[test]
     fn rejects_empty_output() {
-        assert!(parse_gh_output(b"").is_none());
+        assert!(parse_gh_output(b"", None).is_none());
     }
 
     #[test]
     fn rejects_an_empty_pr_list() {
-        assert!(parse_gh_output(b"[]").is_none());
+        assert!(parse_gh_output(b"[]", None).is_none());
     }
 
     /// A head branch accumulates PRs over its life. `gh pr list` answers newest
@@ -409,7 +515,7 @@ mod tests {
             {"baseRefName":"main","number":9,"url":"u9","state":"CLOSED","isDraft":false},
             {"baseRefName":"main","number":4,"url":"u4","state":"OPEN","isDraft":false}
         ]"#;
-        let info = parse_gh_output(stdout).unwrap();
+        let info = parse_gh_output(stdout, None).unwrap();
         assert_eq!(info.number, 4);
         assert_eq!(info.state, PrState::Open);
     }
@@ -420,7 +526,7 @@ mod tests {
             {"baseRefName":"main","number":9,"url":"u9","state":"MERGED","isDraft":false},
             {"baseRefName":"main","number":4,"url":"u4","state":"OPEN","isDraft":true}
         ]"#;
-        let info = parse_gh_output(stdout).unwrap();
+        let info = parse_gh_output(stdout, None).unwrap();
         assert_eq!(info.number, 4);
         assert_eq!(info.state, PrState::Draft);
     }
@@ -432,7 +538,7 @@ mod tests {
             {"baseRefName":"main","number":9,"url":"u9","state":"MERGED","isDraft":false},
             {"baseRefName":"main","number":4,"url":"u4","state":"CLOSED","isDraft":false}
         ]"#;
-        let info = parse_gh_output(stdout).unwrap();
+        let info = parse_gh_output(stdout, None).unwrap();
         assert_eq!(info.number, 9);
         assert_eq!(info.state, PrState::Merged);
     }
@@ -449,7 +555,7 @@ mod tests {
             let stdout = format!(
                 r#"[{{"baseRefName":"main","number":1,"url":"https://github.com/o/r/pull/1","state":"{json_state}","isDraft":{is_draft}}}]"#
             );
-            let info = parse_gh_output(stdout.as_bytes()).unwrap();
+            let info = parse_gh_output(stdout.as_bytes(), None).unwrap();
             assert_eq!(info.state, expected, "state={json_state} draft={is_draft}");
         }
     }
@@ -459,7 +565,139 @@ mod tests {
         // Old gh versions may omit fields we didn't ask for; degrade, don't drop.
         let stdout =
             br#"[{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}]"#;
-        assert_eq!(parse_gh_output(stdout).unwrap().state, PrState::Open);
+        assert_eq!(parse_gh_output(stdout, None).unwrap().state, PrState::Open);
+    }
+
+    fn pr(number: u64, state: &str, head_owner: &str) -> serde_json::Value {
+        serde_json::json!({
+            "number": number,
+            "baseRefName": "main",
+            "url": format!("u{number}"),
+            "state": state,
+            "isDraft": false,
+            "headRepositoryOwner": { "login": head_owner },
+        })
+    }
+
+    fn number_of(pr: Option<&serde_json::Value>) -> Option<u64> {
+        pr?.get("number")?.as_u64()
+    }
+
+    #[test]
+    fn select_pr_prefers_an_open_pr_over_a_newer_non_open_one() {
+        let prs = [pr(9, "MERGED", "someone"), pr(4, "OPEN", "someone")];
+        assert_eq!(number_of(select_pr(&prs, None)), Some(4));
+    }
+
+    #[test]
+    fn select_pr_takes_the_newest_when_none_are_open() {
+        let prs = [pr(9, "MERGED", "someone"), pr(4, "CLOSED", "someone")];
+        assert_eq!(number_of(select_pr(&prs, None)), Some(9));
+    }
+
+    /// `--head` matches the ref name in *every* head repository, so a generic
+    /// branch name ("dev", "patch-1") collects strangers' PRs.  Theirs must not
+    /// decide this worktree's badge or diff base, however live they are.
+    #[test]
+    fn select_pr_prefers_the_origin_owners_pr_over_a_strangers_open_one() {
+        let prs = [pr(9, "OPEN", "stranger"), pr(4, "MERGED", "me")];
+        assert_eq!(number_of(select_pr(&prs, Some("me"))), Some(4));
+    }
+
+    #[test]
+    fn select_pr_prefers_an_open_pr_among_the_origin_owners_own() {
+        let prs = [pr(9, "MERGED", "me"), pr(7, "OPEN", "stranger"), pr(4, "OPEN", "me")];
+        assert_eq!(number_of(select_pr(&prs, Some("me"))), Some(4));
+    }
+
+    /// GitHub logins are case-insensitive, so a remote URL that disagrees with
+    /// the API's casing still names the same account.
+    #[test]
+    fn select_pr_matches_the_owner_case_insensitively() {
+        let prs = [pr(9, "OPEN", "stranger"), pr(4, "MERGED", "Me")];
+        assert_eq!(number_of(select_pr(&prs, Some("me"))), Some(4));
+    }
+
+    #[test]
+    fn select_pr_falls_back_to_the_plain_policy_when_no_owner_matches() {
+        let prs = [pr(9, "MERGED", "stranger"), pr(4, "OPEN", "other")];
+        assert_eq!(number_of(select_pr(&prs, Some("me"))), Some(4));
+    }
+
+    /// A `gh` too old to report the head owner must not filter every candidate
+    /// away — an unknown owner is no evidence the PR belongs to someone else.
+    #[test]
+    fn select_pr_tolerates_a_missing_head_owner() {
+        let prs = [serde_json::json!({"number": 4, "state": "OPEN"})];
+        assert_eq!(number_of(select_pr(&prs, Some("me"))), Some(4));
+    }
+
+    #[test]
+    fn select_pr_reports_nothing_for_an_empty_list() {
+        assert!(select_pr(&[], Some("me")).is_none());
+    }
+
+    /// The regression this preference exists for: a stale PR opened by a
+    /// stranger on the same branch name, still carrying the base branch the
+    /// repository has since renamed away from.
+    #[test]
+    fn the_origin_owners_pr_decides_the_diff_base() {
+        let stdout = br#"[
+            {"baseRefName":"master","number":9,"url":"u9","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"stranger"}},
+            {"baseRefName":"main","number":4,"url":"u4","state":"MERGED","isDraft":false,"headRepositoryOwner":{"login":"me"}}
+        ]"#;
+        let info = parse_gh_output(stdout, Some("me")).unwrap();
+        assert_eq!(info.number, 4);
+        assert_eq!(info.base_branch, "main");
+    }
+
+    #[test]
+    fn derives_the_owner_from_an_https_remote() {
+        let owner = github_owner_from_url("https://github.com/owner/repo.git");
+        assert_eq!(owner.as_deref(), Some("owner"));
+    }
+
+    #[test]
+    fn derives_the_owner_from_an_scp_style_ssh_remote() {
+        let owner = github_owner_from_url("git@github.com:owner/repo.git");
+        assert_eq!(owner.as_deref(), Some("owner"));
+    }
+
+    /// An `~/.ssh/config` alias is how a fork checkout picks an identity, and it
+    /// hides the host it resolves to — reading it as foreign would blind the
+    /// preference to exactly the layout it exists for.
+    #[test]
+    fn derives_the_owner_from_an_ssh_host_alias() {
+        let owner = github_owner_from_url("gh:owner/repo.git");
+        assert_eq!(owner.as_deref(), Some("owner"));
+    }
+
+    #[test]
+    fn rejects_a_non_github_remote() {
+        assert!(github_owner_from_url("https://gitlab.com/owner/repo.git").is_none());
+        assert!(github_owner_from_url("git@gitlab.com:owner/repo.git").is_none());
+    }
+
+    #[test]
+    fn rejects_a_malformed_remote() {
+        assert!(github_owner_from_url("").is_none());
+        assert!(github_owner_from_url("not a url").is_none());
+        assert!(github_owner_from_url("https://github.com/owner").is_none());
+        assert!(github_owner_from_url("C:/repos/checkout").is_none());
+    }
+
+    #[test]
+    fn the_wsl_batch_line_carries_the_origin_url() {
+        let (url, json) = split_origin_url_line(b"gh:me/repo.git\n[]");
+        assert_eq!(url, Some("gh:me/repo.git"));
+        assert_eq!(json, b"[]".as_slice());
+    }
+
+    #[test]
+    fn a_worktree_without_a_remote_leaves_the_wsl_line_blank() {
+        let (url, json) = split_origin_url_line(b"\n[]");
+        assert_eq!(url, None);
+        assert_eq!(json, b"[]".as_slice());
     }
 
     fn sample_info() -> PrInfo {

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -119,14 +119,8 @@ impl PrCache {
         );
 
         if spawn && may_spawn(self.concurrency, self.in_flight) {
-            let invalidate = should_invalidate(entry.branch.as_deref(), Some(branch));
-            // Clear stale data immediately on branch switch so we don't show
-            // a PR base that belongs to a different branch.
-            if invalidate {
-                entry.info = None;
-            }
             let rx = spawn_lookup(path.to_path_buf(), branch.to_string(), ctx.clone());
-            self.bank_pending(path.to_path_buf(), rx);
+            self.bank_pending(path.to_path_buf(), branch, rx);
         }
 
         self.entries.get(path).and_then(|entry| entry.info.clone())
@@ -169,6 +163,12 @@ impl PrCache {
                     self.generation = self.generation.wrapping_add(1);
                 },
                 Err(mpsc::TryRecvError::Disconnected) => {
+                    // A worker that died without sending has no answer to bank,
+                    // so the TTL is the only thing that can back it off — and it
+                    // must do so even when a refresh was requested mid-flight,
+                    // or the entry re-spawns a thread and a `gh` process on
+                    // every frame for as long as the failure lasts.
+                    entry.queried_at = Some(Instant::now());
                     entry.pending = None;
                     entry.refresh_requested = false;
                     self.in_flight = self.in_flight.saturating_sub(1);
@@ -192,8 +192,21 @@ impl PrCache {
         self.generation = self.generation.wrapping_add(1);
     }
 
-    fn bank_pending(&mut self, path: PathBuf, rx: Receiver<LookupResult>) {
-        self.entries.entry(path).or_default().pending = Some(rx);
+    /// Record a started lookup against its entry.  The entry is keyed to the
+    /// branch being looked up rather than to the last banked answer: a worker
+    /// that dies without sending leaves nothing for the drain to key it with,
+    /// and a mismatched branch makes the entry due again on the next frame
+    /// however recently it was queried.
+    fn bank_pending(&mut self, path: PathBuf, branch: &str, rx: Receiver<LookupResult>) {
+        let entry = self.entries.entry(path).or_default();
+        debug_assert!(entry.pending.is_none(), "a second lookup would strand the first's slot");
+        // Clear stale data immediately on branch switch so we don't show
+        // a PR base that belongs to a different branch.
+        if should_invalidate(entry.branch.as_deref(), Some(branch)) {
+            entry.info = None;
+        }
+        entry.branch = Some(branch.to_string());
+        entry.pending = Some(rx);
         self.in_flight += 1;
     }
 
@@ -203,8 +216,8 @@ impl PrCache {
     }
 
     #[cfg(test)]
-    fn insert_pending(&mut self, path: PathBuf, rx: Receiver<LookupResult>) {
-        self.bank_pending(path, rx);
+    fn insert_pending(&mut self, path: PathBuf, branch: &str, rx: Receiver<LookupResult>) {
+        self.bank_pending(path, branch, rx);
     }
 }
 
@@ -851,7 +864,7 @@ mod tests {
         let mut cache = PrCache::new();
         cache.set_concurrency(1);
         let (tx, rx) = mpsc::channel();
-        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+        cache.insert_pending(PathBuf::from("/repo/wt"), "main", rx);
         assert_eq!(cache.in_flight(), 1);
 
         tx.send(LookupResult { branch: "main".into(), info: None }).unwrap();
@@ -867,7 +880,7 @@ mod tests {
         let mut cache = PrCache::new();
         cache.set_concurrency(1);
         let (tx, rx) = mpsc::channel::<LookupResult>();
-        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+        cache.insert_pending(PathBuf::from("/repo/wt"), "main", rx);
         drop(tx);
 
         cache.drain_completed();
@@ -875,18 +888,41 @@ mod tests {
         assert_eq!(cache.in_flight(), 0);
     }
 
+    /// A dead worker banks no answer, so nothing but the TTL can hold the entry
+    /// back — and the guard's repaint delivers the frame that would re-spawn it.
+    #[test]
+    fn a_dead_worker_leaves_the_entry_ineligible_to_respawn() {
+        let mut cache = PrCache::new();
+        let (tx, rx) = mpsc::channel::<LookupResult>();
+        cache.insert_pending(PathBuf::from("/repo/wt"), "main", rx);
+        drop(tx);
+
+        cache.drain_completed();
+
+        let entry = cache.entries.get(Path::new("/repo/wt")).unwrap();
+        assert!(
+            !should_spawn(
+                entry.branch.as_deref(),
+                Some("main"),
+                entry.queried_at,
+                entry.pending.is_some()
+            ),
+            "a dead worker must not leave the entry due on the very next frame"
+        );
+    }
+
     #[test]
     fn generation_advances_on_a_banked_result_and_holds_still_otherwise() {
         let mut cache = PrCache::new();
         let (_tx, rx) = mpsc::channel::<LookupResult>();
-        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+        cache.insert_pending(PathBuf::from("/repo/pending"), "main", rx);
 
         let before = cache.generation();
         cache.drain_completed();
         assert_eq!(cache.generation(), before, "a frame that banks nothing must not invalidate");
 
         let (tx, rx) = mpsc::channel();
-        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+        cache.insert_pending(PathBuf::from("/repo/banked"), "main", rx);
         tx.send(LookupResult { branch: "main".into(), info: None }).unwrap();
         cache.drain_completed();
         assert!(cache.generation() > before);
@@ -899,7 +935,7 @@ mod tests {
     fn a_refresh_during_a_lookup_survives_the_drain() {
         let mut cache = PrCache::new();
         let (tx, rx) = mpsc::channel();
-        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+        cache.insert_pending(PathBuf::from("/repo/wt"), "main", rx);
 
         cache.invalidate_all();
 

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -538,6 +538,13 @@ mod tests {
         assert!(parse_gh_output(b"[]", None).is_none());
     }
 
+    /// `gh` answers errors as a bare object, so valid JSON that is not a list
+    /// must degrade the same way malformed output does.
+    #[test]
+    fn rejects_json_that_is_not_a_list() {
+        assert!(parse_gh_output(b"{}", None).is_none());
+    }
+
     /// A head branch accumulates PRs over its life. `gh pr list` answers newest
     /// first, but the open one is the live PR — a newer abandoned attempt must
     /// not shadow it.
@@ -1009,6 +1016,25 @@ mod tests {
         assert!(may_spawn(2, 1));
         assert!(!may_spawn(2, 2));
         assert!(!may_spawn(2, 3), "an over-count must not reopen the gate");
+    }
+
+    /// The cap has to hold at the `poll` entry point, not just in the helper:
+    /// a cold cache polls every eligible worktree in one frame.
+    #[test]
+    fn poll_respects_the_concurrency_cap() {
+        let mut cache = PrCache::new();
+        cache.set_concurrency(1);
+        let (_tx, rx) = mpsc::channel::<LookupResult>();
+        cache.insert_pending(PathBuf::from("/repo/busy"), "main", rx);
+
+        let capped = Path::new("/repo/capped");
+        cache.poll(capped, Some("feature"), &egui::Context::default());
+
+        assert!(
+            cache.entries.get(capped).is_none_or(|entry| entry.pending.is_none()),
+            "the cap must refuse the second lookup"
+        );
+        assert_eq!(cache.in_flight(), 1);
     }
 
     /// The drain that frees a concurrency slot only runs on a frame, so a

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -335,13 +335,29 @@ fn pr_state(state: &str, is_draft: bool) -> PrState {
 /// the merged and closed badges that `pr list` would otherwise drop.
 fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
     const PR_JSON_FIELDS: &str = "number,baseRefName,url,state,isDraft,headRepositoryOwner";
+    // `--head` matches the ref name in every head repository and `--state all`
+    // keeps the closed and merged ones, so a generic branch name in a busy base
+    // repo overflows `gh`'s default page of 30 and the owner preference below
+    // never sees this checkout's own PR.
+    const PR_LIMIT: &str = "100";
     match wsl::classify(path) {
         wsl::Location::Windows(p) => {
             let owner = local_origin_owner(&p);
             let output = Command::new("gh")
                 .hide_console()
                 .current_dir(p)
-                .args(["pr", "list", "--head", branch, "--state", "all", "--json", PR_JSON_FIELDS])
+                .args([
+                    "pr",
+                    "list",
+                    "--head",
+                    branch,
+                    "--state",
+                    "all",
+                    "--limit",
+                    PR_LIMIT,
+                    "--json",
+                    PR_JSON_FIELDS,
+                ])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
                 .stdin(Stdio::null())
@@ -367,10 +383,13 @@ fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
             // the JSON always starts after exactly one newline.
             let script = r#"cd "$1" || exit 1
 printf '%s\n' "$(git config --get remote.origin.url 2>/dev/null)"
-exec "$2" pr list --head "$3" --state all --json "$4""#;
-            let stdout =
-                wsl::run_batch(&distro, script, &[&linux_path, &gh, branch, PR_JSON_FIELDS])
-                    .ok()?;
+exec "$2" pr list --head "$3" --state all --limit "$4" --json "$5""#;
+            let stdout = wsl::run_batch(
+                &distro,
+                script,
+                &[&linux_path, &gh, branch, PR_LIMIT, PR_JSON_FIELDS],
+            )
+            .ok()?;
             let (origin_url, json) = split_origin_url_line(&stdout);
             let owner = origin_url.and_then(github_owner_from_url);
             parse_gh_output(json, owner.as_deref())

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -43,12 +43,27 @@ pub struct PrInfo {
     pub state: PrState,
 }
 
-#[derive(Default)]
+/// Cap a cache carries until one is configured.  Zero is not a usable cap —
+/// it admits no lookup at all — so the field cannot be left at its numeric
+/// default.
+pub const DEFAULT_CONCURRENCY: usize = 8;
+
 pub struct PrCache {
     entries: HashMap<PathBuf, Entry>,
     in_flight: usize,
     concurrency: usize,
     generation: u64,
+}
+
+impl Default for PrCache {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            in_flight: 0,
+            concurrency: DEFAULT_CONCURRENCY,
+            generation: 0,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -136,8 +151,10 @@ impl PrCache {
 
     /// The cap on lookups in flight at once. A cold cache is otherwise ready
     /// to fork one `gh` process per eligible worktree in a single frame.
+    /// Clamped to one, since a zero cap would wedge the cache instead of
+    /// uncapping it.
     pub fn set_concurrency(&mut self, cap: usize) {
-        self.concurrency = cap;
+        self.concurrency = cap.max(1);
     }
 
     /// Bank every finished lookup and free its slot.  Runs once a frame ahead
@@ -1029,6 +1046,23 @@ mod tests {
         assert!(may_spawn(2, 1));
         assert!(!may_spawn(2, 2));
         assert!(!may_spawn(2, 3), "an over-count must not reopen the gate");
+    }
+
+    /// A zero cap admits nothing, so the cache cannot start life holding one:
+    /// a caller that never reaches `set_concurrency` would poll every frame
+    /// and spawn nothing.
+    #[test]
+    fn a_cache_that_was_never_configured_still_admits_a_lookup() {
+        let cache = PrCache::new();
+        assert!(may_spawn(cache.concurrency, cache.in_flight));
+    }
+
+    #[test]
+    fn set_concurrency_clamps_zero_to_one() {
+        let mut cache = PrCache::new();
+        cache.set_concurrency(0);
+        assert!(may_spawn(cache.concurrency, 0));
+        assert!(!may_spawn(cache.concurrency, 1));
     }
 
     /// The cap has to hold at the `poll` entry point, not just in the helper:

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -58,7 +58,9 @@ struct Entry {
     branch: Option<String>,
     info: Option<PrInfo>,
     queried_at: Option<Instant>,
-    /// Set while a background thread is running; drained on the next poll.
+    /// Set while a background thread is running.  `poll` reads this to
+    /// avoid starting a competing lookup; `drain_completed` is what banks
+    /// the result and clears it.
     pending: Option<Receiver<LookupResult>>,
     /// A refresh landed while `pending` was already occupied.  The drain
     /// leaves `queried_at` cleared instead of stamping the fresh lookup's
@@ -280,8 +282,9 @@ fn spawn_lookup(path: PathBuf, branch: String, ctx: egui::Context) -> Receiver<L
         // concurrency slot only runs on a frame, so an exit without a repaint
         // can stall polling for good.
         let _wake = RepaintOnDrop(ctx);
+        let _tx = tx;
         let info = query_gh(&path, &branch);
-        let _ = tx.send(LookupResult { branch, info });
+        let _ = _tx.send(LookupResult { branch, info });
     });
     rx
 }
@@ -577,6 +580,9 @@ mod tests {
     #[test]
     fn generation_advances_on_a_banked_result_and_holds_still_otherwise() {
         let mut cache = PrCache::new();
+        let (_tx, rx) = mpsc::channel::<LookupResult>();
+        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+
         let before = cache.generation();
         cache.drain_completed();
         assert_eq!(cache.generation(), before, "a frame that banks nothing must not invalidate");

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -35,7 +35,7 @@ pub enum PrState {
     Closed,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PrInfo {
     pub number: u64,
     pub base_branch: String,
@@ -46,8 +46,12 @@ pub struct PrInfo {
 #[derive(Default)]
 pub struct PrCache {
     entries: HashMap<PathBuf, Entry>,
+    in_flight: usize,
+    concurrency: usize,
+    generation: u64,
 }
 
+#[derive(Default)]
 struct Entry {
     /// Branch the cached result was queried for.  Switching branches in the
     /// same worktree invalidates the entry.
@@ -56,8 +60,13 @@ struct Entry {
     queried_at: Option<Instant>,
     /// Set while a background thread is running; drained on the next poll.
     pending: Option<Receiver<LookupResult>>,
+    /// A refresh landed while `pending` was already occupied.  The drain
+    /// leaves `queried_at` cleared instead of stamping the fresh lookup's
+    /// result as current, so the next poll re-queries.
+    refresh_requested: bool,
 }
 
+#[derive(Debug, PartialEq)]
 struct LookupResult {
     branch: String,
     info: Option<PrInfo>,
@@ -90,23 +99,7 @@ impl PrCache {
         branch: Option<&str>,
         ctx: &egui::Context,
     ) -> Option<PrInfo> {
-        let entry = self.entries.entry(path.to_path_buf()).or_insert_with(|| Entry {
-            branch: None,
-            info: None,
-            queried_at: None,
-            pending: None,
-        });
-
-        // Drain any completed background lookup before deciding whether to
-        // refresh — a result that just arrived shouldn't be ignored.
-        if let Some(rx) = entry.pending.as_ref() {
-            if let Ok(result) = rx.try_recv() {
-                entry.branch = Some(result.branch);
-                entry.info = result.info;
-                entry.queried_at = Some(Instant::now());
-                entry.pending = None;
-            }
-        }
+        let entry = self.entries.entry(path.to_path_buf()).or_default();
 
         // A `None` poll (the git-status compute hasn't produced a branch
         // yet, or never will) carries no information about the current
@@ -116,20 +109,121 @@ impl PrCache {
             return entry.info.clone();
         };
 
-        let invalidate = should_invalidate(entry.branch.as_deref(), Some(branch));
-        let fresh = entry.queried_at.map_or(false, |when| when.elapsed() < TTL);
+        let spawn = should_spawn(
+            entry.branch.as_deref(),
+            Some(branch),
+            entry.queried_at,
+            entry.pending.is_some(),
+        );
 
-        if (invalidate || !fresh) && entry.pending.is_none() {
+        if spawn && may_spawn(self.concurrency, self.in_flight) {
+            let invalidate = should_invalidate(entry.branch.as_deref(), Some(branch));
             // Clear stale data immediately on branch switch so we don't show
             // a PR base that belongs to a different branch.
             if invalidate {
                 entry.info = None;
             }
-            entry.pending = Some(spawn_lookup(path.to_path_buf(), branch.to_string(), ctx.clone()));
+            let rx = spawn_lookup(path.to_path_buf(), branch.to_string(), ctx.clone());
+            self.bank_pending(path.to_path_buf(), rx);
         }
 
-        entry.info.clone()
+        self.entries.get(path).and_then(|entry| entry.info.clone())
     }
+
+    /// Advances whenever what `state` would answer may have moved.  The sidebar
+    /// reconciler compares it to know a filtered row set needs rebuilding; a
+    /// banked result that happens to match the previous one costs one extra
+    /// rebuild, which is cheaper than diffing states to avoid it.
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// `0` means unlimited, which is how many `gh` processes a cold cache
+    /// already forks: one per eligible worktree, all in one frame.
+    pub fn set_concurrency(&mut self, cap: usize) {
+        self.concurrency = cap;
+    }
+
+    /// Bank every finished lookup and free its slot.  Runs once a frame ahead
+    /// of every poll site rather than inside `poll`: an entry whose project
+    /// collapsed mid-lookup is never polled again, and a slot it still held
+    /// would never come back.
+    pub fn drain_completed(&mut self) {
+        for entry in self.entries.values_mut() {
+            let Some(rx) = entry.pending.as_ref() else {
+                continue;
+            };
+            match rx.try_recv() {
+                Ok(result) => {
+                    entry.branch = Some(result.branch);
+                    entry.info = result.info;
+                    // A refresh that arrived mid-lookup wants the *next* answer,
+                    // so leave the entry stale and let the next poll re-query.
+                    entry.queried_at =
+                        if entry.refresh_requested { None } else { Some(Instant::now()) };
+                    entry.refresh_requested = false;
+                    entry.pending = None;
+                    self.in_flight = self.in_flight.saturating_sub(1);
+                    self.generation = self.generation.wrapping_add(1);
+                },
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    entry.pending = None;
+                    entry.refresh_requested = false;
+                    self.in_flight = self.in_flight.saturating_sub(1);
+                },
+                Err(mpsc::TryRecvError::Empty) => {},
+            }
+        }
+    }
+
+    /// Mark every entry stale.  Entries with a lookup already running also get
+    /// `refresh_requested`, because clearing `queried_at` alone cannot reach
+    /// them: `poll` will not spawn while `pending` is occupied, and the drain
+    /// would stamp a fresh timestamp over the request.
+    pub fn invalidate_all(&mut self) {
+        for entry in self.entries.values_mut() {
+            entry.queried_at = None;
+            if entry.pending.is_some() {
+                entry.refresh_requested = true;
+            }
+        }
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    fn bank_pending(&mut self, path: PathBuf, rx: Receiver<LookupResult>) {
+        self.entries.entry(path).or_default().pending = Some(rx);
+        self.in_flight += 1;
+    }
+
+    #[cfg(test)]
+    fn in_flight(&self) -> usize {
+        self.in_flight
+    }
+
+    #[cfg(test)]
+    fn insert_pending(&mut self, path: PathBuf, rx: Receiver<LookupResult>) {
+        self.bank_pending(path, rx);
+    }
+}
+
+/// Whether another lookup may start.  `0` is unlimited.
+fn may_spawn(concurrency: usize, in_flight: usize) -> bool {
+    concurrency == 0 || in_flight < concurrency
+}
+
+/// Whether this entry is due for a lookup, ignoring the concurrency cap.
+fn should_spawn(
+    cached_branch: Option<&str>,
+    branch: Option<&str>,
+    queried_at: Option<Instant>,
+    pending: bool,
+) -> bool {
+    if pending {
+        return false;
+    }
+    let invalidate = should_invalidate(cached_branch, branch);
+    let fresh = queried_at.map_or(false, |when| when.elapsed() < TTL);
+    invalidate || !fresh
 }
 
 /// A `None` incoming branch never invalidates — the caller has nothing to
@@ -182,11 +276,22 @@ pub fn effective_branch<'a>(
 fn spawn_lookup(path: PathBuf, branch: String, ctx: egui::Context) -> Receiver<LookupResult> {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
+        // Fires on a panicking unwind too: the drain that frees this lookup's
+        // concurrency slot only runs on a frame, so an exit without a repaint
+        // can stall polling for good.
+        let _wake = RepaintOnDrop(ctx);
         let info = query_gh(&path, &branch);
         let _ = tx.send(LookupResult { branch, info });
-        ctx.request_repaint();
     });
     rx
+}
+
+struct RepaintOnDrop(egui::Context);
+
+impl Drop for RepaintOnDrop {
+    fn drop(&mut self) {
+        self.0.request_repaint();
+    }
 }
 
 fn pr_state(state: &str, is_draft: bool) -> PrState {
@@ -329,6 +434,7 @@ mod tests {
                 info: Some(sample_info()),
                 queried_at: Some(Instant::now()),
                 pending: None,
+                refresh_requested: false,
             },
         );
 
@@ -427,6 +533,7 @@ mod tests {
                 }),
                 queried_at: None,
                 pending: None,
+                refresh_requested: false,
             },
         );
 
@@ -434,5 +541,155 @@ mod tests {
         assert_eq!(cache.state(p, Some("main")), Some(PrState::Open));
         assert_eq!(cache.state(p, Some("feature")), None);
         assert_eq!(cache.state(p, None), None);
+    }
+
+    /// A collapsed project stops polling its entry, so a decrement that lived
+    /// in `poll` would strand the slot forever.
+    #[test]
+    fn drain_completed_frees_a_slot_for_an_entry_nobody_polls() {
+        let mut cache = PrCache::new();
+        cache.set_concurrency(1);
+        let (tx, rx) = mpsc::channel();
+        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+        assert_eq!(cache.in_flight(), 1);
+
+        tx.send(LookupResult { branch: "main".into(), info: None }).unwrap();
+        cache.drain_completed();
+
+        assert_eq!(cache.in_flight(), 0);
+    }
+
+    /// A worker that panics never sends. Without a decrement here a capped
+    /// cache stops polling permanently.
+    #[test]
+    fn drain_completed_frees_a_slot_for_a_disconnected_worker() {
+        let mut cache = PrCache::new();
+        cache.set_concurrency(1);
+        let (tx, rx) = mpsc::channel::<LookupResult>();
+        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+        drop(tx);
+
+        cache.drain_completed();
+
+        assert_eq!(cache.in_flight(), 0);
+    }
+
+    #[test]
+    fn generation_advances_on_a_banked_result_and_holds_still_otherwise() {
+        let mut cache = PrCache::new();
+        let before = cache.generation();
+        cache.drain_completed();
+        assert_eq!(cache.generation(), before, "a frame that banks nothing must not invalidate");
+
+        let (tx, rx) = mpsc::channel();
+        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+        tx.send(LookupResult { branch: "main".into(), info: None }).unwrap();
+        cache.drain_completed();
+        assert!(cache.generation() > before);
+    }
+
+    /// A refresh that lands while a lookup is in flight must survive it: `poll`
+    /// only spawns when `pending` is empty, and the drain would otherwise stamp
+    /// a fresh `queried_at` and swallow the request.
+    #[test]
+    fn a_refresh_during_a_lookup_survives_the_drain() {
+        let mut cache = PrCache::new();
+        let (tx, rx) = mpsc::channel();
+        cache.insert_pending(PathBuf::from("/repo/wt"), rx);
+
+        cache.invalidate_all();
+
+        tx.send(LookupResult { branch: "main".into(), info: None }).unwrap();
+        cache.drain_completed();
+
+        let entry = cache.entries.get(Path::new("/repo/wt")).unwrap();
+        assert!(entry.queried_at.is_none(), "the next poll must re-query");
+        assert!(!entry.refresh_requested, "and the request is spent, not sticky");
+        // `queried_at: None` is only the precondition; assert the decision that
+        // actually re-queries, or this passes with a `poll` that never spawns.
+        assert!(
+            should_spawn(
+                entry.branch.as_deref(),
+                Some("main"),
+                entry.queried_at,
+                entry.pending.is_some()
+            ),
+            "a spent refresh must leave the entry eligible to spawn"
+        );
+    }
+
+    /// Setting the flag on idle entries too would double-poll every one of
+    /// them: the drain banks nothing, `poll` starts the lookup, and the still-set
+    /// flag then refuses to stamp `queried_at`, so a second lookup starts.
+    #[test]
+    fn a_refresh_on_an_idle_entry_does_not_set_the_flag() {
+        let mut cache = PrCache::new();
+        cache.entries.insert(
+            PathBuf::from("/repo/wt"),
+            Entry {
+                branch: Some("main".into()),
+                info: None,
+                queried_at: Some(Instant::now()),
+                pending: None,
+                refresh_requested: false,
+            },
+        );
+
+        cache.invalidate_all();
+
+        let entry = cache.entries.get(Path::new("/repo/wt")).unwrap();
+        assert!(entry.queried_at.is_none());
+        assert!(!entry.refresh_requested);
+    }
+
+    #[test]
+    fn the_cap_admits_until_it_is_reached_and_zero_never_blocks() {
+        assert!(may_spawn(0, 0));
+        assert!(may_spawn(0, 99), "0 is unlimited");
+        assert!(may_spawn(2, 0));
+        assert!(may_spawn(2, 1));
+        assert!(!may_spawn(2, 2));
+        assert!(!may_spawn(2, 3), "an over-count must not reopen the gate");
+    }
+
+    /// The drain that frees a concurrency slot only runs on a frame, so a
+    /// worker that exits without waking the app can stall polling for good.
+    #[test]
+    fn dropping_the_guard_wakes_the_app() {
+        let ctx = egui::Context::default();
+        // A fresh context always wants an initial repaint, and `run` only
+        // clears it once that first request has been consumed — hence two
+        // passes, so the assertion below can only be satisfied by the guard.
+        let _ = ctx.run(Default::default(), |_| {});
+        let _ = ctx.run(Default::default(), |_| {});
+        assert!(!ctx.has_requested_repaint(), "precondition: no repaint pending");
+
+        drop(RepaintOnDrop(ctx.clone()));
+
+        assert!(ctx.has_requested_repaint());
+    }
+
+    #[test]
+    fn a_panicking_worker_still_wakes_the_app_and_disconnects() {
+        let ctx = egui::Context::default();
+        // See `dropping_the_guard_wakes_the_app`: a fresh context needs two
+        // passes before its initial repaint request is fully consumed.
+        let _ = ctx.run(Default::default(), |_| {});
+        let _ = ctx.run(Default::default(), |_| {});
+        assert!(!ctx.has_requested_repaint(), "precondition: no repaint pending");
+        let (tx, rx) = mpsc::channel::<LookupResult>();
+
+        let worker = {
+            let ctx = ctx.clone();
+            thread::spawn(move || {
+                let _wake = RepaintOnDrop(ctx);
+                let _tx = tx;
+                panic!("worker died");
+            })
+        };
+        assert!(worker.join().is_err(), "the worker must have panicked");
+
+        assert!(ctx.has_requested_repaint(), "a panicking unwind still wakes the app");
+        assert_eq!(rx.try_recv(), Err(mpsc::TryRecvError::Disconnected));
     }
 }

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -310,9 +310,16 @@ fn pr_state(state: &str, is_draft: bool) -> PrState {
 
 /// Ask `gh` for the PR associated with `branch` in `path`.  Returns `None`
 /// on any failure mode (no `gh`, not authenticated, no PR, non-GitHub
-/// remote, ...).  The branch is passed as a positional selector so the
-/// answer is tied to that specific branch rather than whatever ref happens
-/// to be checked out in the worktree.
+/// remote, ...).  The branch is named explicitly so the answer is tied to
+/// that specific branch rather than whatever ref happens to be checked out
+/// in the worktree.
+///
+/// `--head` rather than `gh pr view <branch>`: `pr view` matches a PR's head
+/// *label*, which is the bare branch only while the head lives in the base
+/// repo and becomes `owner:branch` once it lives on a fork.  A checkout whose
+/// `origin` is a personal fork therefore finds nothing.  `--head` filters on
+/// the head ref name alone, which both layouts share, and `--state all` keeps
+/// the merged and closed badges that `pr list` would otherwise drop.
 fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
     const PR_JSON_FIELDS: &str = "number,baseRefName,url,state,isDraft";
     match wsl::classify(path) {
@@ -320,7 +327,7 @@ fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
             let output = Command::new("gh")
                 .hide_console()
                 .current_dir(p)
-                .args(["pr", "view", branch, "--json", PR_JSON_FIELDS])
+                .args(["pr", "list", "--head", branch, "--state", "all", "--json", PR_JSON_FIELDS])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
                 .stdin(Stdio::null())
@@ -339,7 +346,7 @@ fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
         // `--exec` PATH lacks.
         wsl::Location::Wsl { distro, linux_path } => {
             let gh = crate::wsl_helper::capability_gh(&distro).unwrap_or_else(|| "gh".to_string());
-            let script = r#"cd "$1" && exec "$2" pr view "$3" --json "$4""#;
+            let script = r#"cd "$1" && exec "$2" pr list --head "$3" --state all --json "$4""#;
             let stdout =
                 wsl::run_batch(&distro, script, &[&linux_path, &gh, branch, PR_JSON_FIELDS])
                     .ok()?;
@@ -348,8 +355,19 @@ fn query_gh(path: &Path, branch: &str) -> Option<PrInfo> {
     }
 }
 
+/// Pick the PR a head branch's badge should show.  `gh pr list` answers newest
+/// first, and a branch accumulates PRs over its life; an open one is the live
+/// PR, so it outranks a newer abandoned attempt.  Drafts report `OPEN` too, so
+/// this covers them.  Mirrors how `gh pr view` orders its own candidates.
+fn select_pr(prs: &[serde_json::Value]) -> Option<&serde_json::Value> {
+    prs.iter()
+        .find(|pr| pr.get("state").and_then(|s| s.as_str()) == Some("OPEN"))
+        .or_else(|| prs.first())
+}
+
 fn parse_gh_output(stdout: &[u8]) -> Option<PrInfo> {
-    let value: serde_json::Value = serde_json::from_slice(stdout).ok()?;
+    let list: serde_json::Value = serde_json::from_slice(stdout).ok()?;
+    let value = select_pr(list.as_array()?)?;
     let number = value.get("number")?.as_u64()?;
     let base = value.get("baseRefName")?.as_str()?.to_string();
     let url = value.get("url")?.as_str()?.to_string();
@@ -365,7 +383,7 @@ mod tests {
     #[test]
     fn parses_gh_json() {
         let stdout =
-            br#"{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}"#;
+            br#"[{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}]"#;
         let info = parse_gh_output(stdout).unwrap();
         assert_eq!(info.number, 42);
         assert_eq!(info.base_branch, "main");
@@ -378,6 +396,48 @@ mod tests {
     }
 
     #[test]
+    fn rejects_an_empty_pr_list() {
+        assert!(parse_gh_output(b"[]").is_none());
+    }
+
+    /// A head branch accumulates PRs over its life. `gh pr list` answers newest
+    /// first, but the open one is the live PR — a newer abandoned attempt must
+    /// not shadow it.
+    #[test]
+    fn an_open_pr_wins_over_a_newer_closed_one() {
+        let stdout = br#"[
+            {"baseRefName":"main","number":9,"url":"u9","state":"CLOSED","isDraft":false},
+            {"baseRefName":"main","number":4,"url":"u4","state":"OPEN","isDraft":false}
+        ]"#;
+        let info = parse_gh_output(stdout).unwrap();
+        assert_eq!(info.number, 4);
+        assert_eq!(info.state, PrState::Open);
+    }
+
+    #[test]
+    fn a_draft_counts_as_open_when_selecting() {
+        let stdout = br#"[
+            {"baseRefName":"main","number":9,"url":"u9","state":"MERGED","isDraft":false},
+            {"baseRefName":"main","number":4,"url":"u4","state":"OPEN","isDraft":true}
+        ]"#;
+        let info = parse_gh_output(stdout).unwrap();
+        assert_eq!(info.number, 4);
+        assert_eq!(info.state, PrState::Draft);
+    }
+
+    /// With nothing open, the newest attempt is the one worth painting.
+    #[test]
+    fn the_newest_pr_wins_when_none_are_open() {
+        let stdout = br#"[
+            {"baseRefName":"main","number":9,"url":"u9","state":"MERGED","isDraft":false},
+            {"baseRefName":"main","number":4,"url":"u4","state":"CLOSED","isDraft":false}
+        ]"#;
+        let info = parse_gh_output(stdout).unwrap();
+        assert_eq!(info.number, 9);
+        assert_eq!(info.state, PrState::Merged);
+    }
+
+    #[test]
     fn parses_pr_states() {
         for (json_state, is_draft, expected) in [
             ("OPEN", false, PrState::Open),
@@ -387,7 +447,7 @@ mod tests {
             ("SOMETHING_NEW", false, PrState::Open),
         ] {
             let stdout = format!(
-                r#"{{"baseRefName":"main","number":1,"url":"https://github.com/o/r/pull/1","state":"{json_state}","isDraft":{is_draft}}}"#
+                r#"[{{"baseRefName":"main","number":1,"url":"https://github.com/o/r/pull/1","state":"{json_state}","isDraft":{is_draft}}}]"#
             );
             let info = parse_gh_output(stdout.as_bytes()).unwrap();
             assert_eq!(info.state, expected, "state={json_state} draft={is_draft}");
@@ -398,7 +458,7 @@ mod tests {
     fn missing_state_fields_default_to_open() {
         // Old gh versions may omit fields we didn't ask for; degrade, don't drop.
         let stdout =
-            br#"{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}"#;
+            br#"[{"baseRefName":"main","number":42,"url":"https://github.com/o/r/pull/42"}]"#;
         assert_eq!(parse_gh_output(stdout).unwrap().state, PrState::Open);
     }
 

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -134,8 +134,8 @@ impl PrCache {
         self.generation
     }
 
-    /// `0` means unlimited, which is how many `gh` processes a cold cache
-    /// already forks: one per eligible worktree, all in one frame.
+    /// The cap on lookups in flight at once. A cold cache is otherwise ready
+    /// to fork one `gh` process per eligible worktree in a single frame.
     pub fn set_concurrency(&mut self, cap: usize) {
         self.concurrency = cap;
     }
@@ -221,9 +221,9 @@ impl PrCache {
     }
 }
 
-/// Whether another lookup may start.  `0` is unlimited.
+/// Whether another lookup may start.
 fn may_spawn(concurrency: usize, in_flight: usize) -> bool {
-    concurrency == 0 || in_flight < concurrency
+    in_flight < concurrency
 }
 
 /// Whether this entry is due for a lookup, ignoring the concurrency cap.
@@ -1023,9 +1023,8 @@ mod tests {
     }
 
     #[test]
-    fn the_cap_admits_until_it_is_reached_and_zero_never_blocks() {
-        assert!(may_spawn(0, 0));
-        assert!(may_spawn(0, 99), "0 is unlimited");
+    fn the_cap_admits_until_it_is_reached() {
+        assert!(!may_spawn(0, 0), "a zero cap never admits a lookup");
         assert!(may_spawn(2, 0));
         assert!(may_spawn(2, 1));
         assert!(!may_spawn(2, 2));

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -17,6 +17,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::command_ext::CommandExt;
+use crate::projects::Worktree;
 use crate::wsl;
 
 /// Re-query at most this often.  PR base branches rarely change, and a stale
@@ -65,6 +66,18 @@ struct LookupResult {
 impl PrCache {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// The state of a cached lookup, without starting or refreshing one.
+    /// `None` unless the entry was queried for `branch`: an entry is keyed by
+    /// path but only ever valid for one branch, so a caller reading it under a
+    /// different branch would be reading the previous branch's PR.
+    pub fn state(&self, path: &Path, branch: Option<&str>) -> Option<PrState> {
+        let entry = self.entries.get(path)?;
+        if entry.branch.as_deref() != branch {
+            return None;
+        }
+        entry.info.as_ref().map(|i| i.state)
     }
 
     /// Returns the PR info known for `(path, branch)` right now, kicking off
@@ -126,6 +139,43 @@ fn should_invalidate(cached_branch: Option<&str>, incoming_branch: Option<&str>)
     match incoming_branch {
         None => false,
         Some(_) => cached_branch != incoming_branch,
+    }
+}
+
+/// Whether a worktree in `state` survives the projects panel's PR dimension.
+/// The active states union; with none active every worktree passes.  An unknown
+/// state — no lookup yet, no PR, or no `gh` — satisfies no active toggle.
+pub fn pr_pass(
+    state: Option<PrState>,
+    open: bool,
+    draft: bool,
+    merged: bool,
+    closed: bool,
+) -> bool {
+    if !(open || draft || merged || closed) {
+        return true;
+    }
+    match state {
+        None => false,
+        Some(PrState::Open) => open,
+        Some(PrState::Draft) => draft,
+        Some(PrState::Merged) => merged,
+        Some(PrState::Closed) => closed,
+    }
+}
+
+/// The branch a worktree's PR lookup is keyed to.  The active worktree prefers
+/// its live status branch; every other worktree, and an active one whose
+/// `StatusCache` has not produced a branch yet, uses the stored snapshot.
+pub fn effective_branch<'a>(
+    wt: &'a Worktree,
+    current_workspace: Option<&Path>,
+    live_branch: Option<&'a str>,
+) -> Option<&'a str> {
+    if current_workspace == Some(wt.path.as_path()) {
+        live_branch.or(wt.branch.as_deref())
+    } else {
+        wt.branch.as_deref()
     }
 }
 
@@ -290,5 +340,99 @@ mod tests {
         assert_eq!(entry.branch.as_deref(), Some("b"));
         assert!(entry.info.is_some(), "None poll must not clear the cached info");
         assert!(entry.pending.is_none(), "None poll must not spawn a competing lookup");
+    }
+
+    fn worktree(path: &str, branch: Option<&str>) -> Worktree {
+        Worktree {
+            name: String::new(),
+            path: PathBuf::from(path),
+            branch: branch.map(String::from),
+            is_main: false,
+            prunable: false,
+        }
+    }
+
+    #[test]
+    fn no_active_pr_toggle_passes_every_state() {
+        for state in [
+            None,
+            Some(PrState::Open),
+            Some(PrState::Draft),
+            Some(PrState::Merged),
+            Some(PrState::Closed),
+        ] {
+            assert!(pr_pass(state, false, false, false, false), "{state:?}");
+        }
+    }
+
+    #[test]
+    fn an_active_pr_toggle_admits_only_its_own_state() {
+        assert!(pr_pass(Some(PrState::Open), true, false, false, false));
+        assert!(!pr_pass(Some(PrState::Draft), true, false, false, false));
+        assert!(!pr_pass(Some(PrState::Merged), true, false, false, false));
+    }
+
+    #[test]
+    fn pr_toggles_union_within_the_dimension() {
+        for state in [PrState::Open, PrState::Draft] {
+            assert!(pr_pass(Some(state), true, true, false, false), "{state:?}");
+        }
+        assert!(!pr_pass(Some(PrState::Closed), true, true, false, false));
+    }
+
+    /// No lookup yet, no PR, or no `gh` are indistinguishable here, and none of
+    /// them is evidence a worktree belongs in a PR-filtered list.
+    #[test]
+    fn an_unknown_state_never_satisfies_an_active_toggle() {
+        assert!(!pr_pass(None, true, false, false, false));
+        assert!(!pr_pass(None, true, true, true, true));
+    }
+
+    #[test]
+    fn effective_branch_prefers_the_live_branch_for_the_active_worktree() {
+        let wt = worktree("/repo/wt", Some("stored"));
+        let active = Some(Path::new("/repo/wt"));
+        assert_eq!(effective_branch(&wt, active, Some("live")), Some("live"));
+    }
+
+    /// A workspace that just became active has a fresh `StatusCache` with no
+    /// branch yet; falling back to the stored one is what stops a valid cached
+    /// lookup from reading as unknown for a frame.
+    #[test]
+    fn effective_branch_falls_back_to_the_stored_branch() {
+        let wt = worktree("/repo/wt", Some("stored"));
+        let active = Some(Path::new("/repo/wt"));
+        assert_eq!(effective_branch(&wt, active, None), Some("stored"));
+    }
+
+    #[test]
+    fn effective_branch_ignores_a_live_branch_from_another_workspace() {
+        let wt = worktree("/repo/wt", Some("stored"));
+        let active = Some(Path::new("/repo/other"));
+        assert_eq!(effective_branch(&wt, active, Some("live")), Some("stored"));
+    }
+
+    #[test]
+    fn state_is_none_for_a_branch_the_entry_was_not_queried_for() {
+        let mut cache = PrCache::new();
+        cache.entries.insert(
+            PathBuf::from("/repo/wt"),
+            Entry {
+                branch: Some("main".into()),
+                info: Some(PrInfo {
+                    number: 1,
+                    base_branch: "master".into(),
+                    url: String::new(),
+                    state: PrState::Open,
+                }),
+                queried_at: None,
+                pending: None,
+            },
+        );
+
+        let p = Path::new("/repo/wt");
+        assert_eq!(cache.state(p, Some("main")), Some(PrState::Open));
+        assert_eq!(cache.state(p, Some("feature")), None);
+        assert_eq!(cache.state(p, None), None);
     }
 }

--- a/alacritree/src/sidebar_focus.rs
+++ b/alacritree/src/sidebar_focus.rs
@@ -8,7 +8,7 @@
 //! return from, while a row gone from the model was deleted and the cursor
 //! slides to a sibling.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::app::WorkspaceKey;
 use crate::projects::Project;
@@ -301,6 +301,18 @@ pub struct UiInputs<'a> {
     pub session_rows_always: bool,
     pub query: &'a str,
     pub toggles: u32,
+    /// Whether the toggles narrow rows this frame.  A search scope that stands
+    /// them down changes the projection while `toggles` itself holds still.
+    pub toggles_apply: bool,
+    /// Advances when a PR lookup is banked or invalidated.  Fed as `0` unless a
+    /// PR filter is active, so a completion cannot invalidate a projection it
+    /// could not have changed.
+    pub pr_generation: u64,
+    /// The workspace whose live branch `active_branch` describes.  Without it a
+    /// switch between two worktrees whose caches hold the same branch string
+    /// moves every PR lookup key while nothing observed changes.
+    pub active_workspace: Option<&'a Path>,
+    pub active_branch: Option<&'a str>,
 }
 
 #[cfg(test)]
@@ -332,7 +344,7 @@ struct ProjectInput {
     root: PathBuf,
     name: String,
     expanded: bool,
-    worktrees: Vec<(PathBuf, String, bool)>,
+    worktrees: Vec<(PathBuf, String, bool, Option<String>)>,
 }
 
 /// Everything the snapshot is a function of.  Captured on rebuild, compared
@@ -344,6 +356,10 @@ pub struct ObservedInputs {
     session_rows_always: bool,
     query: String,
     toggles: u32,
+    toggles_apply: bool,
+    pr_generation: u64,
+    active_workspace: Option<PathBuf>,
+    active_branch: Option<String>,
 }
 
 impl ObservedInputs {
@@ -362,7 +378,9 @@ impl ObservedInputs {
                     worktrees: p
                         .worktrees
                         .iter()
-                        .map(|wt| (wt.path.clone(), wt.name.clone(), wt.prunable))
+                        .map(|wt| {
+                            (wt.path.clone(), wt.name.clone(), wt.prunable, wt.branch.clone())
+                        })
                         .collect(),
                 })
                 .collect(),
@@ -370,6 +388,10 @@ impl ObservedInputs {
             session_rows_always: ui.session_rows_always,
             query: ui.query.to_string(),
             toggles: ui.toggles,
+            toggles_apply: ui.toggles_apply,
+            pr_generation: ui.pr_generation,
+            active_workspace: ui.active_workspace.map(Path::to_path_buf),
+            active_branch: ui.active_branch.map(str::to_string),
         }
     }
 
@@ -390,6 +412,10 @@ impl ObservedInputs {
         if self.session_rows_always != ui.session_rows_always
             || self.query != ui.query
             || self.toggles != ui.toggles
+            || self.toggles_apply != ui.toggles_apply
+            || self.pr_generation != ui.pr_generation
+            || self.active_workspace.as_deref() != ui.active_workspace
+            || self.active_branch.as_deref() != ui.active_branch
         {
             return false;
         }
@@ -407,7 +433,10 @@ impl ObservedInputs {
             }
             for (wt_was, wt_now) in was.worktrees.iter().zip(&now.worktrees) {
                 visit();
-                if wt_was.0 != wt_now.path || wt_was.1 != wt_now.name || wt_was.2 != wt_now.prunable
+                if wt_was.0 != wt_now.path
+                    || wt_was.1 != wt_now.name
+                    || wt_was.2 != wt_now.prunable
+                    || wt_was.3 != wt_now.branch
                 {
                     return false;
                 }
@@ -442,7 +471,74 @@ mod tests {
     }
 
     fn ui(query: &str, toggles: u32) -> UiInputs<'_> {
-        UiInputs { session_rows_always: false, query, toggles }
+        UiInputs {
+            session_rows_always: false,
+            query,
+            toggles,
+            toggles_apply: true,
+            pr_generation: 0,
+            active_workspace: None,
+            active_branch: None,
+        }
+    }
+
+    fn ui_full<'a>(
+        query: &'a str,
+        toggles: u32,
+        toggles_apply: bool,
+        pr_generation: u64,
+        active_workspace: Option<&'a Path>,
+        active_branch: Option<&'a str>,
+    ) -> UiInputs<'a> {
+        UiInputs {
+            session_rows_always: false,
+            query,
+            toggles,
+            toggles_apply,
+            pr_generation,
+            active_workspace,
+            active_branch,
+        }
+    }
+
+    /// Each new field is a way the row set moves without any older field
+    /// moving. Missing one leaves the sidebar showing a stale projection.
+    #[test]
+    fn each_new_ui_input_invalidates_the_snapshot() {
+        let projects: Vec<Project> = Vec::new();
+        let none: [SessionInput<'_>; 0] = [];
+        let wt = PathBuf::from("/repo/wt");
+
+        let base = ui_full("q", 0b01, true, 7, Some(&wt), Some("main"));
+        let captured = ObservedInputs::capture(&projects, none.iter().copied(), base);
+
+        assert!(captured.matches(&projects, none.iter().copied(), base), "control");
+
+        for changed in [
+            ui_full("q", 0b01, false, 7, Some(&wt), Some("main")),
+            ui_full("q", 0b01, true, 8, Some(&wt), Some("main")),
+            ui_full("q", 0b01, true, 7, None, Some("main")),
+            ui_full("q", 0b01, true, 7, Some(&wt), Some("feature")),
+        ] {
+            assert!(
+                !captured.matches(&projects, none.iter().copied(), changed),
+                "a changed input reported unchanged: {changed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_worktree_branch_change_invalidates_the_snapshot() {
+        use crate::sidebar_nav::tests::project;
+
+        let mut a = project("/a", true, &["/a/wt1"]);
+        a.worktrees[0].branch = Some("main".to_string());
+        let base = ObservedInputs::capture(&[a.clone()], std::iter::empty(), ui("", 0));
+
+        let mut changed = a.clone();
+        changed.worktrees[0].branch = Some("feature".to_string());
+
+        assert!(!base.matches(&[changed], std::iter::empty(), ui("", 0)));
     }
 
     /// home, project /a expanded with worktree /a/wt1 holding sessions 1 and 2.
@@ -527,7 +623,15 @@ mod tests {
         assert!(!base.matches(
             &[],
             [session(&HOME, 1, false)].into_iter(),
-            UiInputs { session_rows_always: true, query: "", toggles: 0 },
+            UiInputs {
+                session_rows_always: true,
+                query: "",
+                toggles: 0,
+                toggles_apply: true,
+                pr_generation: 0,
+                active_workspace: None,
+                active_branch: None,
+            },
         ));
 
         // Each session input on its own: attention, id, count.

--- a/alacritree/src/sidebar_focus.rs
+++ b/alacritree/src/sidebar_focus.rs
@@ -11,7 +11,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::app::WorkspaceKey;
-use crate::projects::Project;
+use crate::projects::{Project, Worktree};
 use crate::session::SessionId;
 use crate::sidebar_nav::SidebarRow;
 
@@ -344,7 +344,50 @@ struct ProjectInput {
     root: PathBuf,
     name: String,
     expanded: bool,
-    worktrees: Vec<(PathBuf, String, bool, Option<String>)>,
+    worktrees: Vec<WorktreeInput>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct WorktreeInput {
+    path: PathBuf,
+    name: String,
+    prunable: bool,
+    branch: Option<String>,
+}
+
+/// A [`WorktreeInput`] and a live [`Worktree`] reduced to the same borrowed
+/// shape.  The compare path runs every frame and must not allocate, so the two
+/// are matched through this rather than by cloning one into the other's type —
+/// and a field added to `WorktreeInput` without a view of it stops compiling
+/// instead of silently dropping out of the comparison.
+#[derive(PartialEq, Eq)]
+struct WorktreeView<'a> {
+    path: &'a Path,
+    name: &'a str,
+    prunable: bool,
+    branch: Option<&'a str>,
+}
+
+impl WorktreeInput {
+    fn view(&self) -> WorktreeView<'_> {
+        WorktreeView {
+            path: &self.path,
+            name: &self.name,
+            prunable: self.prunable,
+            branch: self.branch.as_deref(),
+        }
+    }
+}
+
+impl<'a> From<&'a Worktree> for WorktreeView<'a> {
+    fn from(wt: &'a Worktree) -> Self {
+        Self {
+            path: &wt.path,
+            name: &wt.name,
+            prunable: wt.prunable,
+            branch: wt.branch.as_deref(),
+        }
+    }
 }
 
 /// Everything the snapshot is a function of.  Captured on rebuild, compared
@@ -378,8 +421,11 @@ impl ObservedInputs {
                     worktrees: p
                         .worktrees
                         .iter()
-                        .map(|wt| {
-                            (wt.path.clone(), wt.name.clone(), wt.prunable, wt.branch.clone())
+                        .map(|wt| WorktreeInput {
+                            path: wt.path.clone(),
+                            name: wt.name.clone(),
+                            prunable: wt.prunable,
+                            branch: wt.branch.clone(),
                         })
                         .collect(),
                 })
@@ -433,11 +479,7 @@ impl ObservedInputs {
             }
             for (wt_was, wt_now) in was.worktrees.iter().zip(&now.worktrees) {
                 visit();
-                if wt_was.0 != wt_now.path
-                    || wt_was.1 != wt_now.name
-                    || wt_was.2 != wt_now.prunable
-                    || wt_was.3 != wt_now.branch
-                {
+                if wt_was.view() != WorktreeView::from(wt_now) {
                     return false;
                 }
             }

--- a/alacritree/src/steady_state.rs
+++ b/alacritree/src/steady_state.rs
@@ -111,7 +111,15 @@ mod tests {
     fn an_unchanged_frame_allocates_nothing() {
         let projects = tree(10, 5);
         let live = sessions(150);
-        let ui = UiInputs { session_rows_always: false, query: "", toggles: 0 };
+        let ui = UiInputs {
+            session_rows_always: false,
+            query: "",
+            toggles: 0,
+            toggles_apply: true,
+            pr_generation: 0,
+            active_workspace: None,
+            active_branch: None,
+        };
         let base = ObservedInputs::capture(&projects, inputs(&live), ui);
 
         let (same, counts) = measure(|| base.matches(&projects, inputs(&live), ui));
@@ -129,7 +137,15 @@ mod tests {
     fn an_unchanged_filtering_frame_allocates_nothing() {
         let projects = tree(10, 5);
         let live = sessions(150);
-        let ui = UiInputs { session_rows_always: false, query: "worktree-3", toggles: 0b11 };
+        let ui = UiInputs {
+            session_rows_always: false,
+            query: "worktree-3",
+            toggles: 0b11,
+            toggles_apply: true,
+            pr_generation: 0,
+            active_workspace: None,
+            active_branch: None,
+        };
         let base = ObservedInputs::capture(&projects, inputs(&live), ui);
 
         let (same, counts) = measure(|| base.matches(&projects, inputs(&live), ui));
@@ -142,7 +158,15 @@ mod tests {
     fn the_compare_is_linear_in_the_tree_size() {
         let small = tree(10, 5);
         let big = tree(50, 10);
-        let ui = UiInputs { session_rows_always: false, query: "", toggles: 0 };
+        let ui = UiInputs {
+            session_rows_always: false,
+            query: "",
+            toggles: 0,
+            toggles_apply: true,
+            pr_generation: 0,
+            active_workspace: None,
+            active_branch: None,
+        };
 
         let base_small = ObservedInputs::capture(&small, std::iter::empty(), ui);
         sidebar_focus::reset_visits();
@@ -172,7 +196,15 @@ mod tests {
         for (p, w, s) in [(10, 5, 150), (50, 10, 500)] {
             let projects = tree(p, w);
             let live = sessions(s);
-            let ui = UiInputs { session_rows_always: false, query: "", toggles: 0 };
+            let ui = UiInputs {
+                session_rows_always: false,
+                query: "",
+                toggles: 0,
+                toggles_apply: true,
+                pr_generation: 0,
+                active_workspace: None,
+                active_branch: None,
+            };
             let base = ObservedInputs::capture(&projects, inputs(&live), ui);
 
             // Warm the caches so the first iteration is not the whole sample.

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -323,6 +323,12 @@ vsync              = true   # restart required — wait for the display's refres
                             # before showing a finished frame (default true).
                             # false presents each frame as soon as it is drawn,
                             # trading tearing for lower keystroke-to-screen delay
+search_scope       = "filtered"  # whether a sidebar search is confined by the
+                                 # active toggle filters
+                                 # "filtered" (default): a query narrows what
+                                 # the toggles already allow
+                                 # "all": a query reaches every row; the
+                                 # toggles resume when it empties
 confirm_session_close = "never"  # when the sidebar × asks before killing a PTY:
                                  # "never" (default) | "busy" | "always"
 last_session_close = "respawn"   # closing the on-screen workspace's last
@@ -330,6 +336,8 @@ last_session_close = "respawn"   # closing the on-screen workspace's last
                                  # one, "navigate" moves to another workspace
 pr_status          = false  # poll `gh` for each branch's open PR, which drives
                             # the PR row icons and $pr below (default false)
+pr_status_concurrency = 0   # cap concurrent `gh` PR lookups; 0 (default) is
+                            # unlimited
 delta_path         = "delta"     # explicit delta binary for the diff pane;
                                  # unset discovers it on PATH
 worktree_name      = "$name ${pr: }"  # template for worktree row labels:

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -337,8 +337,8 @@ last_session_close = "respawn"   # closing the on-screen workspace's last
 pr_status          = false  # poll `gh` for each branch's open PR, which drives
                             # the PR row icons, the PR-state filters, and $pr
                             # below (default false)
-pr_status_concurrency = 0   # cap concurrent `gh` PR lookups; 0 (default) is
-                            # unlimited
+pr_status_concurrency = 8   # cap concurrent `gh` PR lookups; default 8,
+                            # clamped to a minimum of 1
 delta_path         = "delta"     # explicit delta binary for the diff pane;
                                  # unset discovers it on PATH
 worktree_name      = "$name ${pr: }"  # template for worktree row labels:

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -335,7 +335,8 @@ last_session_close = "respawn"   # closing the on-screen workspace's last
                                  # session: "respawn" (default) starts a fresh
                                  # one, "navigate" moves to another workspace
 pr_status          = false  # poll `gh` for each branch's open PR, which drives
-                            # the PR row icons and $pr below (default false)
+                            # the PR row icons, the PR-state filters, and $pr
+                            # below (default false)
 pr_status_concurrency = 0   # cap concurrent `gh` PR lookups; 0 (default) is
                             # unlimited
 delta_path         = "delta"     # explicit delta binary for the diff pane;

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -68,6 +68,11 @@ below is hard-coded.
 | `O`                  | Sidebar focused: expand/collapse the selected project |
 | `Delete`             | Sidebar focused: close/delete/remove the selected row |
 | `Shift+R`            | Sidebar focused: rename the selected project          |
+| `S`                  | Projects sidebar focused: toggle the sessions filter  |
+| `A`                  | Projects sidebar focused: toggle the attention filter |
+| `M`                  | Git sidebar focused: toggle the modified-files filter |
+| `D`                  | Git sidebar focused: toggle the deleted-files filter  |
+| `U`                  | Git sidebar focused: toggle the untracked-files filter|
 | `Ctrl+K`             | Open the command palette                              |
 | `Home` / `End`       | Palette open: cursor to the first / last row          |
 | `PageUp` / `PageDown`| Palette open: cursor a screenful up / down            |
@@ -271,6 +276,69 @@ Rebind them to any non-text-producing key or chord (`Enter`, `Esc`, `Shift+Esc`,
 function keys, `Ctrl`/`Shift` chords). Binding a search action to a key that also
 produces text (a bare, `Shift`-, or `AltGr`-printable) is unsupported: the
 keystroke would both type into the query and fire the action.
+
+### Sidebar filters
+
+Toggle actions that narrow a sidebar's rows. Defaults act only while the
+owning sidebar has keyboard focus, the same way `R` and `O` do above.
+
+Projects sidebar — the session filter and the attention filter are
+independent dimensions that AND together; the four PR filters are one
+dimension whose active states union (an open-or-draft filter shows both):
+
+- `ToggleSessionsFilter` (default `S`) — narrow to workspaces with a live
+  session.
+- `ToggleAttentionFilter` (default `A`) — narrow to workspaces whose session
+  wants attention.
+- `TogglePrOpenFilter` / `TogglePrDraftFilter` / `TogglePrMergedFilter` /
+  `TogglePrClosedFilter` (no default key) — narrow to worktrees with an open,
+  draft, merged, or closed PR. These four exist only when `[ui] pr_status =
+  true` (default `false`); a query against `gh` runs per worktree, so
+  filtered rows fill in as each answer arrives rather than appearing all at
+  once.
+- `ClearProjectFilters` (no default key) — drop every projects-sidebar
+  toggle at once.
+
+Git sidebar — one dimension (a file only ever matches one change kind), so
+the active toggles union:
+
+- `ToggleModifiedFilter` (default `M`) — narrow to modified and renamed
+  files.
+- `ToggleDeletedFilter` (default `D`) — narrow to deleted files.
+- `ToggleUntrackedFilter` (default `U`) — narrow to untracked and added
+  files.
+- `ClearGitFilters` (no default key) — drop every git-sidebar toggle at
+  once.
+
+Not scoped to either panel:
+
+- `ToggleSearchScope` (no default key) — switch a sidebar's fuzzy-search
+  query between confined-by-the-active-toggles and reaching every row.
+  Runtime-only: restarting returns to `[ui] search_scope`.
+- `RefreshPrStatus` (no default key; acts while the projects sidebar has
+  focus) — invalidate every worktree's cached PR state and re-query `gh`.
+
+Widening PR lookups to cover a collapsed project happens only while the
+projects sidebar is painted, so hiding that sidebar stops *that* widening. It
+does not stop PR lookups altogether: the git sidebar still polls the active
+workspace's PR state, and a lookup already running still finishes and is
+still banked by the frame-start drain.
+
+A binding you write replaces the built-in binding on the same key. If you bind
+a key that a filter toggle uses by default, that toggle loses its key —
+silently. Two of your own bindings on one key both stay, and each runs only in
+the panel it belongs to, so you can give a key back its old meaning alongside
+the new one:
+
+```toml
+[[keyboard.bindings]]
+key = "D"
+action = "DeleteSelected"        # projects sidebar
+
+[[keyboard.bindings]]
+key = "D"
+action = "ToggleDeletedFilter"   # git sidebar
+```
 
 ### Misc
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -72,7 +72,7 @@ below is hard-coded.
 | `A`                  | Projects sidebar focused: toggle the attention filter |
 | `M`                  | Git sidebar focused: toggle the modified-files filter |
 | `D`                  | Git sidebar focused: toggle the deleted-files filter  |
-| `U`                  | Git sidebar focused: toggle the untracked-files filter|
+| `U`                  | Git sidebar focused: toggle the untracked-files filter |
 | `Ctrl+K`             | Open the command palette                              |
 | `Home` / `End`       | Palette open: cursor to the first / last row          |
 | `PageUp` / `PageDown`| Palette open: cursor a screenful up / down            |
@@ -284,7 +284,10 @@ owning sidebar has keyboard focus, the same way `R` and `O` do above.
 
 Projects sidebar — the session filter and the attention filter are
 independent dimensions that AND together; the four PR filters are one
-dimension whose active states union (an open-or-draft filter shows both):
+dimension whose active states union (an open-or-draft filter shows both);
+and that PR dimension in turn ANDs with the other two, so a worktree must
+satisfy the session/attention conjunction and match one active PR state to
+survive:
 
 - `ToggleSessionsFilter` (default `S`) — narrow to workspaces with a live
   session.
@@ -298,6 +301,8 @@ dimension whose active states union (an open-or-draft filter shows both):
   once.
 - `ClearProjectFilters` (no default key) — drop every projects-sidebar
   toggle at once.
+- `RefreshPrStatus` (no default key) — invalidate every worktree's cached PR
+  state and re-query `gh`. Acts while the projects sidebar has focus.
 
 Git sidebar — one dimension (a file only ever matches one change kind), so
 the active toggles union:
@@ -315,8 +320,6 @@ Not scoped to either panel:
 - `ToggleSearchScope` (no default key) — switch a sidebar's fuzzy-search
   query between confined-by-the-active-toggles and reaching every row.
   Runtime-only: restarting returns to `[ui] search_scope`.
-- `RefreshPrStatus` (no default key; acts while the projects sidebar has
-  focus) — invalidate every worktree's cached PR state and re-query `gh`.
 
 Widening PR lookups to cover a collapsed project happens only while the
 projects sidebar is painted, so hiding that sidebar stops *that* widening. It


### PR DESCRIPTION
Fifth in the numbered stack, behind #161 `[1]`, #162 `[2]`, #163 `[3]`, and #160 `[4]`.

Adds three opt-in sidebar features and fixes PR resolution for fork-based checkouts. Set none of the new config keys and behaviour is identical to master.

**Filter toggle actions** — thirteen bindable actions that toggle the sidebars' row filters, available from `[[keyboard.bindings]]` and the command palette. Five carry default keys (`S` `A` `M` `D` `U`), each scoped to the sidebar that owns it. A focus-rejected match is left unconsumed, so those keys still reach the terminal when it has focus.

**PR-state filters** — four toggles narrowing the projects sidebar to worktrees whose branch has an open / draft / merged / closed PR, backed by a per-worktree cache that shells out to `gh`. Gated behind `[ui] pr_status`, default `false`, so no `gh` process spawns unless you opt in. `[ui] pr_status_concurrency` caps concurrent lookups (default 8, clamped to >= 1).

**Search scope** — `[ui] search_scope` (`"filtered"` default, or `"all"`) plus a runtime toggle action, controlling whether a sidebar's fuzzy search is confined by the active toggle filters or reaches every row.

**Fork-head PR resolution** — `gh pr view <branch>` resolves a bare selector against the base repository only, so PR lookups returned nothing in a fork-based checkout. Now `gh pr list --head <branch> --state all`, with a head-owner preference so a colliding branch name in a busy base repo doesn't resolve a stranger's PR.

28 commits, 757 tests passing, zero build warnings. Documented in `docs/alacritree.md` and `docs/keyboard-shortcuts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
