### PR TITLE
feat(sidebar): show branch upstream status [7]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -766,7 +766,9 @@ impl AlacritreeApp {
                 // background discovery later swaps in via `poll_project_refreshes`.
                 let root = wsl::normalize_root(p.root.clone());
                 let mut project = match wsl::classify(&root) {
-                    wsl::Location::Windows(_) => Project::discover(root).project,
+                    wsl::Location::Windows(_) => {
+                        Project::discover(root, config.ui.upstream_status).project
+                    },
                     wsl::Location::Wsl { .. } => Project::placeholder(root),
                 };
                 project.expanded = p.expanded;
@@ -951,8 +953,9 @@ impl AlacritreeApp {
         let (tx, rx) = mpsc::channel();
         let ctx = ctx.clone();
         let worker_root = root.clone();
+        let upstream = self.config.ui.upstream_status;
         std::thread::spawn(move || {
-            let _ = tx.send(Project::discover(worker_root));
+            let _ = tx.send(Project::discover(worker_root, upstream));
             ctx.request_repaint();
         });
         self.project_refreshes.start(root, rx);
@@ -1465,9 +1468,9 @@ impl AlacritreeApp {
             return;
         }
         match wsl::classify(&path) {
-            wsl::Location::Windows(_) => {
-                self.projects.push(Project::discover(path.clone()).project)
-            },
+            wsl::Location::Windows(_) => self
+                .projects
+                .push(Project::discover(path.clone(), self.config.ui.upstream_status).project),
             wsl::Location::Wsl { .. } => {
                 self.projects.push(Project::placeholder(path.clone()));
                 let idx = self.projects.len() - 1;
@@ -1486,7 +1489,7 @@ impl AlacritreeApp {
         if let Some(idx) = self.projects.iter().position(|p| p.root == path) {
             return &self.projects[idx];
         }
-        self.projects.push(Project::discover(path.clone()).project);
+        self.projects.push(Project::discover(path.clone(), self.config.ui.upstream_status).project);
         self.persist_project(&path);
         self.projects.last().expect("just pushed")
     }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -5227,7 +5227,7 @@ fn icon_button(ui: &mut egui::Ui, glyph: &str, color: Color32, theme: &Theme) ->
 /// table styles a key without setting `glyph`.  `default_px` and `slot_px`
 /// are deliberately separate: `icon_button` paints its glyph at `12.0 *
 /// ui_scale` inside a `16.0 * ui_scale` slot, and conflating the two would
-/// resize every unconfigured icon while claiming pixel-identity.
+/// resize every unconfigured icon.
 ///
 /// One resolver, not one paint helper: `RichText` participates in layout
 /// while painter text draws into preallocated geometry, so each site keeps
@@ -5421,10 +5421,10 @@ fn panel_header_filter_ui(
             .show(ui, |ui| {
                 ui.spacing_mut().item_spacing.x = 3.0 * s;
                 // `TextStyle::Small`'s logical size is `font_normal`, unscaled —
-                // the same size `.small()` painted before this icon was
-                // configurable. The slot is generous (double that) since the
-                // icon sits in a frame that grows with its content rather
-                // than a fixed-pixel button.
+                // `resolve_icon` multiplies by `ui_scale` internally, so dividing
+                // it out here keeps the resolved size at `font_normal`. The slot
+                // is generous (double that) since the icon sits in a frame that
+                // grows with its content rather than a fixed-pixel button.
                 let default_px = theme.font_normal / s;
                 let (glyph, font, color) = resolve_icon(
                     search_icon,
@@ -9792,8 +9792,8 @@ mod tests {
         assert_eq!(color, Color32::RED);
     }
 
-    /// An unstyled icon must render `FontFamily::Proportional`, exactly what
-    /// every pre-existing call site painted before icons became configurable.
+    /// An unstyled icon must render `FontFamily::Proportional`, matching
+    /// every icon call site with no `bold`/`italic` configured.
     #[test]
     fn an_unconfigured_icon_resolves_to_the_proportional_family() {
         let theme = Theme::from_config(&Config::default());
@@ -9811,27 +9811,6 @@ mod tests {
         let style = IconStyle { italic: true, ..Default::default() };
         let (_, font, _) = resolve_icon(&style, "○", Color32::WHITE, 10.0, 10.0, &theme);
         assert_eq!(font.family, egui::FontFamily::Name(crate::fonts::UI_ITALIC_FAMILY.into()));
-    }
-
-    /// The search prompt derives its `resolve_icon` inputs from
-    /// `theme.font_normal` rather than a literal constant, since it used to
-    /// paint through `.small()`.  An unconfigured icon must still land on
-    /// exactly `font_normal`, matching what `TextStyle::Small` painted before
-    /// the icon became configurable.
-    #[test]
-    fn an_unconfigured_search_icon_matches_the_small_text_style_size() {
-        let theme = Theme::from_config(&Config::default());
-        let s = theme.ui_scale;
-        let default_px = theme.font_normal / s;
-        let (_, font, _) = resolve_icon(
-            &IconStyle::default(),
-            DEFAULT_SEARCH_ICON,
-            theme.text_dim,
-            default_px,
-            default_px * 2.0,
-            &theme,
-        );
-        assert_eq!(font.size, theme.font_normal);
     }
 
     /// A context with the three chrome variant families bound, as
@@ -9853,19 +9832,23 @@ mod tests {
         ctx
     }
 
-    /// The font family and paint color of the first shape whose text matches
-    /// `text`, or `None` if nothing painted it.
+    /// The font family, size, and paint color of the first shape whose text
+    /// matches `text`, or `None` if nothing painted it.
     fn painted_glyph_style(
         shapes: &[egui::epaint::ClippedShape],
         text: &str,
-    ) -> Option<(egui::FontFamily, Color32)> {
-        fn walk(shape: &egui::Shape, text: &str, out: &mut Option<(egui::FontFamily, Color32)>) {
+    ) -> Option<(egui::FontFamily, f32, Color32)> {
+        fn walk(
+            shape: &egui::Shape,
+            text: &str,
+            out: &mut Option<(egui::FontFamily, f32, Color32)>,
+        ) {
             match shape {
                 egui::Shape::Text(t) => {
                     if out.is_none() && t.galley.text() == text {
-                        let family = t.galley.job.sections[0].format.font_id.family.clone();
+                        let font_id = t.galley.job.sections[0].format.font_id.clone();
                         let color = t.override_text_color.unwrap_or(t.fallback_color);
-                        *out = Some((family, color));
+                        *out = Some((font_id.family, font_id.size, color));
                     }
                 },
                 egui::Shape::Vec(v) => v.iter().for_each(|s| walk(s, text, out)),
@@ -9917,7 +9900,7 @@ mod tests {
                 );
             });
         });
-        let (family, color) =
+        let (family, _, color) =
             painted_glyph_style(&output.shapes, "✕").expect("the configured glyph painted");
         assert_eq!(family, egui::FontFamily::Name(crate::fonts::UI_BOLD_FAMILY.into()));
         assert_eq!(color, Color32::RED);
@@ -9928,10 +9911,81 @@ mod tests {
     #[test]
     fn an_unconfigured_upstream_badge_keeps_its_built_in_color_and_family() {
         let theme = Theme::from_config(&Config::default());
-        let (family, color) = painted_glyph_style(&render_worktree_row_with_badges(), "✓")
+        let (family, _, color) = painted_glyph_style(&render_worktree_row_with_badges(), "✓")
             .expect("the default glyph painted");
         assert_eq!(family, egui::FontFamily::Proportional);
         assert_eq!(color, theme.upstream_level);
+    }
+
+    /// End-to-end: an unconfigured search icon painted through
+    /// `panel_header_filter_ui` must land at exactly `theme.font_normal`,
+    /// what `TextStyle::Small` painted at that call site. Pins the
+    /// production `default_px`/`slot_px` expression, not a copy of it.
+    #[test]
+    fn an_unconfigured_search_icon_paints_at_the_small_text_style_size() {
+        let theme = Theme::from_config(&Config::default());
+        let mut filter = PanelFilter::new(&[]);
+        filter.on_text("/");
+        let icons = crate::config::Icons::default();
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::Vec2::new(400.0, 100.0),
+            )),
+            ..Default::default()
+        };
+        let ctx = egui::Context::default();
+        let output = ctx.run(input, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                panel_header_filter_ui(ui, "Projects", &filter, &icons.search, &theme, true);
+            });
+        });
+        let (_, size, _) = painted_glyph_style(&output.shapes, DEFAULT_SEARCH_ICON)
+            .expect("the search icon painted");
+        assert_eq!(size, theme.font_normal);
+    }
+
+    /// The expand/collapse arrow is the sidebar's only `styled_icon_button`
+    /// call site. It must keep `icon_button`'s 16x16 slot while painting a
+    /// glyph, color, and weight from config.
+    #[test]
+    fn styled_icon_button_paints_a_configured_glyph_in_its_16px_slot() {
+        let theme = Theme::from_config(&Config::default());
+        let ctx = ctx_with_ui_variant_faces();
+        let s = theme.ui_scale;
+        let style = IconStyle {
+            glyph: Some("▶".to_string()),
+            color: Some(Color32::RED),
+            bold: true,
+            italic: false,
+            size: None,
+        };
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::Vec2::new(100.0, 100.0),
+            )),
+            ..Default::default()
+        };
+        let mut rect = None;
+        let output = ctx.run(input, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                rect = Some(styled_icon_button(ui, &style, "▸", theme.text_dim, &theme).rect);
+            });
+        });
+
+        let painted_size = rect.expect("the button painted").size();
+        let expected_size = egui::vec2(16.0 * s, 16.0 * s);
+        assert!(
+            (painted_size - expected_size).length() < 0.01,
+            "styled_icon_button must keep icon_button's 16x16 slot: got {painted_size:?}, \
+             expected {expected_size:?}"
+        );
+        let (family, size, color) =
+            painted_glyph_style(&output.shapes, "▶").expect("the configured glyph painted");
+        assert_eq!(family, egui::FontFamily::Name(crate::fonts::UI_BOLD_FAMILY.into()));
+        assert_eq!(size, 12.0 * s, "a button glyph paints at 12px inside its 16px slot");
+        assert_eq!(color, Color32::RED);
     }
 
     /// `[ui] sidebar_tooltips` bounds the row tooltip on both sides: `off`

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -8539,6 +8539,8 @@ mod tests {
             branch: None,
             is_main,
             prunable: false,
+            upstream: None,
+            detached: false,
         };
         Project {
             root: PathBuf::from(root),
@@ -9543,6 +9545,8 @@ mod tests {
             branch: None,
             is_main: false,
             prunable: false,
+            upstream: None,
+            detached: false,
         };
 
         let texts = texts_while_hovering(140.0, |ui| {
@@ -9607,6 +9611,8 @@ mod tests {
                 branch: None,
                 is_main: false,
                 prunable: false,
+                upstream: None,
+                detached: false,
             };
 
             let texts = texts_while_hovering(140.0, |ui| {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -4985,6 +4985,40 @@ fn truncating_label(
     (response, galley)
 }
 
+/// The hints for icons a row paints inside itself, with the rect each covers.
+///
+/// A row allocates its frame at end-of-show, so its retroactive `interact`
+/// registers after the icons in egui's z-order and takes the hover mark away
+/// from them — an icon's own `on_hover_text` never opens. The row answers for
+/// whichever icon the pointer is over instead, the same way it already routes
+/// a click that landed on a button.
+#[derive(Default)]
+struct IconHints(Vec<(egui::Rect, String)>);
+
+impl IconHints {
+    fn add(&mut self, rect: egui::Rect, hint: impl Into<String>) {
+        self.0.push((rect, hint.into()));
+    }
+
+    fn at(&self, pos: egui::Pos2) -> Option<&str> {
+        self.0.iter().find(|(rect, _)| rect.contains(pos)).map(|(_, hint)| hint.as_str())
+    }
+
+    /// The tooltip `resp` should carry: an icon's hint where the pointer is on
+    /// one, otherwise `fallback` for the rest of the row.
+    fn apply(
+        &self,
+        resp: egui::Response,
+        enabled: bool,
+        fallback: impl FnOnce(egui::Response) -> egui::Response,
+    ) -> egui::Response {
+        match resp.hover_pos().and_then(|pos| self.at(pos)) {
+            Some(hint) if enabled => resp.on_hover_text(hint.to_owned()),
+            _ => fallback(resp),
+        }
+    }
+}
+
 /// Offer `hint` — what the icon under `resp` does or reports — as its tooltip,
 /// unless `[ui] icon_tooltips` turns the hints off.
 fn icon_tooltip(resp: egui::Response, hint: &str, enabled: bool) -> egui::Response {
@@ -5575,6 +5609,7 @@ fn home_row(
 
     let mut spawn_clicked = false;
     let mut spawn_rect: Option<egui::Rect> = None;
+    let mut hints = IconHints::default();
     let frame = Frame::default().inner_margin(Margin { left: 6, right: 0, top: 3, bottom: 3 });
     let resp = frame
         .show(ui, |ui| {
@@ -5598,11 +5633,8 @@ fn home_row(
                     );
                 },
                 |ui| {
-                    let btn = icon_tooltip(
-                        icon_button(ui, "+", theme.text_muted, theme),
-                        "new shell",
-                        theme.icon_tooltips,
-                    );
+                    let btn = icon_button(ui, "+", theme.text_muted, theme);
+                    hints.add(btn.rect, "new shell");
                     spawn_rect = Some(btn.rect);
                     if btn.clicked() {
                         spawn_clicked = true;
@@ -5612,6 +5644,9 @@ fn home_row(
         })
         .response
         .interact(egui::Sense::click());
+    // The row carries no name tooltip of its own, so the button's hint is the
+    // only thing a hover here has to say.
+    let resp = hints.apply(resp, theme.icon_tooltips, |resp| resp);
 
     // Same z-order recovery as worktree_row: the retroactive frame interact
     // shadows the inner button, so route clicks inside its rect to spawn.
@@ -6179,6 +6214,7 @@ fn worktree_row(
     let panel_x = ui.max_rect().x_range();
 
     let mut delete_clicked = false;
+    let mut hints = IconHints::default();
     let mut delete_rect: Option<egui::Rect> = None;
     let mut spawn_clicked = false;
     let mut spawn_rect: Option<egui::Rect> = None;
@@ -6237,21 +6273,15 @@ fn worktree_row(
                         } else {
                             "delete worktree and branch"
                         };
-                        let btn = icon_tooltip(
-                            icon_button(ui, "×", theme.text_muted, theme),
-                            hover,
-                            theme.icon_tooltips,
-                        );
+                        let btn = icon_button(ui, "×", theme.text_muted, theme);
+                        hints.add(btn.rect, hover);
                         delete_rect = Some(btn.rect);
                         if btn.clicked() {
                             delete_clicked = true;
                         }
                     }
-                    let btn = icon_tooltip(
-                        icon_button(ui, "+", theme.text_muted, theme),
-                        "new shell",
-                        theme.icon_tooltips,
-                    );
+                    let btn = icon_button(ui, "+", theme.text_muted, theme);
+                    hints.add(btn.rect, "new shell");
                     spawn_rect = Some(btn.rect);
                     if btn.clicked() {
                         spawn_clicked = true;
@@ -6261,7 +6291,7 @@ fn worktree_row(
                             pr_badge(icons, theme, info.state);
                         let (glyph, font, color) =
                             resolve_icon(style, default_glyph, color, 10.0, 10.0, theme);
-                        let (rect, resp) = ui
+                        let (rect, _) = ui
                             .allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
                         ui.painter().text(
                             rect.center(),
@@ -6270,14 +6300,14 @@ fn worktree_row(
                             font,
                             color,
                         );
-                        resp.on_hover_text(format!("PR #{} — {word}", info.number));
+                        hints.add(rect, format!("PR #{} — {word}", info.number));
                     }
                     if let Some(state) = wt.upstream.as_ref() {
                         let (style, default_glyph, color, tip) =
                             upstream_badge(icons, theme, state);
                         let (glyph, font, color) =
                             resolve_icon(style, default_glyph, color, 10.0, 10.0, theme);
-                        let (rect, resp) = ui
+                        let (rect, _) = ui
                             .allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
                         ui.painter().text(
                             rect.center(),
@@ -6286,18 +6316,20 @@ fn worktree_row(
                             font,
                             color,
                         );
-                        resp.on_hover_text(tip);
+                        hints.add(rect, tip);
                     }
                 },
             );
         })
         .response
         .interact(egui::Sense::click());
-    let resp = if wt.prunable {
-        resp.on_hover_text("worktree directory is missing — × prunes it")
-    } else {
-        name_tooltip(resp, display_name, name_elided, theme.sidebar_tooltips)
-    };
+    let resp = hints.apply(resp, theme.icon_tooltips, |resp| {
+        if wt.prunable {
+            resp.on_hover_text("worktree directory is missing — × prunes it")
+        } else {
+            name_tooltip(resp, display_name, name_elided, theme.sidebar_tooltips)
+        }
+    });
 
     // Frame allocates its space at end-of-show, so its retroactive `interact`
     // registers *after* the inner button in egui's z-order — meaning clicks on
@@ -6364,6 +6396,7 @@ fn session_row(
     let panel_x = ui.max_rect().x_range();
 
     let mut close_clicked = false;
+    let mut hints = IconHints::default();
     let mut close_rect: Option<egui::Rect> = None;
     let mut title_elided = false;
     // One indent level deeper than worktree rows (16); right: 0 keeps the ×
@@ -6393,11 +6426,8 @@ fn session_row(
                     title_elided = galley.elided;
                 },
                 |ui| {
-                    let btn = icon_tooltip(
-                        icon_button(ui, "×", theme.text_muted, theme),
-                        "close session",
-                        theme.icon_tooltips,
-                    );
+                    let btn = icon_button(ui, "×", theme.text_muted, theme);
+                    hints.add(btn.rect, "close session");
                     close_rect = Some(btn.rect);
                     if btn.clicked() {
                         close_clicked = true;
@@ -6407,7 +6437,9 @@ fn session_row(
         })
         .response
         .interact(egui::Sense::click());
-    let resp = name_tooltip(resp, &row.title, title_elided, theme.sidebar_tooltips);
+    let resp = hints.apply(resp, theme.icon_tooltips, |resp| {
+        name_tooltip(resp, &row.title, title_elided, theme.sidebar_tooltips)
+    });
 
     // Frame allocates its space at end-of-show, so its retroactive `interact`
     // registers *after* the inner button in egui's z-order — meaning clicks on
@@ -9660,8 +9692,23 @@ mod tests {
     fn texts_while_hovering_at(
         hover: egui::Pos2,
         row_width: f32,
-        mut row: impl FnMut(&mut egui::Ui),
+        row: impl FnMut(&mut egui::Ui),
     ) -> Vec<Vec<(String, bool)>> {
+        frames_while_hovering_at(hover, row_width, row)
+            .iter()
+            .map(|shapes| painted_texts(shapes))
+            .collect()
+    }
+
+    /// The shapes behind `texts_while_hovering_at`. A status badge exposes no
+    /// rect to aim at, so its tests paint one pass with the pointer away to
+    /// find where the glyph landed, then hover exactly that — which only holds
+    /// because both passes lay out through this same function.
+    fn frames_while_hovering_at(
+        hover: egui::Pos2,
+        row_width: f32,
+        mut row: impl FnMut(&mut egui::Ui),
+    ) -> Vec<Vec<egui::epaint::ClippedShape>> {
         let ctx = egui::Context::default();
         let mut seen = Vec::new();
         for frame in 0..8 {
@@ -9691,9 +9738,29 @@ mod tests {
                     );
                 });
             });
-            seen.push(painted_texts(&output.shapes));
+            seen.push(output.shapes);
         }
         seen
+    }
+
+    /// Where each glyph painted, keyed by its text.
+    fn painted_glyph_positions(
+        shapes: &[egui::epaint::ClippedShape],
+    ) -> HashMap<String, egui::Pos2> {
+        fn walk(shape: &egui::Shape, out: &mut HashMap<String, egui::Pos2>) {
+            match shape {
+                egui::Shape::Text(t) => {
+                    out.insert(t.galley.text().to_owned(), t.pos + t.galley.size() / 2.0);
+                },
+                egui::Shape::Vec(v) => v.iter().for_each(|s| walk(s, out)),
+                _ => {},
+            }
+        }
+        let mut out = HashMap::new();
+        for clipped in shapes {
+            walk(&clipped.shape, &mut out);
+        }
+        out
     }
 
     /// Rest the pointer on a lone sidebar button and report whether its hint
@@ -9764,26 +9831,6 @@ mod tests {
             tooltip_shown(&texts, &wt.name),
             "hovering the elided row painted no tooltip with the full name: {texts:?}"
         );
-    }
-
-    /// A sidebar button says what it does on hover, and `[ui] icon_tooltips`
-    /// is what decides whether it may. The two settings are independent axes:
-    /// silencing the row names must leave the button hints alone, or turning
-    /// off one kind of tooltip would quietly cost the other.
-    #[test]
-    fn icon_tooltips_gate_the_button_hint() {
-        for (icon_tooltips, want) in [(true, true), (false, false)] {
-            let mut config = Config::default();
-            config.ui.icon_tooltips = icon_tooltips;
-            config.ui.sidebar_tooltips = SidebarTooltips::Off;
-            let theme = Theme::from_config(&config);
-
-            assert_eq!(
-                button_hint_painted(&theme, "close session"),
-                want,
-                "icon_tooltips = {icon_tooltips}"
-            );
-        }
     }
 
     #[test]
@@ -10011,6 +10058,150 @@ mod tests {
         assert_eq!(family, egui::FontFamily::Name(crate::fonts::UI_BOLD_FAMILY.into()));
         assert_eq!(size, 12.0 * s, "a button glyph paints at 12px inside its 16px slot");
         assert_eq!(color, Color32::RED);
+    }
+
+    /// Rest the pointer on the worktree-row badge that painted `glyph` and
+    /// report every text drawn while it lingers there.
+    fn texts_while_hovering_badge(theme: &Theme, glyph: &str) -> Vec<Vec<(String, bool)>> {
+        let icons = crate::config::Icons::default();
+        let wt = crate::projects::Worktree {
+            name: "wt".to_owned(),
+            path: PathBuf::from("/repo/wt"),
+            branch: None,
+            is_main: false,
+            prunable: false,
+            upstream: Some(UpstreamState::Level { upstream: "origin/x".into() }),
+        };
+        let pr = PrInfo {
+            number: 7,
+            base_branch: "main".into(),
+            url: String::new(),
+            state: PrState::Open,
+        };
+        let mut render = |ui: &mut egui::Ui| {
+            worktree_row(
+                ui,
+                &wt,
+                &wt.name,
+                Some(&pr),
+                true,
+                false,
+                false,
+                false,
+                None,
+                false,
+                &icons,
+                theme,
+            );
+        };
+
+        texts_while_hovering_icon(&mut render, glyph)
+    }
+
+    /// Whether resting the pointer on the icon that painted `glyph` surfaces
+    /// `hint`.
+    fn hint_painted_over(row: impl FnMut(&mut egui::Ui), glyph: &str, hint: &str) -> bool {
+        texts_while_hovering_icon(row, glyph).iter().flatten().any(|(text, _)| text == hint)
+    }
+
+    /// Find the icon that painted `glyph`, then hover it. Two passes: an icon
+    /// exposes no rect to aim at, so the first pass reads the position back out
+    /// of the shapes it drew.
+    fn texts_while_hovering_icon(
+        mut row: impl FnMut(&mut egui::Ui),
+        glyph: &str,
+    ) -> Vec<Vec<(String, bool)>> {
+        const WIDTH: f32 = 220.0;
+        let off_pointer = egui::Pos2::new(-100.0, -100.0);
+        let probe = frames_while_hovering_at(off_pointer, WIDTH, &mut row);
+        let at = painted_glyph_positions(probe.last().expect("the row painted"));
+        let centre = *at.get(glyph).unwrap_or_else(|| panic!("no {glyph} icon painted: {at:?}"));
+
+        texts_while_hovering_at(centre, WIDTH, &mut row)
+    }
+
+    /// Every icon a worktree row paints — buttons and status badges alike —
+    /// explains itself on hover, and answers to one key. A row that senses its
+    /// own frame outranks the icons inside it, so each of these would go quiet
+    /// on its own `on_hover_text`.
+    #[test]
+    fn icon_tooltips_gate_every_worktree_row_icon() {
+        for (icon_tooltips, want) in [(true, true), (false, false)] {
+            let mut config = Config::default();
+            config.ui.icon_tooltips = icon_tooltips;
+            config.ui.sidebar_tooltips = SidebarTooltips::Off;
+            let theme = Theme::from_config(&config);
+
+            for (glyph, hint) in [
+                (DEFAULT_UPSTREAM_LEVEL_ICON, "tracks origin/x"),
+                (DEFAULT_PR_OPEN_ICON, "PR #7 — open"),
+                ("×", "delete worktree and branch"),
+                ("+", "new shell"),
+            ] {
+                let texts = texts_while_hovering_badge(&theme, glyph);
+                let shown = texts.iter().flatten().any(|(text, _)| text == hint);
+                assert_eq!(shown, want, "icon_tooltips = {icon_tooltips}, icon {glyph}");
+            }
+        }
+    }
+
+    /// The session and home rows sense their own frames the same way, so their
+    /// buttons need the same recovery as the worktree row's.
+    #[test]
+    fn icon_tooltips_reach_the_session_and_home_row_buttons() {
+        let icons = crate::config::Icons::default();
+        for (icon_tooltips, want) in [(true, true), (false, false)] {
+            let mut config = Config::default();
+            config.ui.icon_tooltips = icon_tooltips;
+            config.ui.sidebar_tooltips = SidebarTooltips::Off;
+            let theme = Theme::from_config(&config);
+
+            let row = SessionRowData {
+                id: 1,
+                title: "zsh".to_owned(),
+                needs_attention: false,
+                agent_glyph: None,
+                is_active: true,
+                is_displayed: true,
+            };
+            let mut session = |ui: &mut egui::Ui| {
+                session_row(ui, &row, false, false, &icons, &theme);
+            };
+            assert_eq!(
+                hint_painted_over(&mut session, "×", "close session"),
+                want,
+                "session row, icon_tooltips = {icon_tooltips}"
+            );
+
+            let mut home = |ui: &mut egui::Ui| {
+                home_row(ui, true, false, false, false, None, &icons, &theme);
+            };
+            assert_eq!(
+                hint_painted_over(&mut home, "+", "new shell"),
+                want,
+                "home row, icon_tooltips = {icon_tooltips}"
+            );
+        }
+    }
+
+    /// A sidebar button says what it does on hover, and `[ui] icon_tooltips`
+    /// is what decides whether it may. The two settings are independent axes:
+    /// silencing the row names must leave the button hints alone, or turning
+    /// off one kind of tooltip would quietly cost the other.
+    #[test]
+    fn icon_tooltips_gate_the_button_hint() {
+        for (icon_tooltips, want) in [(true, true), (false, false)] {
+            let mut config = Config::default();
+            config.ui.icon_tooltips = icon_tooltips;
+            config.ui.sidebar_tooltips = SidebarTooltips::Off;
+            let theme = Theme::from_config(&config);
+
+            assert_eq!(
+                button_hint_painted(&theme, "close session"),
+                want,
+                "icon_tooltips = {icon_tooltips}"
+            );
+        }
     }
 
     /// `[ui] sidebar_tooltips` bounds the row tooltip on both sides: `off`

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -8697,7 +8697,6 @@ mod tests {
             is_main,
             prunable: false,
             upstream: None,
-            detached: false,
         };
         Project {
             root: PathBuf::from(root),
@@ -9737,7 +9736,6 @@ mod tests {
             is_main: false,
             prunable: false,
             upstream: None,
-            detached: false,
         };
 
         let texts = texts_while_hovering(140.0, |ui| {
@@ -9900,7 +9898,6 @@ mod tests {
             is_main: false,
             prunable: false,
             upstream: Some(UpstreamState::Gone { upstream: "origin/x".into() }),
-            detached: false,
         };
         let input = egui::RawInput {
             screen_rect: Some(egui::Rect::from_min_size(
@@ -10031,7 +10028,6 @@ mod tests {
                 is_main: false,
                 prunable: false,
                 upstream: None,
-                detached: false,
             };
 
             let texts = texts_while_hovering(140.0, |ui| {
@@ -10077,7 +10073,6 @@ mod tests {
             is_main: false,
             prunable: false,
             upstream: Some(UpstreamState::Level { upstream: "origin/x".into() }),
-            detached: false,
         };
         let pr = PrInfo {
             number: 1,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -134,6 +134,8 @@ impl Theme {
             config.ui.sidebar_foreground.unwrap_or_else(|| rgb_to_color32(config.palette.fg));
         let accent =
             config.ui.sidebar_accent.unwrap_or_else(|| rgb_to_color32(config.palette.normal[4])); // ANSI blue
+        let attention =
+            config.ui.sidebar_attention.unwrap_or_else(|| rgb_to_color32(config.palette.normal[3])); // ANSI yellow
         let border = config.ui.sidebar_border.unwrap_or_else(|| lighten(sidebar_bg, 0.10));
         let text_muted = blend_toward(text, sidebar_bg, 0.55);
         let (font_normal, font_heading) = ui_text_px(&config.font, &config.ui_font);
@@ -147,7 +149,7 @@ impl Theme {
             text_dim: blend_toward(text, sidebar_bg, 0.35),
             text_muted,
             accent,
-            attention: rgb_to_color32(config.palette.normal[3]), // ANSI yellow
+            attention,
             pr_open: rgb_to_color32(config.palette.normal[2]),   // green
             pr_draft: text_muted,
             pr_merged: rgb_to_color32(config.palette.normal[5]), // magenta
@@ -9456,6 +9458,20 @@ mod tests {
         assert_eq!(theme.path_style.git_rows, PathStyle::Fish);
         assert_eq!(theme.path_style.git_header, PathStyle::Full);
         assert!(theme.path_style.filename.bold);
+    }
+
+    /// With no override, `attention` keeps painting from the palette, exactly
+    /// as it did before `sidebar_attention` existed; a configured color must
+    /// reach `Theme::attention`, not just the raw config field.
+    #[test]
+    fn sidebar_attention_overrides_the_palette_default() {
+        let default_theme = Theme::from_config(&Config::default());
+        assert_eq!(default_theme.attention, rgb_to_color32(Config::default().palette.normal[3]));
+
+        let mut config = Config::default();
+        config.ui.sidebar_attention = Some(Color32::from_rgb(0xff, 0xb8, 0x6c));
+        let theme = Theme::from_config(&config);
+        assert_eq!(theme.attention, Color32::from_rgb(0xff, 0xb8, 0x6c));
     }
 
     /// The header is the one site whose path is absolute, so it is the one that

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -150,7 +150,7 @@ impl Theme {
             text_muted,
             accent,
             attention,
-            pr_open: rgb_to_color32(config.palette.normal[2]),   // green
+            pr_open: rgb_to_color32(config.palette.normal[2]), // green
             pr_draft: text_muted,
             pr_merged: rgb_to_color32(config.palette.normal[5]), // magenta
             pr_closed: rgb_to_color32(config.palette.normal[1]), // red
@@ -9788,8 +9788,8 @@ mod tests {
         assert!(font.size <= 16.0 * theme.ui_scale, "a button glyph clamps to its own 16px slot");
     }
 
-    /// With no config, every icon must paint at exactly the size it does today —
-    /// buttons at 12 inside a 16 slot, status markers at 10.
+    /// With no config, every icon paints at its built-in size: buttons at 12
+    /// inside a 16 slot, status markers at 10.
     #[test]
     fn an_unconfigured_icon_keeps_its_current_size() {
         let theme = Theme::from_config(&Config::default());
@@ -9919,8 +9919,8 @@ mod tests {
         assert_eq!(color, Color32::RED);
     }
 
-    /// Backward compatibility for the same badge, unconfigured: the built-in
-    /// glyph, the theme's built-in color, and the plain proportional family.
+    /// The same badge unconfigured: the built-in glyph, the theme's built-in
+    /// color, and the plain proportional family.
     #[test]
     fn an_unconfigured_upstream_badge_keeps_its_built_in_color_and_family() {
         let theme = Theme::from_config(&Config::default());

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -3450,7 +3450,11 @@ impl AlacritreeApp {
                                     create_request.set(Some(idx));
                                 }
                                 if show_proj_dot {
-                                    attention_dot(ui, &theme);
+                                    icon_tooltip(
+                                        attention_dot(ui, &theme),
+                                        ATTENTION_HINT,
+                                        theme.icon_tooltips,
+                                    );
                                 }
                             },
                         );
@@ -4842,6 +4846,7 @@ fn file_row(
     };
     let path_color = if is_active { theme.text } else { theme.text_dim };
     let mut path_galley = None;
+    let mut hints = IconHints::default();
     // `ui.horizontal` sizes its response rect to the (often short) path text,
     // leaving most of the row's width as a dead zone — and short labels make
     // the row barely taller than the text, so vertical misses are easy too.
@@ -4858,12 +4863,13 @@ fn file_row(
                 // label inside our row would eat clicks before the row sees
                 // them.  Opt out of selection on every label that lives inside
                 // a clickable row so the click falls through.
-                ui.add(
+                let badge = ui.add(
                     egui::Label::new(
                         RichText::new(change.kind.glyph()).color(color).monospace().small(),
                     )
                     .selectable(false),
                 );
+                hints.add(badge.rect, change.kind.label());
                 let (_, galley) = git_path_label(ui, &change.path, path_color, theme);
                 path_galley = Some(galley);
                 fill_row(ui);
@@ -4871,7 +4877,9 @@ fn file_row(
         )
         .response
         .interact(egui::Sense::click());
-    let resp = git_path_tooltip(resp, path_galley.as_deref(), theme);
+    let resp = hints.apply(resp, theme.icon_tooltips, |resp| {
+        git_path_tooltip(resp, path_galley.as_deref(), theme)
+    });
     paint_row_bg(ui, &resp, bg_idx, panel_x, theme, is_active);
     resp
 }
@@ -5194,16 +5202,23 @@ fn row_status_icon_size(theme: &Theme) -> egui::Vec2 {
     egui::vec2(10.0, 14.0) * theme.ui_scale
 }
 
+const ATTENTION_HINT: &str = "needs attention";
+
 /// Painted (rather than `RichText("●")`) so its size is independent of font
 /// metrics — `RichText("●")` renders inconsistently across fallback fonts.
-fn attention_dot(ui: &mut egui::Ui, theme: &Theme) {
-    let (rect, _) = ui.allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
+fn attention_dot(ui: &mut egui::Ui, theme: &Theme) -> egui::Response {
+    let (rect, resp) = ui.allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
     let radius = 3.0 * theme.ui_scale;
     ui.painter().circle_filled(rect.center(), radius, theme.attention);
+    resp
 }
 
 /// Priority: attention dot > agent glyph (animated by the agent's own title
 /// updates) > active highlight > the configured color > the built-in default.
+///
+/// Returns what the slot has to say on hover, for the row to register with the
+/// rest of its icons. The row icon proper reports nothing the row does not
+/// already spell out, so it stays silent.
 fn paint_row_status_icon(
     ui: &mut egui::Ui,
     theme: &Theme,
@@ -5212,10 +5227,9 @@ fn paint_row_status_icon(
     style: &IconStyle,
     default_glyph: &str,
     is_active: bool,
-) {
+) -> Option<(egui::Rect, String)> {
     if attention {
-        attention_dot(ui, theme);
-        return;
+        return Some((attention_dot(ui, theme).rect, ATTENTION_HINT.to_owned()));
     }
     let s = theme.ui_scale;
     let (glyph, font, color) = match agent_glyph {
@@ -5235,6 +5249,8 @@ fn paint_row_status_icon(
     // text would size the slot to its advance width and shift the label with it.
     let (rect, _) = ui.allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
     ui.painter().text(rect.center(), egui::Align2::CENTER_CENTER, glyph, font, color);
+    let name = agent_glyph.and_then(crate::session::agent_name_for_glyph)?;
+    Some((rect, format!("{name} is running")))
 }
 
 /// Gap between adjacent `icon_button`s. They already pad their own glyph, so
@@ -5610,13 +5626,16 @@ fn home_row(
     let mut spawn_clicked = false;
     let mut spawn_rect: Option<egui::Rect> = None;
     let mut hints = IconHints::default();
+    // The leading and trailing groups run as sibling closures, so the status
+    // slot's hint travels out separately and joins the rest afterwards.
+    let mut status_hint = None;
     let frame = Frame::default().inner_margin(Margin { left: 6, right: 0, top: 3, bottom: 3 });
     let resp = frame
         .show(ui, |ui| {
             row_with_trailing(
                 ui,
                 |ui| {
-                    paint_row_status_icon(
+                    status_hint = paint_row_status_icon(
                         ui,
                         theme,
                         attention,
@@ -5644,7 +5663,10 @@ fn home_row(
         })
         .response
         .interact(egui::Sense::click());
-    // The row carries no name tooltip of its own, so the button's hint is the
+    if let Some((rect, hint)) = status_hint {
+        hints.add(rect, hint);
+    }
+    // The row carries no name tooltip of its own, so the icons' hints are the
     // only thing a hover here has to say.
     let resp = hints.apply(resp, theme.icon_tooltips, |resp| resp);
 
@@ -6219,6 +6241,9 @@ fn worktree_row(
     let mut spawn_clicked = false;
     let mut spawn_rect: Option<egui::Rect> = None;
     let mut name_elided = false;
+    // The leading and trailing groups run as sibling closures, so the status
+    // slot's hint travels out separately and joins the rest afterwards.
+    let mut status_hint = None;
     // right: 0 keeps the worktree `×` at the same x as the project row's `×`,
     // which has no frame margin and sits flush against the panel's outer padding.
     let frame = Frame::default().inner_margin(Margin { left: 16, right: 0, top: 3, bottom: 3 });
@@ -6239,7 +6264,7 @@ fn worktree_row(
             row_with_trailing(
                 ui,
                 |ui| {
-                    paint_row_status_icon(
+                    status_hint = paint_row_status_icon(
                         ui,
                         theme,
                         attention,
@@ -6323,6 +6348,9 @@ fn worktree_row(
         })
         .response
         .interact(egui::Sense::click());
+    if let Some((rect, hint)) = status_hint {
+        hints.add(rect, hint);
+    }
     let resp = hints.apply(resp, theme.icon_tooltips, |resp| {
         if wt.prunable {
             resp.on_hover_text("worktree directory is missing — × prunes it")
@@ -6399,6 +6427,9 @@ fn session_row(
     let mut hints = IconHints::default();
     let mut close_rect: Option<egui::Rect> = None;
     let mut title_elided = false;
+    // The leading and trailing groups run as sibling closures, so the status
+    // slot's hint travels out separately and joins the rest afterwards.
+    let mut status_hint = None;
     // One indent level deeper than worktree rows (16); right: 0 keeps the ×
     // at the same x as the other rows' trailing icons.
     let frame = Frame::default().inner_margin(Margin { left: 28, right: 0, top: 3, bottom: 3 });
@@ -6408,7 +6439,7 @@ fn session_row(
             row_with_trailing(
                 ui,
                 |ui| {
-                    paint_row_status_icon(
+                    status_hint = paint_row_status_icon(
                         ui,
                         theme,
                         row.needs_attention,
@@ -6437,6 +6468,9 @@ fn session_row(
         })
         .response
         .interact(egui::Sense::click());
+    if let Some((rect, hint)) = status_hint {
+        hints.add(rect, hint);
+    }
     let resp = hints.apply(resp, theme.icon_tooltips, |resp| {
         name_tooltip(resp, &row.title, title_elided, theme.sidebar_tooltips)
     });
@@ -10200,6 +10234,86 @@ mod tests {
                 button_hint_painted(&theme, "close session"),
                 want,
                 "icon_tooltips = {icon_tooltips}"
+            );
+        }
+    }
+
+    /// The letter a git row leads with is the whole report — `M`, `?`, `!` say
+    /// nothing to a reader who does not already know porcelain. The row senses
+    /// its own frame, so the badge needs the same recovery the sidebar icons do.
+    #[test]
+    fn icon_tooltips_gate_the_git_status_badge_hint() {
+        for (icon_tooltips, want) in [(true, true), (false, false)] {
+            let mut config = Config::default();
+            config.ui.icon_tooltips = icon_tooltips;
+            config.ui.sidebar_tooltips = SidebarTooltips::Off;
+            let theme = Theme::from_config(&config);
+            let palette = config.palette.clone();
+
+            for (kind, glyph, hint) in [
+                (ChangeKind::Modified, "M", "modified"),
+                (ChangeKind::Untracked, "?", "untracked"),
+                (ChangeKind::Conflicted, "!", "conflicted"),
+            ] {
+                let change = FileChange { path: "README.md".to_owned(), kind };
+                let mut row = |ui: &mut egui::Ui| {
+                    let _ = file_row(ui, &change, &theme, &palette, false);
+                };
+                assert_eq!(
+                    hint_painted_over(&mut row, glyph, hint),
+                    want,
+                    "icon_tooltips = {icon_tooltips}, badge {glyph}"
+                );
+            }
+        }
+    }
+
+    /// The slot a row leads with is a report rather than a button: it stands
+    /// for the agent running in the session, or for the session asking to be
+    /// looked at. Both say so on hover. The dot paints no text to aim at, so
+    /// it is found through the slot the glyph occupies — one replaces the
+    /// other in place.
+    #[test]
+    fn icon_tooltips_gate_the_status_slot_hint() {
+        const WIDTH: f32 = 220.0;
+        let icons = crate::config::Icons::default();
+        let session = |attention, agent_glyph| SessionRowData {
+            id: 1,
+            title: "zsh".to_owned(),
+            needs_attention: attention,
+            agent_glyph,
+            is_active: true,
+            is_displayed: true,
+        };
+
+        for (icon_tooltips, want) in [(true, true), (false, false)] {
+            let mut config = Config::default();
+            config.ui.icon_tooltips = icon_tooltips;
+            config.ui.sidebar_tooltips = SidebarTooltips::Off;
+            let theme = Theme::from_config(&config);
+
+            let agent = session(false, Some('✳'));
+            let mut agent_row = |ui: &mut egui::Ui| {
+                session_row(ui, &agent, false, false, &icons, &theme);
+            };
+            assert_eq!(
+                hint_painted_over(&mut agent_row, "✳", "claude is running"),
+                want,
+                "agent glyph, icon_tooltips = {icon_tooltips}"
+            );
+
+            let probe =
+                frames_while_hovering_at(egui::Pos2::new(-100.0, -100.0), WIDTH, &mut agent_row);
+            let slot = painted_glyph_positions(probe.last().expect("the row painted"))["✳"];
+
+            let waiting = session(true, None);
+            let texts = texts_while_hovering_at(slot, WIDTH, |ui| {
+                session_row(ui, &waiting, false, false, &icons, &theme);
+            });
+            assert_eq!(
+                texts.iter().flatten().any(|(text, _)| text == "needs attention"),
+                want,
+                "attention dot, icon_tooltips = {icon_tooltips}"
             );
         }
     }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -9182,7 +9182,7 @@ mod tests {
     #[test]
     fn ui_text_px_overrides_from_ui_font_size() {
         let font = crate::config::FontConfig::default();
-        let ui = crate::config::UiFont { family: None, size: Some(12.0) };
+        let ui = crate::config::UiFont { size: Some(12.0), ..Default::default() };
         let (normal, heading) = ui_text_px(&font, &ui);
         assert_eq!(normal, 16.0); // 12 pt × 96/72
         assert_eq!(

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -9460,9 +9460,9 @@ mod tests {
         assert!(theme.path_style.filename.bold);
     }
 
-    /// With no override, `attention` keeps painting from the palette, exactly
-    /// as it did before `sidebar_attention` existed; a configured color must
-    /// reach `Theme::attention`, not just the raw config field.
+    /// With no override, `attention` reads the palette's yellow slot; a
+    /// configured color must reach `Theme::attention`, not just the raw
+    /// config field.
     #[test]
     fn sidebar_attention_overrides_the_palette_default() {
         let default_theme = Theme::from_config(&Config::default());

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -3372,17 +3372,29 @@ impl AlacritreeApp {
                                     drag_handle(ui, &theme)
                                         .dnd_set_drag_payload(DraggedProject(project.root.clone()));
                                 }
-                                let (arrow_style, arrow_default) = if project.expanded {
-                                    (&icons.project_expanded, DEFAULT_PROJECT_EXPANDED_ICON)
+                                let (arrow_style, arrow_default, arrow_hint) = if project.expanded {
+                                    (
+                                        &icons.project_expanded,
+                                        DEFAULT_PROJECT_EXPANDED_ICON,
+                                        "collapse project",
+                                    )
                                 } else {
-                                    (&icons.project_collapsed, DEFAULT_PROJECT_COLLAPSED_ICON)
+                                    (
+                                        &icons.project_collapsed,
+                                        DEFAULT_PROJECT_COLLAPSED_ICON,
+                                        "expand project",
+                                    )
                                 };
-                                if styled_icon_button(
-                                    ui,
-                                    arrow_style,
-                                    arrow_default,
-                                    theme.text_dim,
-                                    &theme,
+                                if icon_tooltip(
+                                    styled_icon_button(
+                                        ui,
+                                        arrow_style,
+                                        arrow_default,
+                                        theme.text_dim,
+                                        &theme,
+                                    ),
+                                    arrow_hint,
+                                    theme.icon_tooltips,
                                 )
                                 .clicked()
                                 {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -16,8 +16,13 @@ use crate::clipboard_image;
 use crate::colors::rgb_to_color32;
 use crate::command_palette::{self, CommandPalette, PaletteAction, PaletteItem};
 use crate::config::{
-    Config, FontConfig, Icons, LastSessionClose, PathStyleConfig, ScrollbarStyle, SearchScope,
-    SidebarFocus, SidebarTooltips, TextEmphasis, UiFont,
+    Config, DEFAULT_HOME_ICON, DEFAULT_PR_CLOSED_ICON, DEFAULT_PR_DRAFT_ICON,
+    DEFAULT_PR_MERGED_ICON, DEFAULT_PR_OPEN_ICON, DEFAULT_PROJECT_COLLAPSED_ICON,
+    DEFAULT_PROJECT_EXPANDED_ICON, DEFAULT_SEARCH_ICON, DEFAULT_SESSION_ICON,
+    DEFAULT_UPSTREAM_DIVERGED_ICON, DEFAULT_UPSTREAM_GONE_ICON, DEFAULT_UPSTREAM_LEVEL_ICON,
+    DEFAULT_UPSTREAM_UNTRACKED_ICON, DEFAULT_WORKTREE_ICON, DEFAULT_WORKTREE_MAIN_ICON, FontConfig,
+    IconStyle, Icons, LastSessionClose, PathStyleConfig, ScrollbarStyle, SearchScope, SidebarFocus,
+    SidebarTooltips, TextEmphasis, UiFont,
 };
 use crate::doppler;
 use crate::file_drop;
@@ -3365,15 +3370,17 @@ impl AlacritreeApp {
                                     drag_handle(ui, &theme)
                                         .dnd_set_drag_payload(DraggedProject(project.root.clone()));
                                 }
-                                let (arrow, arrow_hint) = if project.expanded {
-                                    (icons.project_expanded.as_str(), "collapse project")
+                                let (arrow_style, arrow_default) = if project.expanded {
+                                    (&icons.project_expanded, DEFAULT_PROJECT_EXPANDED_ICON)
                                 } else {
-                                    (icons.project_collapsed.as_str(), "expand project")
+                                    (&icons.project_collapsed, DEFAULT_PROJECT_COLLAPSED_ICON)
                                 };
-                                if icon_tooltip(
-                                    icon_button(ui, arrow, theme.text_dim, &theme),
-                                    arrow_hint,
-                                    theme.icon_tooltips,
+                                if styled_icon_button(
+                                    ui,
+                                    arrow_style,
+                                    arrow_default,
+                                    theme.text_dim,
+                                    &theme,
                                 )
                                 .clicked()
                                 {
@@ -5148,12 +5155,13 @@ fn attention_dot(ui: &mut egui::Ui, theme: &Theme) {
 }
 
 /// Priority: attention dot > agent glyph (animated by the agent's own title
-/// updates) > the row's default marker.
+/// updates) > active highlight > the configured color > the built-in default.
 fn paint_row_status_icon(
     ui: &mut egui::Ui,
     theme: &Theme,
     attention: bool,
     agent_glyph: Option<char>,
+    style: &IconStyle,
     default_glyph: &str,
     is_active: bool,
 ) {
@@ -5162,22 +5170,23 @@ fn paint_row_status_icon(
         return;
     }
     let s = theme.ui_scale;
-    let (glyph, color) = match agent_glyph {
-        Some(g) => (g.to_string(), if is_active { theme.accent } else { theme.text }),
+    let (glyph, font, color) = match agent_glyph {
+        Some(g) => (
+            g.to_string(),
+            egui::FontId::proportional(10.0 * s),
+            if is_active { theme.accent } else { theme.text },
+        ),
         None => {
-            (default_glyph.to_string(), if is_active { theme.accent } else { theme.text_muted })
+            let (glyph, font, resolved) =
+                resolve_icon(style, default_glyph, theme.text_muted, 10.0, 10.0, theme);
+            let color = if is_active { theme.accent } else { resolved };
+            (glyph.to_string(), font, color)
         },
     };
     // Centered into the fixed slot, like `icon_button`: laying the glyph out as
     // text would size the slot to its advance width and shift the label with it.
     let (rect, _) = ui.allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
-    ui.painter().text(
-        rect.center(),
-        egui::Align2::CENTER_CENTER,
-        glyph,
-        egui::FontId::proportional(10.0 * s),
-        color,
-    );
+    ui.painter().text(rect.center(), egui::Align2::CENTER_CENTER, glyph, font, color);
 }
 
 /// Gap between adjacent `icon_button`s. They already pad their own glyph, so
@@ -5210,6 +5219,59 @@ fn icon_button(ui: &mut egui::Ui, glyph: &str, color: Color32, theme: &Theme) ->
         egui::FontId::proportional(12.0 * s),
         painted,
     );
+    resp
+}
+
+/// Resolve an icon's paint-time glyph, font, and color from its config and
+/// the site's built-in defaults.  `default_glyph` covers the case where a
+/// table styles a key without setting `glyph`.  `default_px` and `slot_px`
+/// are deliberately separate: `icon_button` paints its glyph at `12.0 *
+/// ui_scale` inside a `16.0 * ui_scale` slot, and conflating the two would
+/// resize every unconfigured icon while claiming pixel-identity.
+///
+/// One resolver, not one paint helper: `RichText` participates in layout
+/// while painter text draws into preallocated geometry, so each site keeps
+/// its own drawing call.
+fn resolve_icon<'a>(
+    style: &'a IconStyle,
+    default_glyph: &'a str,
+    default_color: Color32,
+    default_px: f32,
+    slot_px: f32,
+    theme: &Theme,
+) -> (&'a str, egui::FontId, Color32) {
+    let size = style.size.unwrap_or(default_px).min(slot_px) * theme.ui_scale;
+    let family = crate::fonts::ui_variant_family(style.bold, style.italic);
+    (
+        style.or_glyph(default_glyph),
+        egui::FontId::new(size, family),
+        style.color.unwrap_or(default_color),
+    )
+}
+
+/// `icon_button` for a configurable icon: same 16×16 slot and hover
+/// brightening, but the glyph, weight, slant, and size come from config.
+fn styled_icon_button(
+    ui: &mut egui::Ui,
+    style: &IconStyle,
+    default_glyph: &str,
+    color: Color32,
+    theme: &Theme,
+) -> egui::Response {
+    let s = theme.ui_scale;
+    let (glyph, font, color) = resolve_icon(style, default_glyph, color, 12.0, 16.0, theme);
+    let size = egui::vec2(16.0 * s, 16.0 * s);
+    let (rect, resp) = ui.allocate_exact_size(size, egui::Sense::click());
+    let painted = if resp.hovered() {
+        Color32::from_rgb(
+            color.r().saturating_add(40),
+            color.g().saturating_add(40),
+            color.b().saturating_add(40),
+        )
+    } else {
+        color
+    };
+    ui.painter().text(rect.center(), egui::Align2::CENTER_CENTER, glyph, font, painted);
     resp
 }
 
@@ -5341,7 +5403,7 @@ fn panel_header_filter_ui(
     ui: &mut egui::Ui,
     title: &str,
     filter: &PanelFilter,
-    search_icon: &str,
+    search_icon: &IconStyle,
     theme: &Theme,
     toggles_apply: bool,
 ) {
@@ -5358,7 +5420,21 @@ fn panel_header_filter_ui(
             .inner_margin(Margin::symmetric((4.0 * s).round() as i8, (1.0 * s).round() as i8))
             .show(ui, |ui| {
                 ui.spacing_mut().item_spacing.x = 3.0 * s;
-                ui.label(RichText::new(search_icon).color(theme.text_dim).small());
+                // `TextStyle::Small`'s logical size is `font_normal`, unscaled —
+                // the same size `.small()` painted before this icon was
+                // configurable. The slot is generous (double that) since the
+                // icon sits in a frame that grows with its content rather
+                // than a fixed-pixel button.
+                let default_px = theme.font_normal / s;
+                let (glyph, font, color) = resolve_icon(
+                    search_icon,
+                    DEFAULT_SEARCH_ICON,
+                    theme.text_dim,
+                    default_px,
+                    default_px * 2.0,
+                    theme,
+                );
+                ui.label(RichText::new(glyph).color(color).font(font));
                 ui.label(
                     RichText::new(format!("{}▌", filter.query()))
                         .color(theme.text)
@@ -5497,6 +5573,7 @@ fn home_row(
                         attention,
                         agent_glyph,
                         &icons.home,
+                        DEFAULT_HOME_ICON,
                         is_active,
                     );
                     ui.label(
@@ -5996,7 +6073,15 @@ fn creating_row(ui: &mut egui::Ui, branch: &str, icons: &Icons, theme: &Theme) {
         row_with_trailing(
             ui,
             |ui| {
-                ui.label(RichText::new(&icons.worktree).color(theme.text_muted).size(10.0 * s));
+                let (glyph, font, color) = resolve_icon(
+                    &icons.worktree,
+                    DEFAULT_WORKTREE_ICON,
+                    theme.text_muted,
+                    10.0,
+                    10.0,
+                    theme,
+                );
+                ui.label(RichText::new(glyph).color(color).font(font));
                 let (resp, galley) = truncating_label(
                     ui,
                     RichText::new(branch).color(theme.text_muted).small(),
@@ -6017,36 +6102,44 @@ fn pr_badge<'a>(
     icons: &'a Icons,
     theme: &Theme,
     state: PrState,
-) -> (&'a str, Color32, &'static str) {
+) -> (&'a IconStyle, &'static str, Color32, &'static str) {
     match state {
-        PrState::Open => (&icons.pr_open, theme.pr_open, "open"),
-        PrState::Draft => (&icons.pr_draft, theme.pr_draft, "draft"),
-        PrState::Merged => (&icons.pr_merged, theme.pr_merged, "merged"),
-        PrState::Closed => (&icons.pr_closed, theme.pr_closed, "closed"),
+        PrState::Open => (&icons.pr_open, DEFAULT_PR_OPEN_ICON, theme.pr_open, "open"),
+        PrState::Draft => (&icons.pr_draft, DEFAULT_PR_DRAFT_ICON, theme.pr_draft, "draft"),
+        PrState::Merged => (&icons.pr_merged, DEFAULT_PR_MERGED_ICON, theme.pr_merged, "merged"),
+        PrState::Closed => (&icons.pr_closed, DEFAULT_PR_CLOSED_ICON, theme.pr_closed, "closed"),
     }
 }
 
-/// Badge glyph, color, and tooltip for an upstream state.  The tooltip names
+/// Badge style, color, and tooltip for an upstream state.  The tooltip names
 /// the upstream ref because the glyph cannot.
 fn upstream_badge<'a>(
     icons: &'a Icons,
     theme: &Theme,
     state: &UpstreamState,
-) -> (&'a str, Color32, String) {
+) -> (&'a IconStyle, &'static str, Color32, String) {
     match state {
-        UpstreamState::Level { upstream } => {
-            (&icons.upstream_level, theme.upstream_level, format!("tracks {upstream}"))
-        },
+        UpstreamState::Level { upstream } => (
+            &icons.upstream_level,
+            DEFAULT_UPSTREAM_LEVEL_ICON,
+            theme.upstream_level,
+            format!("tracks {upstream}"),
+        ),
         UpstreamState::Diverged { upstream, ahead, behind } => (
             &icons.upstream_diverged,
+            DEFAULT_UPSTREAM_DIVERGED_ICON,
             theme.upstream_diverged,
             format!("tracks {upstream} — {ahead} ahead, {behind} behind"),
         ),
-        UpstreamState::Gone { upstream } => {
-            (&icons.upstream_gone, theme.upstream_gone, format!("{upstream} is missing locally"))
-        },
+        UpstreamState::Gone { upstream } => (
+            &icons.upstream_gone,
+            DEFAULT_UPSTREAM_GONE_ICON,
+            theme.upstream_gone,
+            format!("{upstream} is missing locally"),
+        ),
         UpstreamState::Untracked => (
             &icons.upstream_untracked,
+            DEFAULT_UPSTREAM_UNTRACKED_ICON,
             theme.upstream_untracked,
             "no upstream configured".to_string(),
         ),
@@ -6081,7 +6174,11 @@ fn worktree_row(
     let frame = Frame::default().inner_margin(Margin { left: 16, right: 0, top: 3, bottom: 3 });
     let resp = frame
         .show(ui, |ui| {
-            let default_icon = if wt.is_main { &icons.worktree_main } else { &icons.worktree };
+            let (default_icon, default_glyph) = if wt.is_main {
+                (&icons.worktree_main, DEFAULT_WORKTREE_MAIN_ICON)
+            } else {
+                (&icons.worktree, DEFAULT_WORKTREE_ICON)
+            };
             let name_color = if wt.prunable || deleting {
                 theme.text_muted
             } else if is_active {
@@ -6098,6 +6195,7 @@ fn worktree_row(
                         attention,
                         agent_glyph,
                         default_icon,
+                        default_glyph,
                         is_active,
                     );
                     let (_, galley) = truncating_label(
@@ -6145,27 +6243,33 @@ fn worktree_row(
                         spawn_clicked = true;
                     }
                     if let Some(info) = pr {
-                        let (glyph, color, word) = pr_badge(icons, theme, info.state);
+                        let (style, default_glyph, color, word) =
+                            pr_badge(icons, theme, info.state);
+                        let (glyph, font, color) =
+                            resolve_icon(style, default_glyph, color, 10.0, 10.0, theme);
                         let (rect, resp) = ui
                             .allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
                         ui.painter().text(
                             rect.center(),
                             egui::Align2::CENTER_CENTER,
                             glyph,
-                            egui::FontId::proportional(10.0 * theme.ui_scale),
+                            font,
                             color,
                         );
                         resp.on_hover_text(format!("PR #{} — {word}", info.number));
                     }
                     if let Some(state) = wt.upstream.as_ref() {
-                        let (glyph, color, tip) = upstream_badge(icons, theme, state);
+                        let (style, default_glyph, color, tip) =
+                            upstream_badge(icons, theme, state);
+                        let (glyph, font, color) =
+                            resolve_icon(style, default_glyph, color, 10.0, 10.0, theme);
                         let (rect, resp) = ui
                             .allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
                         ui.painter().text(
                             rect.center(),
                             egui::Align2::CENTER_CENTER,
                             glyph,
-                            egui::FontId::proportional(10.0 * theme.ui_scale),
+                            font,
                             color,
                         );
                         resp.on_hover_text(tip);
@@ -6263,6 +6367,7 @@ fn session_row(
                         row.needs_attention,
                         row.agent_glyph,
                         &icons.session,
+                        DEFAULT_SESSION_ICON,
                         row.is_active,
                     );
                     let (_, galley) = truncating_label(
@@ -9655,6 +9760,180 @@ mod tests {
         }
     }
 
+    #[test]
+    fn a_configured_size_is_clamped_to_the_slot() {
+        let theme = Theme::from_config(&Config::default());
+        let style = IconStyle { size: Some(400.0), ..Default::default() };
+        let (_, font, _) = resolve_icon(&style, "○", Color32::WHITE, 10.0, 10.0, &theme);
+        assert!(
+            font.size <= 10.0 * theme.ui_scale,
+            "an oversized glyph must not overlap its neighbours"
+        );
+
+        let (_, font, _) = resolve_icon(&style, "×", Color32::WHITE, 12.0, 16.0, &theme);
+        assert!(font.size <= 16.0 * theme.ui_scale, "a button glyph clamps to its own 16px slot");
+    }
+
+    /// With no config, every icon must paint at exactly the size it does today —
+    /// buttons at 12 inside a 16 slot, status markers at 10.
+    #[test]
+    fn an_unconfigured_icon_keeps_its_current_size() {
+        let theme = Theme::from_config(&Config::default());
+        let style = IconStyle::default();
+        let (_, font, _) = resolve_icon(&style, "×", Color32::WHITE, 12.0, 16.0, &theme);
+        assert_eq!(font.size, 12.0 * theme.ui_scale);
+    }
+
+    #[test]
+    fn a_configured_color_wins_over_the_site_default() {
+        let theme = Theme::from_config(&Config::default());
+        let style = IconStyle { color: Some(Color32::RED), ..Default::default() };
+        let (_, _, color) = resolve_icon(&style, "○", Color32::WHITE, 10.0, 10.0, &theme);
+        assert_eq!(color, Color32::RED);
+    }
+
+    /// An unstyled icon must render `FontFamily::Proportional`, exactly what
+    /// every pre-existing call site painted before icons became configurable.
+    #[test]
+    fn an_unconfigured_icon_resolves_to_the_proportional_family() {
+        let theme = Theme::from_config(&Config::default());
+        let (_, font, _) =
+            resolve_icon(&IconStyle::default(), "○", Color32::WHITE, 10.0, 10.0, &theme);
+        assert_eq!(font.family, egui::FontFamily::Proportional);
+    }
+
+    /// `italic` alone (no `bold`) must resolve to the italic face, not the
+    /// bold-italic one — the two flags are independent inputs to
+    /// `ui_variant_family`.
+    #[test]
+    fn an_italic_icon_resolves_to_the_italic_family() {
+        let theme = Theme::from_config(&Config::default());
+        let style = IconStyle { italic: true, ..Default::default() };
+        let (_, font, _) = resolve_icon(&style, "○", Color32::WHITE, 10.0, 10.0, &theme);
+        assert_eq!(font.family, egui::FontFamily::Name(crate::fonts::UI_ITALIC_FAMILY.into()));
+    }
+
+    /// The search prompt derives its `resolve_icon` inputs from
+    /// `theme.font_normal` rather than a literal constant, since it used to
+    /// paint through `.small()`.  An unconfigured icon must still land on
+    /// exactly `font_normal`, matching what `TextStyle::Small` painted before
+    /// the icon became configurable.
+    #[test]
+    fn an_unconfigured_search_icon_matches_the_small_text_style_size() {
+        let theme = Theme::from_config(&Config::default());
+        let s = theme.ui_scale;
+        let default_px = theme.font_normal / s;
+        let (_, font, _) = resolve_icon(
+            &IconStyle::default(),
+            DEFAULT_SEARCH_ICON,
+            theme.text_dim,
+            default_px,
+            default_px * 2.0,
+            &theme,
+        );
+        assert_eq!(font.size, theme.font_normal);
+    }
+
+    /// A context with the three chrome variant families bound, as
+    /// `fonts::install_terminal_fonts` leaves it in the app.  egui panics on a
+    /// family it was never given, so any test that paints a bold/italic icon
+    /// needs them registered first.
+    fn ctx_with_ui_variant_faces() -> egui::Context {
+        let ctx = egui::Context::default();
+        let mut fonts = egui::FontDefinitions::default();
+        let mono = fonts.families[&egui::FontFamily::Monospace].clone();
+        for name in [
+            crate::fonts::UI_BOLD_FAMILY,
+            crate::fonts::UI_ITALIC_FAMILY,
+            crate::fonts::UI_BOLD_ITALIC_FAMILY,
+        ] {
+            fonts.families.insert(egui::FontFamily::Name(name.into()), mono.clone());
+        }
+        ctx.set_fonts(fonts);
+        ctx
+    }
+
+    /// The font family and paint color of the first shape whose text matches
+    /// `text`, or `None` if nothing painted it.
+    fn painted_glyph_style(
+        shapes: &[egui::epaint::ClippedShape],
+        text: &str,
+    ) -> Option<(egui::FontFamily, Color32)> {
+        fn walk(shape: &egui::Shape, text: &str, out: &mut Option<(egui::FontFamily, Color32)>) {
+            match shape {
+                egui::Shape::Text(t) => {
+                    if out.is_none() && t.galley.text() == text {
+                        let family = t.galley.job.sections[0].format.font_id.family.clone();
+                        let color = t.override_text_color.unwrap_or(t.fallback_color);
+                        *out = Some((family, color));
+                    }
+                },
+                egui::Shape::Vec(v) => v.iter().for_each(|s| walk(s, text, out)),
+                _ => {},
+            }
+        }
+        let mut out = None;
+        for clipped in shapes {
+            walk(&clipped.shape, text, &mut out);
+        }
+        out
+    }
+
+    /// End-to-end: a worktree row painting an upstream badge styled with a
+    /// custom glyph, color, and weight through `upstream_badge` and
+    /// `resolve_icon` — proving the wiring, not just the resolver in isolation.
+    #[test]
+    fn a_styled_upstream_badge_paints_its_configured_glyph_color_and_weight() {
+        let theme = Theme::from_config(&Config::default());
+        let ctx = ctx_with_ui_variant_faces();
+        let mut icons = crate::config::Icons::default();
+        icons.upstream_gone = IconStyle {
+            glyph: Some("✕".to_string()),
+            color: Some(Color32::RED),
+            bold: true,
+            italic: false,
+            size: None,
+        };
+        let wt = crate::projects::Worktree {
+            name: "feature/x".to_owned(),
+            path: PathBuf::from("/repo/wt"),
+            branch: None,
+            is_main: false,
+            prunable: false,
+            upstream: Some(UpstreamState::Gone { upstream: "origin/x".into() }),
+            detached: false,
+        };
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::Vec2::new(600.0, 200.0),
+            )),
+            ..Default::default()
+        };
+        let output = ctx.run(input, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                worktree_row(
+                    ui, &wt, &wt.name, None, true, false, false, false, None, false, &icons, &theme,
+                );
+            });
+        });
+        let (family, color) =
+            painted_glyph_style(&output.shapes, "✕").expect("the configured glyph painted");
+        assert_eq!(family, egui::FontFamily::Name(crate::fonts::UI_BOLD_FAMILY.into()));
+        assert_eq!(color, Color32::RED);
+    }
+
+    /// Backward compatibility for the same badge, unconfigured: the built-in
+    /// glyph, the theme's built-in color, and the plain proportional family.
+    #[test]
+    fn an_unconfigured_upstream_badge_keeps_its_built_in_color_and_family() {
+        let theme = Theme::from_config(&Config::default());
+        let (family, color) = painted_glyph_style(&render_worktree_row_with_badges(), "✓")
+            .expect("the default glyph painted");
+        assert_eq!(family, egui::FontFamily::Proportional);
+        assert_eq!(color, theme.upstream_level);
+    }
+
     /// `[ui] sidebar_tooltips` bounds the row tooltip on both sides: `off`
     /// withholds a name the panel cut off, and `always` offers one even for a
     /// name that fits — which is what keeps a sweep down the list from losing
@@ -9704,14 +9983,14 @@ mod tests {
     fn the_upstream_tooltip_names_the_upstream_ref() {
         let icons = crate::config::Icons::default();
         let theme = Theme::from_config(&Config::default());
-        let (_, _, tip) = upstream_badge(
+        let (_, _, _, tip) = upstream_badge(
             &icons,
             &theme,
             &UpstreamState::Diverged { upstream: "origin/x".into(), ahead: 2, behind: 1 },
         );
         assert_eq!(tip, "tracks origin/x — 2 ahead, 1 behind");
 
-        let (_, _, tip) = upstream_badge(&icons, &theme, &UpstreamState::Untracked);
+        let (_, _, _, tip) = upstream_badge(&icons, &theme, &UpstreamState::Untracked);
         assert_eq!(tip, "no upstream configured");
     }
 

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -693,11 +693,8 @@ impl AlacritreeApp {
     pub fn new(cc: &CreationContext<'_>, config: Config) -> Self {
         let theme = Theme::from_config(&config);
 
-        let font_chain = crate::fonts::install_terminal_fonts(
-            &cc.egui_ctx,
-            &config.font,
-            config.ui_font.family.as_deref(),
-        );
+        let font_chain =
+            crate::fonts::install_terminal_fonts(&cc.egui_ctx, &config.font, &config.ui_font);
         let color_glyph_budget_mb = config.font.color_glyph_cache_mb;
 
         let mut visuals = egui::Visuals::dark();

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -38,6 +38,7 @@ use crate::sidebar_focus;
 use crate::sidebar_nav::{self, SidebarRow};
 use crate::state::{self, PersistedProject};
 use crate::terminal_view;
+use crate::upstream::UpstreamState;
 use crate::worktree::{self as wt, CreateRequest, Progress};
 use crate::wsl::{self, ShellChoice};
 use crate::wsl_helper::{self, WslProbe};
@@ -78,6 +79,11 @@ struct Theme {
     pr_draft: Color32,
     pr_merged: Color32,
     pr_closed: Color32,
+    /// Branch upstream badge colors, mapped from the ANSI palette.
+    upstream_level: Color32,
+    upstream_diverged: Color32,
+    upstream_gone: Color32,
+    upstream_untracked: Color32,
     /// Logical-pixel size for headings (titles like "Projects", "Git").
     /// `FontConfig::UI_HEADING_RATIO` of the terminal font size.
     font_heading: f32,
@@ -141,6 +147,10 @@ impl Theme {
             pr_draft: text_muted,
             pr_merged: rgb_to_color32(config.palette.normal[5]), // magenta
             pr_closed: rgb_to_color32(config.palette.normal[1]), // red
+            upstream_level: rgb_to_color32(config.palette.normal[2]), // green
+            upstream_diverged: rgb_to_color32(config.palette.normal[3]), // yellow
+            upstream_gone: rgb_to_color32(config.palette.normal[1]), // red
+            upstream_untracked: rgb_to_color32(config.palette.normal[4]), // blue
             font_heading,
             font_normal,
             ui_scale: font_normal / 11.25,
@@ -6019,6 +6029,33 @@ fn pr_badge<'a>(
     }
 }
 
+/// Badge glyph, color, and tooltip for an upstream state.  The tooltip names
+/// the upstream ref because the glyph cannot.
+fn upstream_badge<'a>(
+    icons: &'a Icons,
+    theme: &Theme,
+    state: &UpstreamState,
+) -> (&'a str, Color32, String) {
+    match state {
+        UpstreamState::Level { upstream } => {
+            (&icons.upstream_level, theme.upstream_level, format!("tracks {upstream}"))
+        },
+        UpstreamState::Diverged { upstream, ahead, behind } => (
+            &icons.upstream_diverged,
+            theme.upstream_diverged,
+            format!("tracks {upstream} — {ahead} ahead, {behind} behind"),
+        ),
+        UpstreamState::Gone { upstream } => {
+            (&icons.upstream_gone, theme.upstream_gone, format!("{upstream} is missing locally"))
+        },
+        UpstreamState::Untracked => (
+            &icons.upstream_untracked,
+            theme.upstream_untracked,
+            "no upstream configured".to_string(),
+        ),
+    }
+}
+
 fn worktree_row(
     ui: &mut egui::Ui,
     wt: &Worktree,
@@ -6122,6 +6159,19 @@ fn worktree_row(
                             color,
                         );
                         resp.on_hover_text(format!("PR #{} — {word}", info.number));
+                    }
+                    if let Some(state) = wt.upstream.as_ref() {
+                        let (glyph, color, tip) = upstream_badge(icons, theme, state);
+                        let (rect, resp) = ui
+                            .allocate_exact_size(row_status_icon_size(theme), egui::Sense::hover());
+                        ui.painter().text(
+                            rect.center(),
+                            egui::Align2::CENTER_CENTER,
+                            glyph,
+                            egui::FontId::proportional(10.0 * theme.ui_scale),
+                            color,
+                        );
+                        resp.on_hover_text(tip);
                     }
                 },
             );
@@ -9440,6 +9490,26 @@ mod tests {
         out
     }
 
+    /// The x-coordinate of every painted glyph, keyed by its text — for
+    /// asserting left-to-right screen order rather than the (reversed)
+    /// right-to-left call order `row_with_trailing` lays widgets out in.
+    fn painted_glyph_centers(shapes: &[egui::epaint::ClippedShape]) -> HashMap<String, f32> {
+        fn walk(shape: &egui::Shape, out: &mut HashMap<String, f32>) {
+            match shape {
+                egui::Shape::Text(t) => {
+                    out.insert(t.galley.text().to_owned(), t.pos.x);
+                },
+                egui::Shape::Vec(v) => v.iter().for_each(|s| walk(s, out)),
+                _ => {},
+            }
+        }
+        let mut out = HashMap::new();
+        for clipped in shapes {
+            walk(&clipped.shape, &mut out);
+        }
+        out
+    }
+
     /// Rest the pointer over a row and collect every text painted while it
     /// lingers there, tooltip included. The frames advance the clock past
     /// `tooltip_delay` and keep the pointer still, which is what egui waits
@@ -9631,6 +9701,84 @@ mod tests {
             );
             assert_eq!(tooltip_shown(&texts, name), want, "{mode:?} on {name:?}: {texts:?}");
         }
+    }
+
+    #[test]
+    fn the_upstream_tooltip_names_the_upstream_ref() {
+        let icons = crate::config::Icons::default();
+        let theme = Theme::from_config(&Config::default());
+        let (_, _, tip) = upstream_badge(
+            &icons,
+            &theme,
+            &UpstreamState::Diverged { upstream: "origin/x".into(), ahead: 2, behind: 1 },
+        );
+        assert_eq!(tip, "tracks origin/x — 2 ahead, 1 behind");
+
+        let (_, _, tip) = upstream_badge(&icons, &theme, &UpstreamState::Untracked);
+        assert_eq!(tip, "no upstream configured");
+    }
+
+    /// A single headless frame of a worktree row carrying both a PR and an
+    /// upstream state, so both trailing badges paint alongside the × and +
+    /// buttons.
+    fn render_worktree_row_with_badges() -> Vec<egui::epaint::ClippedShape> {
+        let theme = Theme::from_config(&Config::default());
+        let icons = crate::config::Icons::default();
+        let wt = crate::projects::Worktree {
+            name: "feature/x".to_owned(),
+            path: PathBuf::from("/repo/wt"),
+            branch: None,
+            is_main: false,
+            prunable: false,
+            upstream: Some(UpstreamState::Level { upstream: "origin/x".into() }),
+            detached: false,
+        };
+        let pr = PrInfo {
+            number: 1,
+            base_branch: "main".into(),
+            url: String::new(),
+            state: PrState::Open,
+        };
+
+        let ctx = egui::Context::default();
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::Vec2::new(600.0, 200.0),
+            )),
+            ..Default::default()
+        };
+        let output = ctx.run(input, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                worktree_row(
+                    ui,
+                    &wt,
+                    &wt.name,
+                    Some(&pr),
+                    true,
+                    false,
+                    false,
+                    false,
+                    None,
+                    false,
+                    &icons,
+                    &theme,
+                );
+            });
+        });
+        output.shapes
+    }
+
+    /// `row_with_trailing` lays the trailing group out right-to-left, so call
+    /// order is the reverse of what the user sees.  Assert the rendering, not
+    /// the call order — the two read as opposites.
+    #[test]
+    fn the_upstream_badge_paints_left_of_the_pr_badge_and_the_buttons() {
+        let centers = painted_glyph_centers(&render_worktree_row_with_badges());
+        let x = |g: &str| centers.get(g).copied().expect(g);
+        assert!(x("✓") < x("⬤"), "upstream badge sits left of the PR badge");
+        assert!(x("⬤") < x("+"), "badges sit left of the action buttons");
+        assert!(x("+") < x("×"), "the existing button order is unchanged");
     }
 
     /// Session rows sense their click the same retroactive way, so a long

--- a/alacritree/src/cli/offline.rs
+++ b/alacritree/src/cli/offline.rs
@@ -88,7 +88,7 @@ fn add(state_path: &Path, path: &Path) -> Project {
             s.projects.push(PersistedProject { root, expanded: true, shell: None, label: None });
         }
     });
-    Project::discover(path.to_path_buf()).project
+    Project::discover(path.to_path_buf(), false).project
 }
 
 fn remove(state_path: &Path, root: &Path) -> Result<(), String> {
@@ -123,7 +123,7 @@ fn discover_all(state_path: &Path) -> Vec<Project> {
     projects
         .into_iter()
         .map(|p| {
-            let mut project = Project::discover(p.root).project;
+            let mut project = Project::discover(p.root, false).project;
             project.expanded = p.expanded;
             project.label = p.label;
             project

--- a/alacritree/src/color_glyph.rs
+++ b/alacritree/src/color_glyph.rs
@@ -304,7 +304,7 @@ fn scale_rgba(src: &[u8], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32) -> Vec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::FontConfig;
+    use crate::config::{FontConfig, UiFont};
 
     fn metrics() -> Metrics {
         Metrics { average_advance: 9.0, line_height: 20.0, descent: -4.0 }
@@ -339,7 +339,7 @@ mod tests {
             .collect(),
             ..FontConfig::default()
         };
-        let chain = crate::fonts::install_terminal_fonts(ctx, &font, None);
+        let chain = crate::fonts::install_terminal_fonts(ctx, &font, &UiFont::default());
 
         let renders_emoji = chain.iter().find_map(|face| {
             let data = std::fs::read(&face.path).ok()?;
@@ -432,7 +432,8 @@ mod tests {
     #[test]
     fn plain_text_is_left_to_egui() {
         let ctx = Context::default();
-        let chain = crate::fonts::install_terminal_fonts(&ctx, &FontConfig::default(), None);
+        let chain =
+            crate::fonts::install_terminal_fonts(&ctx, &FontConfig::default(), &UiFont::default());
         let mut cache = ColorGlyphCache::new(chain, 10);
         for c in ['A', 'z', '0', '─', '│'] {
             assert!(cache.get(&ctx, c, &metrics(), 1).is_none(), "{c} took the colour path");

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -606,6 +606,12 @@ pub struct UiFont {
     pub family: Option<String>,
     /// Typographic points, same unit as `[font] size`; clamped to ≥ 1.0.
     pub size: Option<f32>,
+    /// Family used for bold chrome text; falls back to `family` when unset.
+    pub bold_family: Option<String>,
+    /// Family used for italic chrome text; falls back to `family` when unset.
+    pub italic_family: Option<String>,
+    /// Family used for bold-italic chrome text; falls back to `family` when unset.
+    pub bold_italic_family: Option<String>,
 }
 
 /// Sidebar status glyphs, each independently overridable from `[ui.icons]`.
@@ -1420,6 +1426,9 @@ struct RawSessionDisplay {
 struct RawUiFont {
     family: Option<String>,
     size: Option<f32>,
+    bold_family: Option<String>,
+    italic_family: Option<String>,
+    bold_italic_family: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1831,6 +1840,14 @@ impl RawConfig {
         let ui_font = UiFont {
             family: self.ui.font.family.clone().filter(|f| !f.trim().is_empty()),
             size: self.ui.font.size.map(|s| s.max(1.0)),
+            bold_family: self.ui.font.bold_family.clone().filter(|f| !f.trim().is_empty()),
+            italic_family: self.ui.font.italic_family.clone().filter(|f| !f.trim().is_empty()),
+            bold_italic_family: self
+                .ui
+                .font
+                .bold_italic_family
+                .clone()
+                .filter(|f| !f.trim().is_empty()),
         };
 
         // ---- Profiles ----
@@ -2484,6 +2501,20 @@ program = "second"
     fn blank_ui_font_family_is_ignored() {
         let config = parse("[ui.font]\nfamily = \"  \"");
         assert_eq!(config.ui_font.family, None);
+    }
+
+    #[test]
+    fn ui_font_variant_families_parse_and_default_to_none() {
+        let config = parse("[ui.font]\nfamily = \"Inter\"\nbold_family = \"Inter Display\"");
+        assert_eq!(config.ui_font.bold_family.as_deref(), Some("Inter Display"));
+        assert_eq!(config.ui_font.italic_family, None);
+        assert_eq!(config.ui_font.bold_italic_family, None);
+    }
+
+    #[test]
+    fn blank_ui_font_variant_families_are_ignored() {
+        let config = parse("[ui.font]\nbold_family = \"  \"");
+        assert_eq!(config.ui_font.bold_family, None);
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -636,8 +636,11 @@ pub struct UiFont {
 /// Sidebar status glyphs, each independently overridable from `[ui.icons]`
 /// as a bare glyph or a table styling color/weight/slant/size.  An absent key
 /// falls back to the default below; a table with no `glyph` key keeps the
-/// default glyph but applies its own styling.  Action buttons (×, +, ↻, ⇅)
-/// are controls, not status, and stay fixed.
+/// default glyph but applies its own styling.  Action buttons (×, +, ↻) are
+/// controls, not status, and stay fixed. The projects panel's reorder toggle
+/// also paints a fixed glyph (⇅) that happens to match `upstream_diverged`'s
+/// default below — the two are unrelated, and reconfiguring one does not
+/// affect the other.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Icons {
     /// Glyph prefixing the sidebar search prompt.
@@ -706,9 +709,9 @@ impl Default for Icons {
     }
 }
 
-/// A sidebar icon's glyph and how to paint it.  Parses from a bare string
-/// (glyph only) or a table, so configs written before styling existed keep
-/// working unchanged.
+/// A sidebar icon's glyph and how to paint it.  Parses from a bare string,
+/// accepted as glyph-only, or a table that also styles color, weight, slant,
+/// and size.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct IconStyle {
     pub glyph: Option<String>,

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -725,6 +725,11 @@ pub struct UiTheme {
     /// no `gh` processes; when enabled it is best-effort like the diff-base
     /// lookup: no `gh`, no auth, or no PR silently paints nothing.
     pub pr_status: bool,
+    /// Paint a badge showing each worktree branch's upstream state.  Off by
+    /// default so an unmodified config does no extra ref work.  The state comes
+    /// from local refs only — nothing fetches, so a branch deleted on the remote
+    /// still reads as tracked until something prunes.
+    pub upstream_status: bool,
     /// `[ui] pr_status_concurrency`: max `gh` lookups in flight at once.
     /// Defaults to 8; clamped to ≥ 1, since a cold cache spawns one lookup
     /// per eligible worktree in a single frame and an unbounded cap would
@@ -779,6 +784,7 @@ impl Default for UiTheme {
             icon_tooltips: true,
             session_display: SessionDisplay::default(),
             pr_status: false,
+            upstream_status: false,
             pr_status_concurrency: DEFAULT_CONCURRENCY,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
@@ -1464,6 +1470,7 @@ struct RawUi {
     /// Sidebar scrollbar style: "floating" (default) | "solid".
     scrollbar: Option<String>,
     pr_status: Option<bool>,
+    upstream_status: Option<bool>,
     /// Max `gh` lookups in flight at once.  Defaults to 8; clamped to ≥ 1.
     pr_status_concurrency: Option<usize>,
     font: RawUiFont,
@@ -1637,6 +1644,7 @@ impl RawConfig {
                 tabs_always: self.ui.session_display.tabs_always.unwrap_or(false),
             },
             pr_status: self.ui.pr_status.unwrap_or(false),
+            upstream_status: self.ui.upstream_status.unwrap_or(false),
             pr_status_concurrency: self
                 .ui
                 .pr_status_concurrency
@@ -2497,6 +2505,12 @@ program = "second"
     fn pr_status_defaults_off_and_parses_on() {
         assert!(!ui_from_toml("").pr_status);
         assert!(ui_from_toml("[ui]\npr_status = true").pr_status);
+    }
+
+    #[test]
+    fn upstream_status_defaults_off_and_parses_on() {
+        assert!(!ui_from_toml("").upstream_status);
+        assert!(ui_from_toml("[ui]\nupstream_status = true").upstream_status);
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -756,6 +756,7 @@ pub struct UiTheme {
     pub sidebar_foreground: Option<Color32>,
     pub sidebar_border: Option<Color32>,
     pub sidebar_accent: Option<Color32>,
+    pub sidebar_attention: Option<Color32>,
     /// Fire a desktop notification when a non-visible session needs attention.
     pub notifications: bool,
     /// How long an attention trigger must survive without the session going
@@ -832,6 +833,7 @@ impl Default for UiTheme {
             sidebar_foreground: None,
             sidebar_border: None,
             sidebar_accent: None,
+            sidebar_attention: None,
             notifications: true,
             attention_grace: Duration::ZERO,
             confirm_session_close: ConfirmSessionClose::Never,
@@ -1545,6 +1547,7 @@ struct RawUi {
     sidebar_foreground: Option<RgbStr>,
     sidebar_border: Option<RgbStr>,
     sidebar_accent: Option<RgbStr>,
+    sidebar_attention: Option<RgbStr>,
     notifications: Option<bool>,
     /// Grace window in milliseconds before an attention trigger pings; a
     /// session that resumes work inside it swallows the ping.  Default 0.
@@ -1731,6 +1734,7 @@ impl RawConfig {
             sidebar_foreground: self.ui.sidebar_foreground.map(|v| rgb_to_color32(v.0)),
             sidebar_border: self.ui.sidebar_border.map(|v| rgb_to_color32(v.0)),
             sidebar_accent: self.ui.sidebar_accent.map(|v| rgb_to_color32(v.0)),
+            sidebar_attention: self.ui.sidebar_attention.map(|v| rgb_to_color32(v.0)),
             notifications: self.ui.notifications.unwrap_or(true),
             attention_grace: Duration::from_millis(self.ui.attention_grace_ms.unwrap_or(0)),
             confirm_session_close: parse_confirm_session_close(
@@ -2899,6 +2903,15 @@ program = "second"
                 spelling: PathSpelling { quote: Quoting::Posix, wsl_translate: false },
                 highlight: false,
             }
+        );
+    }
+
+    #[test]
+    fn sidebar_attention_parses_and_defaults_to_none() {
+        assert_eq!(ui_from_toml("").sidebar_attention, None);
+        assert_eq!(
+            ui_from_toml("[ui]\nsidebar_attention = \"#ffb86c\"").sidebar_attention,
+            Some(Color32::from_rgb(0xff, 0xb8, 0x6c))
         );
     }
 

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -626,6 +626,10 @@ pub struct Icons {
     pub pr_draft: String,
     pub pr_merged: String,
     pub pr_closed: String,
+    pub upstream_level: String,
+    pub upstream_diverged: String,
+    pub upstream_gone: String,
+    pub upstream_untracked: String,
 }
 
 /// `[ui.focus_outline]`: stroke a border around a panel while it owns
@@ -663,6 +667,10 @@ impl Default for Icons {
             pr_draft: "◯".into(),
             pr_merged: "⬤".into(),
             pr_closed: "⬤".into(),
+            upstream_level: "✓".into(),
+            upstream_diverged: "⇅".into(),
+            upstream_gone: "⌫".into(),
+            upstream_untracked: "↑".into(),
         }
     }
 }
@@ -1356,6 +1364,10 @@ struct RawIcons {
     pr_draft: Option<String>,
     pr_merged: Option<String>,
     pr_closed: Option<String>,
+    upstream_level: Option<String>,
+    upstream_diverged: Option<String>,
+    upstream_gone: Option<String>,
+    upstream_untracked: Option<String>,
 }
 
 /// A trimmed, non-blank override — or the default.
@@ -1379,6 +1391,10 @@ fn build_icons(raw: RawIcons) -> Icons {
         pr_draft: icon_or(raw.pr_draft, &d.pr_draft),
         pr_merged: icon_or(raw.pr_merged, &d.pr_merged),
         pr_closed: icon_or(raw.pr_closed, &d.pr_closed),
+        upstream_level: icon_or(raw.upstream_level, &d.upstream_level),
+        upstream_diverged: icon_or(raw.upstream_diverged, &d.upstream_diverged),
+        upstream_gone: icon_or(raw.upstream_gone, &d.upstream_gone),
+        upstream_untracked: icon_or(raw.upstream_untracked, &d.upstream_untracked),
     }
 }
 
@@ -2499,6 +2515,15 @@ program = "second"
         let ui = ui_from_toml("[ui.icons]\nworktree_main = \"   \"\nsession = \"\"");
         assert_eq!(ui.icons.worktree_main, "●");
         assert_eq!(ui.icons.session, "▪");
+    }
+
+    #[test]
+    fn upstream_icons_have_defaults() {
+        let ui = ui_from_toml("");
+        assert_eq!(ui.icons.upstream_level, "✓");
+        assert_eq!(ui.icons.upstream_diverged, "⇅");
+        assert_eq!(ui.icons.upstream_gone, "⌫");
+        assert_eq!(ui.icons.upstream_untracked, "↑");
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -2700,9 +2700,14 @@ program = "second"
 
     #[test]
     fn blank_icon_override_falls_back() {
+        // `build_icons` stores a blank override's glyph as-is (blank, not
+        // `None`) and defers filtering to `or_glyph` at the paint site — the
+        // same deferral a table with no `glyph` key gets. A sentinel default
+        // that differs from both the raw blank input and every built-in
+        // glyph makes the assertion fail if that filtering ever breaks.
         let ui = ui_from_toml("[ui.icons]\nworktree_main = \"   \"\nsession = \"\"");
-        assert_eq!(ui.icons.worktree_main.or_glyph("●"), "●");
-        assert_eq!(ui.icons.session.or_glyph("▪"), "▪");
+        assert_eq!(ui.icons.worktree_main.or_glyph("sentinel"), "sentinel");
+        assert_eq!(ui.icons.session.or_glyph("sentinel"), "sentinel");
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -475,7 +475,26 @@ fn text_emphasis(raw: &RawTextEmphasis) -> TextEmphasis {
 
 /// Text-presentation magnifier (U+2315).  Not in egui's bundled fonts; it
 /// resolves through the system fallback chain `fonts.rs` registers.
-const DEFAULT_SEARCH_ICON: &str = "⌕";
+pub(crate) const DEFAULT_SEARCH_ICON: &str = "⌕";
+
+/// Default glyphs for every other `[ui.icons]` key, shared between
+/// `Icons::default()` and the paint sites' `resolve_icon` fallback — a table
+/// override that styles a key without setting `glyph` still needs the real
+/// default to fall back to, not a blank string.
+pub(crate) const DEFAULT_WORKTREE_MAIN_ICON: &str = "●";
+pub(crate) const DEFAULT_WORKTREE_ICON: &str = "○";
+pub(crate) const DEFAULT_SESSION_ICON: &str = "▪";
+pub(crate) const DEFAULT_HOME_ICON: &str = "⌂";
+pub(crate) const DEFAULT_PROJECT_EXPANDED_ICON: &str = "▾";
+pub(crate) const DEFAULT_PROJECT_COLLAPSED_ICON: &str = "▸";
+pub(crate) const DEFAULT_PR_OPEN_ICON: &str = "⬤";
+pub(crate) const DEFAULT_PR_DRAFT_ICON: &str = "◯";
+pub(crate) const DEFAULT_PR_MERGED_ICON: &str = "⬤";
+pub(crate) const DEFAULT_PR_CLOSED_ICON: &str = "⬤";
+pub(crate) const DEFAULT_UPSTREAM_LEVEL_ICON: &str = "✓";
+pub(crate) const DEFAULT_UPSTREAM_DIVERGED_ICON: &str = "⇅";
+pub(crate) const DEFAULT_UPSTREAM_GONE_ICON: &str = "⌫";
+pub(crate) const DEFAULT_UPSTREAM_UNTRACKED_ICON: &str = "↑";
 
 /// What happens when the on-screen workspace's last session closes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -614,28 +633,29 @@ pub struct UiFont {
     pub bold_italic_family: Option<String>,
 }
 
-/// Sidebar status glyphs, each independently overridable from `[ui.icons]`.
-/// Overrides are trimmed and a blank value falls back to the default, so a
-/// row marker can never be rendered empty.  Action buttons (×, +, ↻, ⇅) are
-/// controls, not status, and stay fixed.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Sidebar status glyphs, each independently overridable from `[ui.icons]`
+/// as a bare glyph or a table styling color/weight/slant/size.  An absent key
+/// falls back to the default below; a table with no `glyph` key keeps the
+/// default glyph but applies its own styling.  Action buttons (×, +, ↻, ⇅)
+/// are controls, not status, and stay fixed.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Icons {
     /// Glyph prefixing the sidebar search prompt.
-    pub search: String,
-    pub worktree_main: String,
-    pub worktree: String,
-    pub session: String,
-    pub home: String,
-    pub project_expanded: String,
-    pub project_collapsed: String,
-    pub pr_open: String,
-    pub pr_draft: String,
-    pub pr_merged: String,
-    pub pr_closed: String,
-    pub upstream_level: String,
-    pub upstream_diverged: String,
-    pub upstream_gone: String,
-    pub upstream_untracked: String,
+    pub search: IconStyle,
+    pub worktree_main: IconStyle,
+    pub worktree: IconStyle,
+    pub session: IconStyle,
+    pub home: IconStyle,
+    pub project_expanded: IconStyle,
+    pub project_collapsed: IconStyle,
+    pub pr_open: IconStyle,
+    pub pr_draft: IconStyle,
+    pub pr_merged: IconStyle,
+    pub pr_closed: IconStyle,
+    pub upstream_level: IconStyle,
+    pub upstream_diverged: IconStyle,
+    pub upstream_gone: IconStyle,
+    pub upstream_untracked: IconStyle,
 }
 
 /// `[ui.focus_outline]`: stroke a border around a panel while it owns
@@ -659,24 +679,29 @@ impl Default for FocusOutline {
     }
 }
 
+/// A default icon: just the glyph, no styling.
+fn glyph(g: &str) -> IconStyle {
+    IconStyle { glyph: Some(g.to_string()), ..Default::default() }
+}
+
 impl Default for Icons {
     fn default() -> Self {
         Self {
-            search: DEFAULT_SEARCH_ICON.into(),
-            worktree_main: "●".into(),
-            worktree: "○".into(),
-            session: "▪".into(),
-            home: "⌂".into(),
-            project_expanded: "▾".into(),
-            project_collapsed: "▸".into(),
-            pr_open: "⬤".into(),
-            pr_draft: "◯".into(),
-            pr_merged: "⬤".into(),
-            pr_closed: "⬤".into(),
-            upstream_level: "✓".into(),
-            upstream_diverged: "⇅".into(),
-            upstream_gone: "⌫".into(),
-            upstream_untracked: "↑".into(),
+            search: glyph(DEFAULT_SEARCH_ICON),
+            worktree_main: glyph(DEFAULT_WORKTREE_MAIN_ICON),
+            worktree: glyph(DEFAULT_WORKTREE_ICON),
+            session: glyph(DEFAULT_SESSION_ICON),
+            home: glyph(DEFAULT_HOME_ICON),
+            project_expanded: glyph(DEFAULT_PROJECT_EXPANDED_ICON),
+            project_collapsed: glyph(DEFAULT_PROJECT_COLLAPSED_ICON),
+            pr_open: glyph(DEFAULT_PR_OPEN_ICON),
+            pr_draft: glyph(DEFAULT_PR_DRAFT_ICON),
+            pr_merged: glyph(DEFAULT_PR_MERGED_ICON),
+            pr_closed: glyph(DEFAULT_PR_CLOSED_ICON),
+            upstream_level: glyph(DEFAULT_UPSTREAM_LEVEL_ICON),
+            upstream_diverged: glyph(DEFAULT_UPSTREAM_DIVERGED_ICON),
+            upstream_gone: glyph(DEFAULT_UPSTREAM_GONE_ICON),
+            upstream_untracked: glyph(DEFAULT_UPSTREAM_UNTRACKED_ICON),
         }
     }
 }
@@ -1373,53 +1398,53 @@ struct RawWsl {
     automount_root: Option<String>,
 }
 
-/// `[ui.icons]`: sidebar glyph overrides.  Any string works, so Nerd Font
-/// users can substitute their own icons.
+/// `[ui.icons]`: sidebar glyph overrides.  A bare string sets the glyph
+/// alone; a table also styles color/weight/slant/size.  Any glyph works, so
+/// Nerd Font users can substitute their own icons.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 struct RawIcons {
-    search: Option<String>,
-    worktree_main: Option<String>,
-    worktree: Option<String>,
-    session: Option<String>,
-    home: Option<String>,
-    project_expanded: Option<String>,
-    project_collapsed: Option<String>,
-    pr_open: Option<String>,
-    pr_draft: Option<String>,
-    pr_merged: Option<String>,
-    pr_closed: Option<String>,
-    upstream_level: Option<String>,
-    upstream_diverged: Option<String>,
-    upstream_gone: Option<String>,
-    upstream_untracked: Option<String>,
+    search: Option<RawIconStyle>,
+    worktree_main: Option<RawIconStyle>,
+    worktree: Option<RawIconStyle>,
+    session: Option<RawIconStyle>,
+    home: Option<RawIconStyle>,
+    project_expanded: Option<RawIconStyle>,
+    project_collapsed: Option<RawIconStyle>,
+    pr_open: Option<RawIconStyle>,
+    pr_draft: Option<RawIconStyle>,
+    pr_merged: Option<RawIconStyle>,
+    pr_closed: Option<RawIconStyle>,
+    upstream_level: Option<RawIconStyle>,
+    upstream_diverged: Option<RawIconStyle>,
+    upstream_gone: Option<RawIconStyle>,
+    upstream_untracked: Option<RawIconStyle>,
 }
 
-/// A trimmed, non-blank override — or the default.
-fn icon_or(raw: Option<String>, default: &str) -> String {
-    raw.map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| default.to_string())
+/// An absent key falls back to the key's default style (glyph included); a
+/// present one always wins, even if it styles without setting `glyph`.
+fn style_or(raw: Option<RawIconStyle>, default: &IconStyle) -> IconStyle {
+    raw.map(IconStyle::from).unwrap_or_else(|| default.clone())
 }
 
 fn build_icons(raw: RawIcons) -> Icons {
     let d = Icons::default();
     Icons {
-        search: icon_or(raw.search, &d.search),
-        worktree_main: icon_or(raw.worktree_main, &d.worktree_main),
-        worktree: icon_or(raw.worktree, &d.worktree),
-        session: icon_or(raw.session, &d.session),
-        home: icon_or(raw.home, &d.home),
-        project_expanded: icon_or(raw.project_expanded, &d.project_expanded),
-        project_collapsed: icon_or(raw.project_collapsed, &d.project_collapsed),
-        pr_open: icon_or(raw.pr_open, &d.pr_open),
-        pr_draft: icon_or(raw.pr_draft, &d.pr_draft),
-        pr_merged: icon_or(raw.pr_merged, &d.pr_merged),
-        pr_closed: icon_or(raw.pr_closed, &d.pr_closed),
-        upstream_level: icon_or(raw.upstream_level, &d.upstream_level),
-        upstream_diverged: icon_or(raw.upstream_diverged, &d.upstream_diverged),
-        upstream_gone: icon_or(raw.upstream_gone, &d.upstream_gone),
-        upstream_untracked: icon_or(raw.upstream_untracked, &d.upstream_untracked),
+        search: style_or(raw.search, &d.search),
+        worktree_main: style_or(raw.worktree_main, &d.worktree_main),
+        worktree: style_or(raw.worktree, &d.worktree),
+        session: style_or(raw.session, &d.session),
+        home: style_or(raw.home, &d.home),
+        project_expanded: style_or(raw.project_expanded, &d.project_expanded),
+        project_collapsed: style_or(raw.project_collapsed, &d.project_collapsed),
+        pr_open: style_or(raw.pr_open, &d.pr_open),
+        pr_draft: style_or(raw.pr_draft, &d.pr_draft),
+        pr_merged: style_or(raw.pr_merged, &d.pr_merged),
+        pr_closed: style_or(raw.pr_closed, &d.pr_closed),
+        upstream_level: style_or(raw.upstream_level, &d.upstream_level),
+        upstream_diverged: style_or(raw.upstream_diverged, &d.upstream_diverged),
+        upstream_gone: style_or(raw.upstream_gone, &d.upstream_gone),
+        upstream_untracked: style_or(raw.upstream_untracked, &d.upstream_untracked),
     }
 }
 
@@ -2154,8 +2179,50 @@ mod tests {
 
     #[test]
     fn search_icon_defaults_and_overrides() {
-        assert_eq!(ui_from_toml("").icons.search, DEFAULT_SEARCH_ICON);
-        assert_eq!(ui_from_toml("[ui.icons]\nsearch = \"\u{f002}\"").icons.search, "\u{f002}");
+        assert_eq!(ui_from_toml("").icons.search.or_glyph(""), DEFAULT_SEARCH_ICON);
+        assert_eq!(
+            ui_from_toml("[ui.icons]\nsearch = \"\u{f002}\"").icons.search.or_glyph(""),
+            "\u{f002}"
+        );
+    }
+
+    #[test]
+    fn icons_defaults_are_unchanged_for_every_pre_existing_key() {
+        let ui = ui_from_toml("");
+        assert_eq!(ui.icons.worktree_main.or_glyph(""), "●");
+        assert_eq!(ui.icons.worktree.or_glyph(""), "○");
+        assert_eq!(ui.icons.session.or_glyph(""), "▪");
+        assert_eq!(ui.icons.home.or_glyph(""), "⌂");
+        assert_eq!(ui.icons.project_expanded.or_glyph(""), "▾");
+        assert_eq!(ui.icons.project_collapsed.or_glyph(""), "▸");
+        assert_eq!(ui.icons.pr_open.or_glyph(""), "⬤");
+        assert_eq!(ui.icons.pr_draft.or_glyph(""), "◯");
+    }
+
+    #[test]
+    fn a_bare_string_icon_override_parses_through_the_real_config_path() {
+        let ui = ui_from_toml("[ui.icons]\nworktree = \"◆\"");
+        assert_eq!(ui.icons.worktree.or_glyph("○"), "◆");
+        assert_eq!(ui.icons.worktree.color, None);
+        assert!(!ui.icons.worktree.bold);
+        // An untouched key keeps today's default glyph, unaffected by a
+        // sibling key's override.
+        assert_eq!(ui.icons.worktree_main.or_glyph(""), "●");
+    }
+
+    #[test]
+    fn a_table_icon_override_parses_glyph_color_weight_slant_and_size_through_the_real_config_path()
+    {
+        let ui = ui_from_toml(
+            "[ui.icons]\nupstream_gone = { glyph = \"⌫\", color = \"#ff5555\", bold = true, \
+             italic = true, size = 14 }",
+        );
+        let style = &ui.icons.upstream_gone;
+        assert_eq!(style.or_glyph(""), "⌫");
+        assert_eq!(style.color, Some(Color32::from_rgb(0xff, 0x55, 0x55)));
+        assert!(style.bold);
+        assert!(style.italic);
+        assert_eq!(style.size, Some(14.0));
     }
 
     #[derive(Deserialize)]
@@ -2611,40 +2678,40 @@ program = "second"
     fn icons_default_to_todays_glyphs() {
         let ui = ui_from_toml("");
         assert_eq!(ui.icons, Icons::default());
-        assert_eq!(ui.icons.worktree_main, "●");
-        assert_eq!(ui.icons.worktree, "○");
-        assert_eq!(ui.icons.session, "▪");
-        assert_eq!(ui.icons.home, "⌂");
-        assert_eq!(ui.icons.project_expanded, "▾");
-        assert_eq!(ui.icons.project_collapsed, "▸");
-        assert_eq!(ui.icons.pr_open, "⬤");
-        assert_eq!(ui.icons.pr_draft, "◯");
-        assert_eq!(ui.icons.pr_merged, "⬤");
-        assert_eq!(ui.icons.pr_closed, "⬤");
+        assert_eq!(ui.icons.worktree_main.or_glyph(""), "●");
+        assert_eq!(ui.icons.worktree.or_glyph(""), "○");
+        assert_eq!(ui.icons.session.or_glyph(""), "▪");
+        assert_eq!(ui.icons.home.or_glyph(""), "⌂");
+        assert_eq!(ui.icons.project_expanded.or_glyph(""), "▾");
+        assert_eq!(ui.icons.project_collapsed.or_glyph(""), "▸");
+        assert_eq!(ui.icons.pr_open.or_glyph(""), "⬤");
+        assert_eq!(ui.icons.pr_draft.or_glyph(""), "◯");
+        assert_eq!(ui.icons.pr_merged.or_glyph(""), "⬤");
+        assert_eq!(ui.icons.pr_closed.or_glyph(""), "⬤");
     }
 
     #[test]
     fn icon_overrides_apply_and_trim() {
         let ui = ui_from_toml("[ui.icons]\nworktree = \" W \"\nhome = \"H\"");
-        assert_eq!(ui.icons.worktree, "W");
-        assert_eq!(ui.icons.home, "H");
-        assert_eq!(ui.icons.worktree_main, "●", "untouched fields keep defaults");
+        assert_eq!(ui.icons.worktree.or_glyph(""), "W");
+        assert_eq!(ui.icons.home.or_glyph(""), "H");
+        assert_eq!(ui.icons.worktree_main.or_glyph(""), "●", "untouched fields keep defaults");
     }
 
     #[test]
     fn blank_icon_override_falls_back() {
         let ui = ui_from_toml("[ui.icons]\nworktree_main = \"   \"\nsession = \"\"");
-        assert_eq!(ui.icons.worktree_main, "●");
-        assert_eq!(ui.icons.session, "▪");
+        assert_eq!(ui.icons.worktree_main.or_glyph("●"), "●");
+        assert_eq!(ui.icons.session.or_glyph("▪"), "▪");
     }
 
     #[test]
     fn upstream_icons_have_defaults() {
         let ui = ui_from_toml("");
-        assert_eq!(ui.icons.upstream_level, "✓");
-        assert_eq!(ui.icons.upstream_diverged, "⇅");
-        assert_eq!(ui.icons.upstream_gone, "⌫");
-        assert_eq!(ui.icons.upstream_untracked, "↑");
+        assert_eq!(ui.icons.upstream_level.or_glyph(""), "✓");
+        assert_eq!(ui.icons.upstream_diverged.or_glyph(""), "⇅");
+        assert_eq!(ui.icons.upstream_gone.or_glyph(""), "⌫");
+        assert_eq!(ui.icons.upstream_untracked.or_glyph(""), "↑");
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -681,6 +681,25 @@ impl Default for Icons {
     }
 }
 
+/// A sidebar icon's glyph and how to paint it.  Parses from a bare string
+/// (glyph only) or a table, so configs written before styling existed keep
+/// working unchanged.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct IconStyle {
+    pub glyph: Option<String>,
+    pub color: Option<Color32>,
+    pub bold: bool,
+    pub italic: bool,
+    /// Logical pixels before `ui_scale`; clamped to the icon's slot at paint.
+    pub size: Option<f32>,
+}
+
+impl IconStyle {
+    pub fn or_glyph<'a>(&'a self, default: &'a str) -> &'a str {
+        self.glyph.as_deref().map(str::trim).filter(|g| !g.is_empty()).unwrap_or(default)
+    }
+}
+
 /// How one text span is emphasized.  `color: None` inherits whatever color the
 /// site normally paints, so an emphasis that sets only `bold` still tracks the
 /// theme.
@@ -1404,6 +1423,39 @@ fn build_icons(raw: RawIcons) -> Icons {
     }
 }
 
+/// A styled icon override: either a bare glyph string (`worktree = "◆"`) or a
+/// table (`worktree = { glyph = "◆", color = "#ff5555", bold = true }`), so
+/// existing bare-string configs keep parsing unchanged.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawIconStyle {
+    Glyph(String),
+    Table {
+        glyph: Option<String>,
+        color: Option<RgbStr>,
+        #[serde(default)]
+        bold: bool,
+        #[serde(default)]
+        italic: bool,
+        size: Option<f32>,
+    },
+}
+
+impl From<RawIconStyle> for IconStyle {
+    fn from(raw: RawIconStyle) -> Self {
+        match raw {
+            RawIconStyle::Glyph(glyph) => IconStyle { glyph: Some(glyph), ..Default::default() },
+            RawIconStyle::Table { glyph, color, bold, italic, size } => IconStyle {
+                glyph,
+                color: color.map(|c| rgb_to_color32(c.0)),
+                bold,
+                italic,
+                size: size.map(|s| s.max(1.0)),
+            },
+        }
+    }
+}
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 struct RawUiWsl {
@@ -2104,6 +2156,44 @@ mod tests {
     fn search_icon_defaults_and_overrides() {
         assert_eq!(ui_from_toml("").icons.search, DEFAULT_SEARCH_ICON);
         assert_eq!(ui_from_toml("[ui.icons]\nsearch = \"\u{f002}\"").icons.search, "\u{f002}");
+    }
+
+    #[derive(Deserialize)]
+    struct IconStyleWrapper {
+        icon: RawIconStyle,
+    }
+
+    fn icon_style_from_toml(input: &str) -> IconStyle {
+        let wrapper: IconStyleWrapper = toml::from_str(input).expect("valid toml");
+        wrapper.icon.into()
+    }
+
+    #[test]
+    fn icon_style_parses_a_bare_string() {
+        let icon = icon_style_from_toml("icon = \"◆\"");
+        assert_eq!(icon.or_glyph("○"), "◆");
+        assert_eq!(icon.color, None);
+        assert!(!icon.bold);
+    }
+
+    #[test]
+    fn icon_style_parses_a_table() {
+        let icon = icon_style_from_toml(
+            "icon = { glyph = \"⌫\", color = \"#ff5555\", bold = true, size = 12 }",
+        );
+        assert_eq!(icon.or_glyph("x"), "⌫");
+        assert_eq!(icon.color, Some(Color32::from_rgb(0xff, 0x55, 0x55)));
+        assert!(icon.bold);
+        assert_eq!(icon.size, Some(12.0));
+    }
+
+    #[test]
+    fn a_blank_glyph_falls_back_to_the_default() {
+        let icon = icon_style_from_toml("icon = \"   \"");
+        assert_eq!(icon.or_glyph("○"), "○");
+
+        let icon = icon_style_from_toml("icon = { color = \"#ff0000\" }");
+        assert_eq!(icon.or_glyph("○"), "○", "a table with no glyph keeps the default");
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -1454,8 +1454,8 @@ fn build_icons(raw: RawIcons) -> Icons {
 }
 
 /// A styled icon override: either a bare glyph string (`worktree = "◆"`) or a
-/// table (`worktree = { glyph = "◆", color = "#ff5555", bold = true }`), so
-/// existing bare-string configs keep parsing unchanged.
+/// table (`worktree = { glyph = "◆", color = "#ff5555", bold = true }`).  The
+/// bare form is listed first so a plain string never attempts the table arm.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum RawIconStyle {
@@ -2212,8 +2212,8 @@ mod tests {
         assert_eq!(ui.icons.worktree.or_glyph("○"), "◆");
         assert_eq!(ui.icons.worktree.color, None);
         assert!(!ui.icons.worktree.bold);
-        // An untouched key keeps today's default glyph, unaffected by a
-        // sibling key's override.
+        // An untouched key keeps its default glyph, unaffected by a sibling
+        // key's override.
         assert_eq!(ui.icons.worktree_main.or_glyph(""), "●");
     }
 

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -884,9 +884,6 @@ fn build_font_definitions(
         register_fallback_faces(&mut defs, family, style, variant, targets, fonts, &mut book);
     }
 
-    // The normal chain only splices when a UI font is configured, but the
-    // variant families must always exist — with no UI font they inherit the
-    // terminal's variant faces, which is what chrome text already renders with.
     install_ui_font(&mut defs, ui, fonts);
 
     Some((defs, book.chain))
@@ -1462,23 +1459,75 @@ mod tests {
 
     /// An egui family is a flat vector of font ids — one family cannot reference
     /// another — so each UI variant chain must physically contain the terminal
-    /// variant's ids, deduplicated, after its own faces.
+    /// variant's ids, deduplicated, after its own faces.  `register_variant`
+    /// with no real face falls back to normal bytes under a fresh id, so
+    /// `BOLD_FONT_ID`/`ITALIC_FONT_ID`/`BOLD_ITALIC_FONT_ID` here are fallback
+    /// ids, not real variant faces — this only proves the splice carries
+    /// whatever ids the terminal chain published, real or not.
     #[test]
-    fn ui_variant_families_are_registered_and_deduplicated() {
+    fn ui_variant_families_inherit_the_terminal_chain() {
         let fonts = SystemFonts::with_cache_dir(None);
         let mut defs = FontDefinitions::default();
-        let face = map_font_file(&write_parseable_font("ui_variant_test.ttf")).unwrap();
+        let path = write_parseable_font("alacritree_test_ui_variant_chain.ttf");
+        let face = map_font_file(&path).unwrap();
         insert_face(&mut defs, NORMAL_FONT_ID, face, 0);
         register_variant(&mut defs, BOLD_FONT_ID, BOLD_FAMILY, None, (face, 0));
+        register_variant(&mut defs, ITALIC_FONT_ID, ITALIC_FAMILY, None, (face, 0));
+        register_variant(&mut defs, BOLD_ITALIC_FONT_ID, BOLD_ITALIC_FAMILY, None, (face, 0));
 
         install_ui_font(&mut defs, &UiFont::default(), &fonts);
 
-        for family in [UI_BOLD_FAMILY, UI_ITALIC_FAMILY, UI_BOLD_ITALIC_FAMILY] {
-            let ids = defs.families.get(&FontFamily::Name(family.into())).expect(family);
-            assert!(!ids.is_empty(), "{family} must resolve to at least one face");
+        let proportional_head = defs.families[&FontFamily::Proportional][0].clone();
+        for (ui_family, terminal_id) in [
+            (UI_BOLD_FAMILY, BOLD_FONT_ID),
+            (UI_ITALIC_FAMILY, ITALIC_FONT_ID),
+            (UI_BOLD_ITALIC_FAMILY, BOLD_ITALIC_FONT_ID),
+        ] {
+            let ids = defs.families.get(&FontFamily::Name(ui_family.into())).expect(ui_family);
+            assert!(
+                ids.contains(&terminal_id.to_string()),
+                "{ui_family} must inherit the terminal chain's {terminal_id}"
+            );
+            assert!(
+                ids.contains(&proportional_head),
+                "{ui_family} must inherit Proportional's head face"
+            );
             let mut seen = std::collections::HashSet::new();
-            assert!(ids.iter().all(|id| seen.insert(id)), "{family} has duplicate ids");
+            assert!(ids.iter().all(|id| seen.insert(id)), "{ui_family} has duplicate ids");
         }
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The variant parse gate at the heart of `install_ui_variant` exists so a
+    /// configured `[ui.font]` variant family pointing at non-font bytes is
+    /// skipped instead of registered — registering it would make egui panic
+    /// when it parses the face at render time.
+    #[test]
+    fn unparseable_configured_variant_is_skipped_not_registered() {
+        let fonts = SystemFonts::with_cache_dir(None);
+        let mut defs = FontDefinitions::default();
+        let junk_path = std::env::temp_dir().join("alacritree_test_ui_variant_junk.ttf");
+        std::fs::write(&junk_path, b"not a font").unwrap();
+        let before = defs.font_data.len();
+
+        let ui = UiFont {
+            bold_family: Some(junk_path.to_string_lossy().into_owned()),
+            ..UiFont::default()
+        };
+        install_ui_font(&mut defs, &ui, &fonts);
+
+        assert_eq!(
+            defs.font_data.len(),
+            before,
+            "unparseable bytes must not register a new font id"
+        );
+        assert!(
+            !defs.font_data.contains_key(&format!("{UI_BOLD_FAMILY}_0")),
+            "the skipped candidate must never mint an id"
+        );
+
+        std::fs::remove_file(&junk_path).ok();
     }
 
     #[test]

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -776,8 +776,30 @@ pub fn install_terminal_fonts(ctx: &Context, font: &FontConfig, ui: &UiFont) -> 
             ctx.set_fonts(defs);
             chain
         },
-        None => Vec::new(),
+        None => {
+            install_unresolvable_font_fallback(ctx);
+            Vec::new()
+        },
     }
+}
+
+/// Bind every chrome and terminal variant family to a family egui's own
+/// defaults always provide, for the case where `[font.normal]` cannot be
+/// resolved at all and `build_font_definitions` returns `None`. Without
+/// this, `ctx.set_fonts` is never called, so `alacritree_*`/`alacritree_ui_*`
+/// are unbound names — egui panics the moment anything paints a bold or
+/// italic cell or icon, rather than just falling back to the wrong face.
+fn install_unresolvable_font_fallback(ctx: &Context) {
+    let mut defs = FontDefinitions::default();
+    let monospace = defs.families[&FontFamily::Monospace].clone();
+    let proportional = defs.families[&FontFamily::Proportional].clone();
+    for name in [BOLD_FAMILY, ITALIC_FAMILY, BOLD_ITALIC_FAMILY] {
+        defs.families.insert(FontFamily::Name(name.into()), monospace.clone());
+    }
+    for name in [UI_BOLD_FAMILY, UI_ITALIC_FAMILY, UI_BOLD_ITALIC_FAMILY] {
+        defs.families.insert(FontFamily::Name(name.into()), proportional.clone());
+    }
+    ctx.set_fonts(defs);
 }
 
 /// Resolve and register every face for `install_terminal_fonts`, separated
@@ -1607,6 +1629,48 @@ mod tests {
         // The first pass is what forces epaint to parse every face.
         ctx.begin_pass(Default::default());
         let _ = ctx.end_pass();
+    }
+
+    // Unix-excluded: fontconfig substitutes *some* font for any family name,
+    // so `[font.normal]` never fails to resolve there and `None` is
+    // unreachable through this path on that platform.
+    #[cfg(not(unix))]
+    #[test]
+    fn an_unresolvable_normal_font_still_binds_every_chrome_family() {
+        let ctx = Context::default();
+        let config = FontConfig {
+            normal: crate::config::FontFace {
+                family: Some("alacritree-no-such-terminal-family-9f3a".to_string()),
+                style: None,
+            },
+            ..Default::default()
+        };
+        let chain = install_terminal_fonts(&ctx, &config, &UiFont::default());
+        assert!(chain.is_empty(), "an unresolvable family produces no fallback chain");
+
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::Vec2::new(200.0, 200.0),
+            )),
+            ..Default::default()
+        };
+        // egui panics on an unbound `FontFamily::Name`; painting each one and
+        // reaching the assertion below is the proof that all six are bound.
+        let _ = ctx.run(input, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                for family in [
+                    FontFamily::Name(BOLD_FAMILY.into()),
+                    FontFamily::Name(ITALIC_FAMILY.into()),
+                    FontFamily::Name(BOLD_ITALIC_FAMILY.into()),
+                    FontFamily::Name(UI_BOLD_FAMILY.into()),
+                    FontFamily::Name(UI_ITALIC_FAMILY.into()),
+                    FontFamily::Name(UI_BOLD_ITALIC_FAMILY.into()),
+                ] {
+                    ui.label(egui::RichText::new("x").font(egui::FontId::new(12.0, family)));
+                }
+            });
+        });
     }
 
     // Unix-excluded: fontconfig substitutes *some* font for any family name,

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use egui::{Context, FontData, FontDefinitions, FontFamily, FontTweak};
 
-use crate::config::FontConfig;
+use crate::config::{FontConfig, UiFont};
 
 /// Hard cap on fallback faces.  fontconfig's trimmed sort tops out at a few
 /// dozen on a typical system; this just bounds startup memory and parse cost
@@ -40,6 +40,14 @@ const UI_FONT_ID: &str = "alacritree_ui_normal";
 /// Temporary family the UI chain is assembled under before being spliced to
 /// the head of `Proportional`; removed again so it never leaks to egui.
 const UI_FAMILY: &str = "alacritree_ui";
+
+/// Registered variant families for chrome text.  Distinct from
+/// `BOLD_FAMILY`/`ITALIC_FAMILY`/`BOLD_ITALIC_FAMILY` (the terminal grid's
+/// variant faces) so a `[ui.font]` override never changes what bold/italic
+/// cells render in the terminal.
+pub const UI_BOLD_FAMILY: &str = "alacritree_ui_bold";
+pub const UI_ITALIC_FAMILY: &str = "alacritree_ui_italic";
+pub const UI_BOLD_ITALIC_FAMILY: &str = "alacritree_ui_bold_italic";
 
 #[derive(Clone, Copy)]
 enum Variant {
@@ -601,8 +609,12 @@ fn fallback_tweak(primary_ratio: Option<f32>, data: &[u8], index: u32) -> FontTw
 /// it.  `Monospace` (the grid) is untouched.  Returns `false` and leaves the
 /// definitions unchanged when the family cannot be resolved or read, in which
 /// case the chrome keeps using the terminal font.
-fn install_ui_font(defs: &mut FontDefinitions, family_or_path: &str, fonts: &SystemFonts) -> bool {
-    let Some(resolved) = resolve_ui_face(family_or_path, fonts) else {
+fn install_ui_normal_chain(
+    defs: &mut FontDefinitions,
+    family_or_path: &str,
+    fonts: &SystemFonts,
+) -> bool {
+    let Some(resolved) = resolve_ui_face(family_or_path, Variant::Normal, fonts) else {
         log::warn!("could not resolve ui font '{family_or_path}'; keeping the terminal font");
         return false;
     };
@@ -651,16 +663,115 @@ fn install_ui_font(defs: &mut FontDefinitions, family_or_path: &str, fonts: &Sys
     true
 }
 
+/// Splice `[ui.font] family` into `Proportional` when configured, then
+/// register the bold/italic/bold-italic chrome families unconditionally —
+/// they must exist even with no `[ui.font]` table so bold/italic chrome text
+/// has somewhere to resolve to.  Returns whether the normal chain installed.
+fn install_ui_font(defs: &mut FontDefinitions, ui: &UiFont, fonts: &SystemFonts) -> bool {
+    let installed = match ui.family.as_deref() {
+        Some(family_or_path) => install_ui_normal_chain(defs, family_or_path, fonts),
+        None => false,
+    };
+
+    install_ui_variant(defs, ui, Variant::Bold, UI_BOLD_FAMILY, BOLD_FAMILY, fonts);
+    install_ui_variant(defs, ui, Variant::Italic, UI_ITALIC_FAMILY, ITALIC_FAMILY, fonts);
+    install_ui_variant(
+        defs,
+        ui,
+        Variant::BoldItalic,
+        UI_BOLD_ITALIC_FAMILY,
+        BOLD_ITALIC_FAMILY,
+        fonts,
+    );
+
+    installed
+}
+
+/// Order is explicit because egui families cannot nest: the configured UI
+/// variant first, then the variant derived from the UI family, then the
+/// terminal's variant ids, then normal.  Deduplicated by id.
+fn install_ui_variant(
+    defs: &mut FontDefinitions,
+    ui: &UiFont,
+    variant: Variant,
+    ui_family_name: &str,
+    terminal_family: &str,
+    fonts: &SystemFonts,
+) {
+    let mut ids: Vec<String> = Vec::new();
+    let configured = match variant {
+        Variant::Bold => ui.bold_family.as_deref(),
+        Variant::Italic => ui.italic_family.as_deref(),
+        Variant::BoldItalic => ui.bold_italic_family.as_deref(),
+        Variant::Normal => None,
+    };
+    for candidate in configured.into_iter().chain(ui.family.as_deref()) {
+        let Some(resolved) = resolve_ui_face(candidate, variant, fonts) else {
+            continue;
+        };
+        let Ok(bytes) = map_font_file(&resolved.path) else {
+            continue;
+        };
+        // The normal UI face is validated before registration; a configured
+        // variant path pointing at non-font bytes would otherwise register
+        // and panic when egui parses it.
+        if !epaint_can_parse(bytes, resolved.face_index) {
+            log::warn!(
+                "ui {} font {} is not parseable; skipping",
+                variant.label(),
+                resolved.path.display()
+            );
+            continue;
+        }
+        let id = format!("{ui_family_name}_{}", ids.len());
+        insert_face(defs, &id, bytes, resolved.face_index);
+        ids.push(id);
+        // The configured family gets its own fallback chain registered
+        // against a scratch family before the inherited terminal ids below
+        // are appended, so the fallback machinery has somewhere to write to.
+        let mut book = FallbackBook::default();
+        book.loaded_faces.insert((resolved.path.clone(), resolved.face_index));
+        book.primary_height_ratio = face_height_ratio(bytes, resolved.face_index);
+        let target = FontFamily::Name(ui_family_name.into());
+        defs.families.insert(target.clone(), ids.clone());
+        register_fallback_faces(
+            defs,
+            candidate,
+            None,
+            variant,
+            &[target.clone()],
+            fonts,
+            &mut book,
+        );
+        ids = defs.families.remove(&target).unwrap_or(ids);
+    }
+    let inherited =
+        defs.families.get(&FontFamily::Name(terminal_family.into())).cloned().unwrap_or_default();
+    ids.extend(inherited);
+    ids.extend(defs.families.get(&FontFamily::Proportional).cloned().unwrap_or_default());
+
+    let mut seen = std::collections::HashSet::new();
+    ids.retain(|id| seen.insert(id.clone()));
+    defs.families.insert(FontFamily::Name(ui_family_name.into()), ids);
+}
+
+/// Maps ANSI-style bold/italic flags onto the chrome font family carrying
+/// that style; unstyled text keeps using `Proportional` directly.
+pub fn ui_variant_family(bold: bool, italic: bool) -> FontFamily {
+    match (bold, italic) {
+        (false, false) => FontFamily::Proportional,
+        (true, false) => FontFamily::Name(UI_BOLD_FAMILY.into()),
+        (false, true) => FontFamily::Name(UI_ITALIC_FAMILY.into()),
+        (true, true) => FontFamily::Name(UI_BOLD_ITALIC_FAMILY.into()),
+    }
+}
+
 /// Register the terminal faces with egui and return the normal-variant
 /// fallback chain, in the order egui consults it, for the colour glyph
 /// renderer to resolve against.
-pub fn install_terminal_fonts(
-    ctx: &Context,
-    font: &FontConfig,
-    ui_family: Option<&str>,
-) -> Vec<ChainFace> {
+pub fn install_terminal_fonts(ctx: &Context, font: &FontConfig, ui: &UiFont) -> Vec<ChainFace> {
     let fonts = SystemFonts::default();
-    match build_font_definitions(font, ui_family, &fonts) {
+    match build_font_definitions(font, ui, &fonts) {
         Some((defs, chain)) => {
             ctx.set_fonts(defs);
             chain
@@ -673,7 +784,7 @@ pub fn install_terminal_fonts(
 /// from the egui handoff so tests can inspect what registration produced.
 fn build_font_definitions(
     font: &FontConfig,
-    ui_family: Option<&str>,
+    ui: &UiFont,
     fonts: &SystemFonts,
 ) -> Option<(FontDefinitions, Vec<ChainFace>)> {
     let (normal, bold, italic, bold_italic) =
@@ -773,9 +884,10 @@ fn build_font_definitions(
         register_fallback_faces(&mut defs, family, style, variant, targets, fonts, &mut book);
     }
 
-    if let Some(ui_family) = ui_family {
-        install_ui_font(&mut defs, ui_family, fonts);
-    }
+    // The normal chain only splices when a UI font is configured, but the
+    // variant families must always exist — with no UI font they inherit the
+    // terminal's variant faces, which is what chrome text already renders with.
+    install_ui_font(&mut defs, ui, fonts);
 
     Some((defs, book.chain))
 }
@@ -1065,7 +1177,11 @@ fn resolve_face(
 /// out (fontdb can't see them), a fair trade for keeping typos on the
 /// terminal font.
 #[cfg(unix)]
-fn resolve_ui_face(family_or_path: &str, fonts: &SystemFonts) -> Option<ResolvedFace> {
+fn resolve_ui_face(
+    family_or_path: &str,
+    variant: Variant,
+    fonts: &SystemFonts,
+) -> Option<ResolvedFace> {
     if let Some(face) = resolve_via_path(family_or_path) {
         return Some(face);
     }
@@ -1073,18 +1189,22 @@ fn resolve_ui_face(family_or_path: &str, fonts: &SystemFonts) -> Option<Resolved
         family_or_path.to_ascii_lowercase().as_str(),
         "sans-serif" | "serif" | "monospace" | "cursive" | "fantasy" | "system-ui"
     );
-    let listed = resolve_via_fontdb(family_or_path, Variant::Normal, fonts);
+    let listed = resolve_via_fontdb(family_or_path, variant, fonts);
     if !generic && listed.is_none() {
         return None;
     }
-    fontconfig_resolve::resolve(family_or_path, None, Variant::Normal).or(listed)
+    fontconfig_resolve::resolve(family_or_path, None, variant).or(listed)
 }
 
 /// fontdb already matches family names literally, so the shared path is
 /// exactly as strict as the UI font needs.
 #[cfg(not(unix))]
-fn resolve_ui_face(family_or_path: &str, fonts: &SystemFonts) -> Option<ResolvedFace> {
-    resolve_face(family_or_path, None, Variant::Normal, fonts)
+fn resolve_ui_face(
+    family_or_path: &str,
+    variant: Variant,
+    fonts: &SystemFonts,
+) -> Option<ResolvedFace> {
+    resolve_face(family_or_path, None, variant, fonts)
 }
 
 #[cfg(not(unix))]
@@ -1312,7 +1432,8 @@ mod tests {
         let fonts = SystemFonts::with_cache_dir(None);
         let mono_before = defs.families[&FontFamily::Monospace].clone();
 
-        assert!(install_ui_font(&mut defs, path.to_string_lossy().as_ref(), &fonts));
+        let ui = UiFont { family: Some(path.to_string_lossy().into_owned()), ..UiFont::default() };
+        assert!(install_ui_font(&mut defs, &ui, &fonts));
 
         let prop = &defs.families[&FontFamily::Proportional];
         assert_eq!(prop.first().map(String::as_str), Some(UI_FONT_ID));
@@ -1330,9 +1451,42 @@ mod tests {
         let fonts = SystemFonts::with_cache_dir(None);
         let before = defs.families[&FontFamily::Proportional].clone();
 
-        assert!(!install_ui_font(&mut defs, "alacritree-no-such-ui-family-9f3a", &fonts));
+        let ui = UiFont {
+            family: Some("alacritree-no-such-ui-family-9f3a".to_string()),
+            ..UiFont::default()
+        };
+        assert!(!install_ui_font(&mut defs, &ui, &fonts));
 
         assert_eq!(defs.families[&FontFamily::Proportional], before);
+    }
+
+    /// An egui family is a flat vector of font ids — one family cannot reference
+    /// another — so each UI variant chain must physically contain the terminal
+    /// variant's ids, deduplicated, after its own faces.
+    #[test]
+    fn ui_variant_families_are_registered_and_deduplicated() {
+        let fonts = SystemFonts::with_cache_dir(None);
+        let mut defs = FontDefinitions::default();
+        let face = map_font_file(&write_parseable_font("ui_variant_test.ttf")).unwrap();
+        insert_face(&mut defs, NORMAL_FONT_ID, face, 0);
+        register_variant(&mut defs, BOLD_FONT_ID, BOLD_FAMILY, None, (face, 0));
+
+        install_ui_font(&mut defs, &UiFont::default(), &fonts);
+
+        for family in [UI_BOLD_FAMILY, UI_ITALIC_FAMILY, UI_BOLD_ITALIC_FAMILY] {
+            let ids = defs.families.get(&FontFamily::Name(family.into())).expect(family);
+            assert!(!ids.is_empty(), "{family} must resolve to at least one face");
+            let mut seen = std::collections::HashSet::new();
+            assert!(ids.iter().all(|id| seen.insert(id)), "{family} has duplicate ids");
+        }
+    }
+
+    #[test]
+    fn ui_variant_family_maps_the_style_flags() {
+        assert_eq!(ui_variant_family(false, false), FontFamily::Proportional);
+        assert_eq!(ui_variant_family(true, false), FontFamily::Name(UI_BOLD_FAMILY.into()));
+        assert_eq!(ui_variant_family(false, true), FontFamily::Name(UI_ITALIC_FAMILY.into()));
+        assert_eq!(ui_variant_family(true, true), FontFamily::Name(UI_BOLD_ITALIC_FAMILY.into()));
     }
 
     // epaint clones the whole buffer of every `Cow::Owned` face it parses, so
@@ -1400,7 +1554,7 @@ mod tests {
     #[test]
     fn every_registered_face_parses_like_epaint() {
         let ctx = Context::default();
-        install_terminal_fonts(&ctx, &FontConfig::default(), None);
+        install_terminal_fonts(&ctx, &FontConfig::default(), &UiFont::default());
         // The first pass is what forces epaint to parse every face.
         ctx.begin_pass(Default::default());
         let _ = ctx.end_pass();
@@ -1580,7 +1734,8 @@ mod tests {
             normal: crate::config::FontFace { family: Some(family), style: None },
             ..Default::default()
         };
-        let (defs, chain) = build_font_definitions(&config, None, &fonts).expect("family resolves");
+        let (defs, chain) =
+            build_font_definitions(&config, &UiFont::default(), &fonts).expect("family resolves");
 
         assert_eq!(defs.font_data[NORMAL_FONT_ID].index, resolved.face_index);
         assert_eq!(chain[0].face_index, resolved.face_index);

--- a/alacritree/src/git_status.rs
+++ b/alacritree/src/git_status.rs
@@ -39,6 +39,18 @@ impl ChangeKind {
             ChangeKind::Conflicted => "!",
         }
     }
+
+    /// What the glyph stands for, for readers who do not know porcelain.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ChangeKind::Added => "added",
+            ChangeKind::Modified => "modified",
+            ChangeKind::Deleted => "deleted",
+            ChangeKind::Renamed => "renamed",
+            ChangeKind::Untracked => "untracked",
+            ChangeKind::Conflicted => "conflicted",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -47,6 +47,7 @@ mod steady_state;
 mod terminal_view;
 #[cfg(test)]
 mod test_util;
+mod upstream;
 mod worktree;
 mod wsl;
 mod wsl_helper;

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -826,6 +826,8 @@ mod tests {
             branch: branch.map(String::from),
             is_main: false,
             prunable: false,
+            upstream: None,
+            detached: false,
         }
     }
 

--- a/alacritree/src/pr_status.rs
+++ b/alacritree/src/pr_status.rs
@@ -827,7 +827,6 @@ mod tests {
             is_main: false,
             prunable: false,
             upstream: None,
-            detached: false,
         }
     }
 

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -686,6 +686,37 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         );
     }
 
+    /// Proves the `upstream` flag gates the git2 branch walk itself, not just
+    /// whether the result gets painted: build a branch with a genuinely
+    /// resolvable upstream, discover the same repo with the flag on and off,
+    /// and require the two runs to disagree. A test that only checked the
+    /// off case would pass against code that never looked anything up at all.
+    #[test]
+    fn the_upstream_flag_gates_whether_the_walk_runs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_dir = tmp.path().join("repo");
+        let repo = init_repo(&repo_dir);
+
+        let head_name = repo.head().unwrap().shorthand().unwrap().to_string();
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("upstream-branch", &head_commit, false).unwrap();
+        let mut head_branch = repo.find_branch(&head_name, git2::BranchType::Local).unwrap();
+        head_branch.set_upstream(Some("upstream-branch")).unwrap();
+
+        let with_flag = Project::discover(repo_dir.clone(), true).project;
+        let without_flag = Project::discover(repo_dir, false).project;
+
+        assert_eq!(
+            with_flag.worktrees[0].upstream,
+            Some(crate::upstream::UpstreamState::Level { upstream: "upstream-branch".to_string() }),
+            "a real upstream must be found when the flag is on"
+        );
+        assert_eq!(
+            without_flag.worktrees[0].upstream, None,
+            "the same upstream must not be found when the flag is off"
+        );
+    }
+
     /// Discovery is adopted through one method by both refresh paths.  Two paths
     /// each listing fields by hand is what lets a newly discovered field land in
     /// one and be dropped by the other — and the folder-picker path, which starts

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -149,6 +149,8 @@ impl Project {
         };
 
         let records = parse_worktree_list_z(sections.get(1).copied().unwrap_or_default());
+        let upstreams =
+            crate::upstream::parse_for_each_ref(sections.get(6).copied().unwrap_or_default());
         let worktrees: Vec<Worktree> = records
             .iter()
             .enumerate()
@@ -162,14 +164,16 @@ impl Project {
                     .or_else(|| rec.head.as_ref().map(|h| h.chars().take(7).collect()));
                 let wt_name = if i == 0 { "main".to_string() } else { display_name(&path) };
                 let prunable = i != 0 && !path.is_dir();
+                let detached = rec.branch.is_none();
+                let upstream = rec.branch.as_deref().and_then(|b| upstreams.get(b).cloned());
                 Worktree {
                     name: wt_name,
                     path,
                     branch,
                     is_main: i == 0,
                     prunable,
-                    upstream: None,
-                    detached: false,
+                    upstream,
+                    detached,
                 }
             })
             .collect();
@@ -193,25 +197,36 @@ impl Project {
     fn from_repo(root: PathBuf, name: String, repo: &Repository) -> Self {
         let main_path = repo.workdir().map(|p| p.to_path_buf()).unwrap_or_else(|| root.clone());
 
+        let upstreams = crate::upstream::map_from_repo(repo);
+        let lookup = |branch: &Option<String>, detached: bool| {
+            if detached { None } else { branch.as_deref().and_then(|b| upstreams.get(b).cloned()) }
+        };
+
         let mut worktrees = Vec::new();
+        let (branch, detached) = current_branch(repo);
+        let upstream = lookup(&branch, detached);
         worktrees.push(Worktree {
             name: "main".to_string(),
             path: main_path.clone(),
-            branch: current_branch(repo),
+            branch,
             is_main: true,
             prunable: false,
-            upstream: None,
-            detached: false,
+            upstream,
+            detached,
         });
 
         if let Ok(names) = repo.worktrees() {
             for name in names.iter().flatten() {
                 if let Ok(wt) = repo.find_worktree(name) {
                     let path = wt.path().to_path_buf();
-                    let branch = Repository::open(&path)
+                    let (branch, detached) = match Repository::open(&path)
                         .ok()
-                        .and_then(|wt_repo| current_branch(&wt_repo))
-                        .or_else(|| branch_from_admin_head(repo, name));
+                        .map(|wt_repo| current_branch(&wt_repo))
+                    {
+                        Some((Some(branch), detached)) => (Some(branch), detached),
+                        _ => (branch_from_admin_head(repo, name), false),
+                    };
+                    let upstream = lookup(&branch, detached);
                     worktrees.push(Worktree {
                         name: name.to_string(),
                         // Directory existence, not git2's `is_prunable`, is
@@ -221,8 +236,8 @@ impl Project {
                         path,
                         branch,
                         is_main: false,
-                        upstream: None,
-                        detached: false,
+                        upstream,
+                        detached,
                     });
                 }
             }
@@ -282,16 +297,16 @@ pub fn project_json(project: &Project) -> Value {
     })
 }
 
-fn current_branch(repo: &Repository) -> Option<String> {
-    let head = repo.head().ok()?;
+/// Branch name, or the short OID when detached.  The flag is what callers
+/// key on: the OID string is indistinguishable from a branch name.
+fn current_branch(repo: &Repository) -> (Option<String>, bool) {
+    let Ok(head) = repo.head() else {
+        return (None, false);
+    };
     if head.is_branch() {
-        head.shorthand().map(|s| s.to_string())
+        (head.shorthand().map(|s| s.to_string()), false)
     } else {
-        // Detached HEAD: show the short OID.
-        head.target().map(|oid| {
-            let s = oid.to_string();
-            s.chars().take(7).collect()
-        })
+        (head.target().map(|oid| oid.to_string().chars().take(7).collect()), true)
     }
 }
 
@@ -355,7 +370,7 @@ fn display_name(root: &std::path::Path) -> String {
 /// Sections: 0 repo-or-not, 1 `worktree list --porcelain -z`,
 /// 2 origin/HEAD symref, 3 which common default-branch names exist,
 /// 4 `init.defaultBranch` only if it names an existing branch,
-/// 5 the distro's `$HOME`.
+/// 5 the distro's `$HOME`, 6 upstream tracking state per local branch.
 const DISCOVER_SCRIPT: &str = r#"
 p="$1"
 sep() { printf '\n@@ALACRITREE@@\n'; }
@@ -371,6 +386,8 @@ cfg=$(git -C "$p" config init.defaultBranch 2>/dev/null)
 if [ -n "$cfg" ] && git -C "$p" rev-parse --verify --quiet "refs/heads/$cfg" >/dev/null 2>&1; then printf '%s' "$cfg"; fi
 sep
 printf '%s' "$HOME"
+sep
+LC_ALL=C git -C "$p" for-each-ref --format='%(refname:short)%09%(upstream:short)%09%(upstream:track,nobracket)' refs/heads/ 2>/dev/null
 "#;
 
 /// One record from `git worktree list --porcelain -z`.  The main worktree is
@@ -612,16 +629,41 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         assert_eq!(records[0].path, "/home/lev/my proj");
     }
 
-    /// `$HOME` rides the existing discovery batch, so its section index must not
-    /// drift from the script.  A blank section means the distro reported nothing
-    /// and there is no home to collapse to.
+    /// Section indices are positional, so a new section must go *after* `$HOME`
+    /// to leave every existing index alone.
     #[test]
-    fn the_discover_script_ends_with_the_home_section() {
+    fn the_discover_script_sections_keep_their_indices() {
+        let sections: Vec<&str> = DISCOVER_SCRIPT.split("\nsep\n").collect();
+        assert_eq!(sections.len(), 7, "six sep boundaries, seven sections");
+        assert!(sections[5].contains(r#"printf '%s' "$HOME""#), "$HOME must stay at index 5");
+        assert!(sections[6].contains("for-each-ref"), "upstream tracking is the new last section");
+        assert!(sections[6].contains("LC_ALL=C"), "the track vocabulary is localized");
+    }
+
+    /// The whole point of the `detached` flag: `branch` holds a short OID here,
+    /// and a real branch can be named the same thing.  Asserting only that the
+    /// *record* has no branch would pass against today's parser and prove
+    /// nothing — build the worktree and check the flag and the lookup.
+    #[test]
+    fn a_detached_worktree_gets_no_badge_even_when_its_oid_looks_like_a_branch() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::now("t", "t@t").unwrap();
+        let tree = repo.find_tree(repo.treebuilder(None).unwrap().write().unwrap()).unwrap();
+        let oid = repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+
+        // A branch named exactly like the short OID the detached row will show.
+        let short: String = oid.to_string().chars().take(7).collect();
+        repo.branch(&short, &repo.find_commit(oid).unwrap(), false).unwrap();
+        repo.set_head_detached(oid).unwrap();
+
+        let project = Project::discover(dir.path().to_path_buf()).project;
+        let main = &project.worktrees[0];
+        assert!(main.detached, "a detached HEAD must be flagged");
         assert!(
-            DISCOVER_SCRIPT.trim_end().ends_with(r#"printf '%s' "$HOME""#),
-            "the $HOME section must be last so its index stays 5"
+            main.upstream.is_none(),
+            "a detached row must not adopt the same-named branch's state"
         );
-        assert_eq!(DISCOVER_SCRIPT.matches("\nsep\n").count(), 5, "one sep per section boundary");
     }
 
     /// Discovery is adopted through one method by both refresh paths.  Two paths

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -36,6 +36,13 @@ pub struct Worktree {
     /// (`git worktree list` still shows it as prunable). Such a row cannot
     /// host a shell and only offers cleanup.
     pub prunable: bool,
+    /// Upstream state for `branch`, when the feature is enabled and the
+    /// backend could answer.
+    pub upstream: Option<crate::upstream::UpstreamState>,
+    /// HEAD points at a commit rather than a branch.  Required because
+    /// `branch` is *not* `None` here — both backends substitute a 7-character
+    /// short OID, which a branch-keyed lookup could collide with.
+    pub detached: bool,
 }
 
 /// A discovery result and whether it can be trusted to replace an existing
@@ -112,6 +119,8 @@ impl Project {
                 branch: None,
                 is_main: true,
                 prunable: false,
+                upstream: None,
+                detached: false,
             }],
             root,
             name,
@@ -153,7 +162,15 @@ impl Project {
                     .or_else(|| rec.head.as_ref().map(|h| h.chars().take(7).collect()));
                 let wt_name = if i == 0 { "main".to_string() } else { display_name(&path) };
                 let prunable = i != 0 && !path.is_dir();
-                Worktree { name: wt_name, path, branch, is_main: i == 0, prunable }
+                Worktree {
+                    name: wt_name,
+                    path,
+                    branch,
+                    is_main: i == 0,
+                    prunable,
+                    upstream: None,
+                    detached: false,
+                }
             })
             .collect();
 
@@ -183,6 +200,8 @@ impl Project {
             branch: current_branch(repo),
             is_main: true,
             prunable: false,
+            upstream: None,
+            detached: false,
         });
 
         if let Ok(names) = repo.worktrees() {
@@ -202,6 +221,8 @@ impl Project {
                         path,
                         branch,
                         is_main: false,
+                        upstream: None,
+                        detached: false,
                     });
                 }
             }
@@ -435,6 +456,8 @@ mod tests {
                 branch: None,
                 is_main: true,
                 prunable: false,
+                upstream: None,
+                detached: false,
             },
             Worktree {
                 name: "feature".to_string(),
@@ -442,6 +465,8 @@ mod tests {
                 branch: Some("feature".to_string()),
                 is_main: false,
                 prunable: false,
+                upstream: None,
+                detached: false,
             },
         ];
 

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -40,10 +40,6 @@ pub struct Worktree {
     /// Upstream state for `branch`, when the feature is enabled and the
     /// backend could answer.
     pub upstream: Option<crate::upstream::UpstreamState>,
-    /// HEAD points at a commit rather than a branch.  Required because
-    /// `branch` is *not* `None` here — both backends substitute a 7-character
-    /// short OID, which a branch-keyed lookup could collide with.
-    pub detached: bool,
 }
 
 /// A discovery result and whether it can be trusted to replace an existing
@@ -121,7 +117,6 @@ impl Project {
                 is_main: true,
                 prunable: false,
                 upstream: None,
-                detached: false,
             }],
             root,
             name,
@@ -173,17 +168,8 @@ impl Project {
                     .or_else(|| rec.head.as_ref().map(|h| h.chars().take(7).collect()));
                 let wt_name = if i == 0 { "main".to_string() } else { display_name(&path) };
                 let prunable = i != 0 && !path.is_dir();
-                let detached = rec.branch.is_none();
                 let upstream = rec.branch.as_deref().and_then(|b| upstreams.get(b).cloned());
-                Worktree {
-                    name: wt_name,
-                    path,
-                    branch,
-                    is_main: i == 0,
-                    prunable,
-                    upstream,
-                    detached,
-                }
+                Worktree { name: wt_name, path, branch, is_main: i == 0, prunable, upstream }
             })
             .collect();
 
@@ -222,7 +208,6 @@ impl Project {
             is_main: true,
             prunable: false,
             upstream,
-            detached,
         });
 
         if let Ok(names) = repo.worktrees() {
@@ -247,7 +232,6 @@ impl Project {
                         branch,
                         is_main: false,
                         upstream,
-                        detached,
                     });
                 }
             }
@@ -489,7 +473,6 @@ mod tests {
                 is_main: true,
                 prunable: false,
                 upstream: None,
-                detached: false,
             },
             Worktree {
                 name: "feature".to_string(),
@@ -498,7 +481,6 @@ mod tests {
                 is_main: false,
                 prunable: false,
                 upstream: None,
-                detached: false,
             },
         ];
 
@@ -660,10 +642,10 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         );
     }
 
-    /// The whole point of the `detached` flag: `branch` holds a short OID here,
-    /// and a real branch can be named the same thing.  Asserting only that the
-    /// *record* has no branch would pass against today's parser and prove
-    /// nothing — build the worktree and check the flag and the lookup.
+    /// A detached HEAD's `branch` holds a short OID, and a real branch can be
+    /// named the same thing.  Build a worktree where that collision actually
+    /// occurs and check the lookup, not just that the record has no branch —
+    /// the latter would pass against today's parser and prove nothing.
     #[test]
     fn a_detached_worktree_gets_no_badge_even_when_its_oid_looks_like_a_branch() {
         let dir = tempfile::tempdir().unwrap();
@@ -679,7 +661,6 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
 
         let project = Project::discover(dir.path().to_path_buf(), true).project;
         let main = &project.worktrees[0];
-        assert!(main.detached, "a detached HEAD must be flagged");
         assert!(
             main.upstream.is_none(),
             "a detached row must not adopt the same-named branch's state"

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -1,5 +1,6 @@
 //! Enumerate sidebar-added directories and their git worktrees.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use git2::Repository;
@@ -94,15 +95,15 @@ impl Project {
     /// Classify the root and discover through the owning backend: in-distro
     /// git for WSL paths, git2 for Windows paths, and a pseudo-worktree
     /// placeholder when the root is not a repository.
-    pub fn discover(root: PathBuf) -> Discovered {
+    pub fn discover(root: PathBuf, upstream: bool) -> Discovered {
         let name = display_name(&root);
         match wsl::classify(&root) {
             wsl::Location::Wsl { distro, linux_path } => {
-                Self::discover_wsl(root, name, &distro, &linux_path)
+                Self::discover_wsl(root, name, &distro, &linux_path, upstream)
             },
             // A directory that is not a repository is a fact, not a failure.
             wsl::Location::Windows(_) => match Repository::open(&root) {
-                Ok(repo) => Discovered::found(Self::from_repo(root, name, &repo)),
+                Ok(repo) => Discovered::found(Self::from_repo(root, name, &repo, upstream)),
                 Err(_) => Discovered::found(Self::placeholder(root)),
             },
         }
@@ -136,10 +137,18 @@ impl Project {
     /// are split on `wsl::SECTION_SEP`.  A round trip that never landed yields
     /// the same pseudo-worktree a non-git folder gets, but marked
     /// non-authoritative so it cannot overwrite a known worktree list.
-    fn discover_wsl(root: PathBuf, name: String, distro: &str, linux_path: &str) -> Discovered {
-        let batch = wsl::run_batch(distro, DISCOVER_SCRIPT, &[linux_path]).map_err(|e| {
-            log::warn!("WSL discovery failed for {}: {e}", root.display());
-        });
+    fn discover_wsl(
+        root: PathBuf,
+        name: String,
+        distro: &str,
+        linux_path: &str,
+        upstream: bool,
+    ) -> Discovered {
+        let upstream_arg = if upstream { "1" } else { "0" };
+        let batch =
+            wsl::run_batch(distro, DISCOVER_SCRIPT, &[linux_path, upstream_arg]).map_err(|e| {
+                log::warn!("WSL discovery failed for {}: {e}", root.display());
+            });
         let sections = batch.as_ref().map(|s| wsl::split_sections(s)).unwrap_or_default();
         let text = |i: usize| {
             sections
@@ -194,10 +203,11 @@ impl Project {
         }
     }
 
-    fn from_repo(root: PathBuf, name: String, repo: &Repository) -> Self {
+    fn from_repo(root: PathBuf, name: String, repo: &Repository, upstream: bool) -> Self {
         let main_path = repo.workdir().map(|p| p.to_path_buf()).unwrap_or_else(|| root.clone());
 
-        let upstreams = crate::upstream::map_from_repo(repo);
+        let upstreams =
+            if upstream { crate::upstream::map_from_repo(repo) } else { HashMap::new() };
         let lookup = |branch: &Option<String>, detached: bool| {
             if detached { None } else { branch.as_deref().and_then(|b| upstreams.get(b).cloned()) }
         };
@@ -370,7 +380,10 @@ fn display_name(root: &std::path::Path) -> String {
 /// Sections: 0 repo-or-not, 1 `worktree list --porcelain -z`,
 /// 2 origin/HEAD symref, 3 which common default-branch names exist,
 /// 4 `init.defaultBranch` only if it names an existing branch,
-/// 5 the distro's `$HOME`, 6 upstream tracking state per local branch.
+/// 5 the distro's `$HOME`, 6 upstream tracking state per local branch —
+/// this last command only runs when `$2` is `"1"`, since `for-each-ref` with
+/// `%(upstream:track)` computes divergence for every branch even when the
+/// caller only wants the parse skipped.
 const DISCOVER_SCRIPT: &str = r#"
 p="$1"
 sep() { printf '\n@@ALACRITREE@@\n'; }
@@ -387,7 +400,9 @@ if [ -n "$cfg" ] && git -C "$p" rev-parse --verify --quiet "refs/heads/$cfg" >/d
 sep
 printf '%s' "$HOME"
 sep
-LC_ALL=C git -C "$p" for-each-ref --format='%(refname:short)%09%(upstream:short)%09%(upstream:track,nobracket)' refs/heads/ 2>/dev/null
+if [ "$2" = "1" ]; then
+  LC_ALL=C git -C "$p" for-each-ref --format='%(refname:short)%09%(upstream:short)%09%(upstream:track,nobracket)' refs/heads/ 2>/dev/null
+fi
 "#;
 
 /// One record from `git worktree list --porcelain -z`.  The main worktree is
@@ -533,7 +548,7 @@ mod tests {
     #[test]
     fn a_non_git_windows_root_is_authoritative() {
         let dir = tempfile::tempdir().unwrap();
-        let found = Project::discover(dir.path().to_path_buf());
+        let found = Project::discover(dir.path().to_path_buf(), false);
         assert!(found.authoritative, "a directory that is genuinely not a repo is the truth");
         assert_eq!(found.project.worktrees.len(), 1);
     }
@@ -545,7 +560,7 @@ mod tests {
         let repo = init_repo(&repo_dir);
         add_worktree(&repo, "feature");
 
-        let project = Project::discover(repo_dir).project;
+        let project = Project::discover(repo_dir, false).project;
         let wt = project.worktrees.iter().find(|w| w.name == "feature").unwrap();
         assert!(!wt.prunable);
         assert_eq!(wt.branch.as_deref(), Some("feature"));
@@ -567,7 +582,7 @@ mod tests {
         let wt_path = add_worktree(&repo, "feature");
         std::fs::remove_dir_all(&wt_path).unwrap();
 
-        let project = Project::discover(repo_dir).project;
+        let project = Project::discover(repo_dir, false).project;
         let wt = project.worktrees.iter().find(|w| w.name == "feature").unwrap();
         assert!(wt.prunable);
         assert_eq!(wt.branch.as_deref(), Some("feature"));
@@ -579,7 +594,7 @@ mod tests {
         let repo_dir = tmp.path().join("repo");
         init_repo(&repo_dir);
 
-        let project = Project::discover(repo_dir).project;
+        let project = Project::discover(repo_dir, false).project;
         assert!(project.worktrees[0].is_main);
         assert!(!project.worktrees[0].prunable);
     }
@@ -590,7 +605,7 @@ mod tests {
         let repo_dir = tmp.path().join("repo");
         init_repo(&repo_dir);
 
-        let mut project = Project::discover(repo_dir).project;
+        let mut project = Project::discover(repo_dir, false).project;
         assert_eq!(project.display_name(), "repo");
 
         project.label = Some("Work".to_string());
@@ -638,6 +653,11 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         assert!(sections[5].contains(r#"printf '%s' "$HOME""#), "$HOME must stay at index 5");
         assert!(sections[6].contains("for-each-ref"), "upstream tracking is the new last section");
         assert!(sections[6].contains("LC_ALL=C"), "the track vocabulary is localized");
+        assert!(
+            sections[6].contains(r#"if [ "$2" = "1" ]; then"#),
+            "the for-each-ref call must stay gated by the upstream flag, or the feature runs \
+             even when disabled"
+        );
     }
 
     /// The whole point of the `detached` flag: `branch` holds a short OID here,
@@ -657,7 +677,7 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         repo.branch(&short, &repo.find_commit(oid).unwrap(), false).unwrap();
         repo.set_head_detached(oid).unwrap();
 
-        let project = Project::discover(dir.path().to_path_buf()).project;
+        let project = Project::discover(dir.path().to_path_buf(), true).project;
         let main = &project.worktrees[0];
         assert!(main.detached, "a detached HEAD must be flagged");
         assert!(

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -368,7 +368,21 @@ fn display_name(root: &std::path::Path) -> String {
 /// this last command only runs when `$2` is `"1"`, since `for-each-ref` with
 /// `%(upstream:track)` computes divergence for every branch even when the
 /// caller only wants the parse skipped.
-const DISCOVER_SCRIPT: &str = r#"
+/// The `for-each-ref` format the upstream section emits.  A macro rather than
+/// a const so the script can `concat!` it and tests can hand the identical
+/// string to git, instead of asserting against a second copy that can drift.
+///
+/// `lstrip=2` rather than `:short`: shortening consults other ref namespaces
+/// and yields `heads/<name>` for a branch whose name a tag also uses, which
+/// no longer joins against the plain branch name in a worktree record.
+macro_rules! upstream_format {
+    () => {
+        "%(refname:lstrip=2)%09%(upstream:short)%09%(upstream:track,nobracket)"
+    };
+}
+
+const DISCOVER_SCRIPT: &str = concat!(
+    r#"
 p="$1"
 sep() { printf '\n@@ALACRITREE@@\n'; }
 git -C "$p" rev-parse --is-inside-work-tree >/dev/null 2>&1 && printf yes || printf no
@@ -385,9 +399,12 @@ sep
 printf '%s' "$HOME"
 sep
 if [ "$2" = "1" ]; then
-  LC_ALL=C git -C "$p" for-each-ref --format='%(refname:short)%09%(upstream:short)%09%(upstream:track,nobracket)' refs/heads/ 2>/dev/null
+  LC_ALL=C git -C "$p" for-each-ref --format='"#,
+    upstream_format!(),
+    r#"' refs/heads/ 2>/dev/null
 fi
-"#;
+"#
+);
 
 /// One record from `git worktree list --porcelain -z`.  The main worktree is
 /// always the first record.
@@ -459,7 +476,45 @@ fn default_branch_from_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::command_ext::CommandExt as _;
     use crate::test_util::{add_worktree, init_repo};
+
+    /// `%(refname:short)` shortens to the *unambiguous* name, so a branch that
+    /// shares its name with a tag comes back as `heads/<name>`.  Worktree
+    /// records carry the plain branch name, so any shortening that consults
+    /// other ref namespaces breaks the join and the row loses its badge.
+    #[test]
+    fn the_upstream_format_keys_branches_by_plain_name_even_when_a_tag_shares_it() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .hide_console()
+                .current_dir(dir.path())
+                .args(args)
+                .output()
+                .expect("git runs");
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out.stdout
+        };
+        git(&["init", "-b", "main"]);
+        git(&["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "x"]);
+        git(&["branch", "release"]);
+        git(&["-c", "user.email=t@t", "-c", "user.name=t", "tag", "-m", "collide", "release"]);
+
+        let out =
+            git(&["for-each-ref", &format!("--format={}", upstream_format!()), "refs/heads/"]);
+        let map = crate::upstream::parse_for_each_ref(&out);
+
+        assert!(
+            map.contains_key("release"),
+            "expected a `release` key, got {:?}",
+            map.keys().collect::<Vec<_>>()
+        );
+    }
 
     #[test]
     fn refresh_keeps_worktrees_when_discovery_is_not_authoritative() {
@@ -626,8 +681,8 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         assert_eq!(records[0].path, "/home/lev/my proj");
     }
 
-    /// Section indices are positional, so a new section must go *after* `$HOME`
-    /// to leave every existing index alone.
+    /// The parser reads sections by position, so their order is a contract:
+    /// each index below names the command whose output belongs there.
     #[test]
     fn the_discover_script_sections_keep_their_indices() {
         let sections: Vec<&str> = DISCOVER_SCRIPT.split("\nsep\n").collect();
@@ -645,7 +700,7 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
     /// A detached HEAD's `branch` holds a short OID, and a real branch can be
     /// named the same thing.  Build a worktree where that collision actually
     /// occurs and check the lookup, not just that the record has no branch —
-    /// the latter would pass against today's parser and prove nothing.
+    /// the latter holds whether or not the lookup guards against the collision.
     #[test]
     fn a_detached_worktree_gets_no_badge_even_when_its_oid_looks_like_a_branch() {
         let dir = tempfile::tempdir().unwrap();

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -117,7 +117,6 @@ mod tests {
             is_main: false,
             prunable: false,
             upstream: None,
-            detached: false,
         }
     }
 
@@ -253,7 +252,6 @@ mod tests {
             is_main: true,
             prunable: false,
             upstream: None,
-            detached: false,
         };
         let mut templates = LabelTemplates::new(Some("$path".to_string()), None);
         assert_eq!(templates.worktree_label(&wt, None), "/home/lev/Git/monorepo");

--- a/alacritree/src/row_label.rs
+++ b/alacritree/src/row_label.rs
@@ -116,6 +116,8 @@ mod tests {
             branch: branch.map(str::to_string),
             is_main: false,
             prunable: false,
+            upstream: None,
+            detached: false,
         }
     }
 
@@ -250,6 +252,8 @@ mod tests {
             branch: Some("main".to_string()),
             is_main: true,
             prunable: false,
+            upstream: None,
+            detached: false,
         };
         let mut templates = LabelTemplates::new(Some("$path".to_string()), None);
         assert_eq!(templates.worktree_label(&wt, None), "/home/lev/Git/monorepo");

--- a/alacritree/src/session.rs
+++ b/alacritree/src/session.rs
@@ -208,6 +208,13 @@ const AGENT_PROCESS_GLYPHS: &[(&str, char)] = &[
     ("continue", '⊕'),
 ];
 
+/// The agent a status glyph stands for. A title's own decorative glyph is not
+/// in the table, so it names nothing rather than claiming an agent alacritree
+/// never recognized.
+pub fn agent_name_for_glyph(glyph: char) -> Option<&'static str> {
+    AGENT_PROCESS_GLYPHS.iter().find(|(_, g)| *g == glyph).map(|(name, _)| *name)
+}
+
 /// Plain-text dump of a session's grid for IPC clients.
 pub struct ScreenSnapshot {
     /// Requested scrollback (top) followed by the full visible screen, one

--- a/alacritree/src/sidebar_nav.rs
+++ b/alacritree/src/sidebar_nav.rs
@@ -206,6 +206,8 @@ pub(crate) mod tests {
                     branch: None,
                     is_main: false,
                     prunable: false,
+                    upstream: None,
+                    detached: false,
                 })
                 .collect(),
             expanded,

--- a/alacritree/src/sidebar_nav.rs
+++ b/alacritree/src/sidebar_nav.rs
@@ -207,7 +207,6 @@ pub(crate) mod tests {
                     is_main: false,
                     prunable: false,
                     upstream: None,
-                    detached: false,
                 })
                 .collect(),
             expanded,

--- a/alacritree/src/upstream.rs
+++ b/alacritree/src/upstream.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+use git2::{BranchType, Repository};
+
 /// What a branch's configured upstream is doing.  Nothing here contacts a
 /// remote, so every state describes local refs only.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,6 +94,60 @@ fn parse_track_counts(track: &str) -> Option<(usize, usize)> {
     parsed.then_some((ahead, behind))
 }
 
+/// Every linked worktree of a project shares `refs/heads` and `refs/remotes`,
+/// so one walk of the project's local branches answers for every row.
+pub fn map_from_repo(repo: &Repository) -> HashMap<String, UpstreamState> {
+    let mut map = HashMap::new();
+    let Ok(branches) = repo.branches(Some(BranchType::Local)) else {
+        return map;
+    };
+    for (branch, _) in branches.flatten() {
+        let Some(name) = branch.name().ok().flatten() else {
+            continue;
+        };
+        let name = name.to_string();
+        let refname = format!("refs/heads/{name}");
+        let state = match branch.upstream() {
+            Ok(upstream) => tracked_state(repo, &branch, &upstream),
+            // The tracking ref did not resolve.  Config still decides whether
+            // an upstream was ever configured.
+            Err(_) => Some(match repo.branch_upstream_name(&refname) {
+                Ok(buf) => UpstreamState::Gone { upstream: shorten(buf.as_str().unwrap_or("")) },
+                Err(_) => UpstreamState::Untracked,
+            }),
+        };
+        // A branch we could not answer for gets no entry, so the row paints
+        // no badge rather than a wrong one.
+        if let Some(state) = state {
+            map.insert(name, state);
+        }
+    }
+    map
+}
+
+fn tracked_state(
+    repo: &Repository,
+    branch: &git2::Branch<'_>,
+    upstream: &git2::Branch<'_>,
+) -> Option<UpstreamState> {
+    let name = upstream.name().ok().flatten().unwrap_or_default().to_string();
+    let (Some(local), Some(remote)) = (branch.get().target(), upstream.get().target()) else {
+        return None;
+    };
+    match repo.graph_ahead_behind(local, remote) {
+        Ok((0, 0)) => Some(UpstreamState::Level { upstream: name }),
+        Ok((ahead, behind)) => Some(UpstreamState::Diverged { upstream: name, ahead, behind }),
+        // Failing to walk the graph is not evidence the branches are level.
+        // No entry means no badge, which is what an unanswerable state looks
+        // like everywhere else.
+        Err(_) => None,
+    }
+}
+
+fn shorten(refname: &str) -> String {
+    refname.strip_prefix("refs/remotes/").unwrap_or(refname).to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -162,5 +218,77 @@ mod tests {
     fn an_unreadable_track_string_yields_no_entry() {
         assert!(parse_for_each_ref(b"b\torigin/b\tvorne 2\n").is_empty());
         assert!(parse_for_each_ref(b"b\torigin/b\tahead many\n").is_empty());
+    }
+}
+
+#[cfg(test)]
+mod git2_tests {
+    use super::*;
+    use git2::Repository;
+
+    /// A branch with no `branch.<name>.remote` is untracked; one whose
+    /// configured tracking ref was deleted is gone.  The two are separated by
+    /// `branch_upstream_name`, which libgit2 builds from config and the fetch
+    /// refspec *before* resolving any reference.
+    #[test]
+    fn separates_untracked_from_gone() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        commit_empty(&repo);
+
+        repo.branch("solo", &repo.head().unwrap().peel_to_commit().unwrap(), false).unwrap();
+
+        let mut branch =
+            repo.branch("dead", &repo.head().unwrap().peel_to_commit().unwrap(), false).unwrap();
+        branch.set_upstream(None).ok();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("branch.dead.remote", "origin").unwrap();
+        cfg.set_str("branch.dead.merge", "refs/heads/dead").unwrap();
+        cfg.set_str("remote.origin.url", "https://example.invalid/r.git").unwrap();
+        cfg.set_str("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*").unwrap();
+
+        let map = map_from_repo(&repo);
+        assert_eq!(map["solo"], UpstreamState::Untracked);
+        assert_eq!(map["dead"], UpstreamState::Gone { upstream: "origin/dead".into() });
+    }
+
+    /// The divergence matrix the spec requires.  `set_upstream` against a
+    /// local ref also covers `remote = "."`, where the upstream is another
+    /// local branch rather than a remote-tracking one.
+    #[test]
+    fn classifies_level_ahead_behind_and_diverged() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let base = commit_empty(&repo);
+
+        // `base` is the upstream; each branch diverges from it differently.
+        for (name, extra) in [("level", 0), ("ahead", 2)] {
+            let mut b = repo.branch(name, &repo.find_commit(base).unwrap(), false).unwrap();
+            b.set_upstream(Some("main")).unwrap();
+            let mut parent = base;
+            for i in 0..extra {
+                parent = commit_onto(&repo, parent, &format!("refs/heads/{name}"), i);
+            }
+        }
+
+        let map = map_from_repo(&repo);
+        assert_eq!(map["level"], UpstreamState::Level { upstream: "main".into() });
+        assert_eq!(
+            map["ahead"],
+            UpstreamState::Diverged { upstream: "main".into(), ahead: 2, behind: 0 }
+        );
+    }
+
+    fn commit_empty(repo: &Repository) -> git2::Oid {
+        let sig = git2::Signature::now("t", "t@t").unwrap();
+        let tree = repo.find_tree(repo.treebuilder(None).unwrap().write().unwrap()).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap()
+    }
+
+    fn commit_onto(repo: &Repository, parent: git2::Oid, refname: &str, n: usize) -> git2::Oid {
+        let sig = git2::Signature::now("t", "t@t").unwrap();
+        let tree = repo.find_tree(repo.treebuilder(None).unwrap().write().unwrap()).unwrap();
+        let parent = repo.find_commit(parent).unwrap();
+        repo.commit(Some(refname), &sig, &sig, &format!("c{n}"), &tree, &[&parent]).unwrap()
     }
 }

--- a/alacritree/src/upstream.rs
+++ b/alacritree/src/upstream.rs
@@ -252,30 +252,57 @@ mod git2_tests {
         assert_eq!(map["dead"], UpstreamState::Gone { upstream: "origin/dead".into() });
     }
 
-    /// The divergence matrix the spec requires.  `set_upstream` against a
-    /// local ref also covers `remote = "."`, where the upstream is another
-    /// local branch rather than a remote-tracking one.
+    /// Exercises every value `graph_ahead_behind` can return: level (0, 0),
+    /// ahead-only, behind-only, and diverged (both nonzero), with the exact
+    /// counts asserted so the tuple order is pinned in both directions.
+    /// `level`/`ahead` share a static upstream (`main`, never advanced) and
+    /// so only ever probe the ahead side; `behind` and `diverged` each get
+    /// their own upstream branch that advances independently of the local
+    /// branch, which is what actually exercises the behind side. Also
+    /// covers `remote = "."`, where `set_upstream` points at another local
+    /// branch rather than a remote-tracking one.
     #[test]
     fn classifies_level_ahead_behind_and_diverged() {
         let dir = tempfile::tempdir().unwrap();
         let repo = Repository::init(dir.path()).unwrap();
         let base = commit_empty(&repo);
 
-        // `base` is the upstream; each branch diverges from it differently.
+        // `main` never moves, so `level` stays level and `ahead` only grows
+        // its own side of the pair.
         for (name, extra) in [("level", 0), ("ahead", 2)] {
             let mut b = repo.branch(name, &repo.find_commit(base).unwrap(), false).unwrap();
             b.set_upstream(Some("main")).unwrap();
-            let mut parent = base;
-            for i in 0..extra {
-                parent = commit_onto(&repo, parent, &format!("refs/heads/{name}"), i);
-            }
+            advance(&repo, base, &format!("refs/heads/{name}"), extra);
         }
+
+        // `behind` never commits itself; only its dedicated upstream moves.
+        repo.branch("upstream-behind", &repo.find_commit(base).unwrap(), false).unwrap();
+        let mut behind = repo.branch("behind", &repo.find_commit(base).unwrap(), false).unwrap();
+        behind.set_upstream(Some("upstream-behind")).unwrap();
+        advance(&repo, base, "refs/heads/upstream-behind", 3);
+
+        // `diverged` and its dedicated upstream each grow from `base` along
+        // their own line, so neither is an ancestor of the other.
+        repo.branch("upstream-diverged", &repo.find_commit(base).unwrap(), false).unwrap();
+        let mut diverged =
+            repo.branch("diverged", &repo.find_commit(base).unwrap(), false).unwrap();
+        diverged.set_upstream(Some("upstream-diverged")).unwrap();
+        advance(&repo, base, "refs/heads/diverged", 2);
+        advance(&repo, base, "refs/heads/upstream-diverged", 4);
 
         let map = map_from_repo(&repo);
         assert_eq!(map["level"], UpstreamState::Level { upstream: "main".into() });
         assert_eq!(
             map["ahead"],
             UpstreamState::Diverged { upstream: "main".into(), ahead: 2, behind: 0 }
+        );
+        assert_eq!(
+            map["behind"],
+            UpstreamState::Diverged { upstream: "upstream-behind".into(), ahead: 0, behind: 3 }
+        );
+        assert_eq!(
+            map["diverged"],
+            UpstreamState::Diverged { upstream: "upstream-diverged".into(), ahead: 2, behind: 4 }
         );
     }
 
@@ -285,10 +312,23 @@ mod git2_tests {
         repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap()
     }
 
+    fn advance(repo: &Repository, from: git2::Oid, refname: &str, extra: usize) -> git2::Oid {
+        let mut parent = from;
+        for i in 0..extra {
+            parent = commit_onto(repo, parent, refname, i);
+        }
+        parent
+    }
+
     fn commit_onto(repo: &Repository, parent: git2::Oid, refname: &str, n: usize) -> git2::Oid {
         let sig = git2::Signature::now("t", "t@t").unwrap();
         let tree = repo.find_tree(repo.treebuilder(None).unwrap().write().unwrap()).unwrap();
         let parent = repo.find_commit(parent).unwrap();
-        repo.commit(Some(refname), &sig, &sig, &format!("c{n}"), &tree, &[&parent]).unwrap()
+        // The message folds in `refname` so two chains started from the same
+        // `base` at the same wall-clock second never produce identical
+        // (parent, tree, message) commits, which git would collapse into one
+        // shared object and silently merge the two branches' histories.
+        repo.commit(Some(refname), &sig, &sig, &format!("{refname} c{n}"), &tree, &[&parent])
+            .unwrap()
     }
 }

--- a/alacritree/src/upstream.rs
+++ b/alacritree/src/upstream.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use git2::{BranchType, Repository};
+use git2::{BranchType, ErrorCode, Repository};
 
 /// What a branch's configured upstream is doing.  Nothing here contacts a
 /// remote, so every state describes local refs only.
@@ -98,12 +98,17 @@ pub fn map_from_repo(repo: &Repository) -> HashMap<String, UpstreamState> {
         let refname = format!("refs/heads/{name}");
         let state = match branch.upstream() {
             Ok(upstream) => tracked_state(repo, &branch, &upstream),
-            // The tracking ref did not resolve.  Config still decides whether
-            // an upstream was ever configured.
-            Err(_) => Some(match repo.branch_upstream_name(&refname) {
-                Ok(buf) => UpstreamState::Gone { upstream: shorten(buf.as_str().unwrap_or("")) },
-                Err(_) => UpstreamState::Untracked,
-            }),
+            // The tracking ref is absent.  Config still decides whether an
+            // upstream was ever configured.
+            Err(e) if e.code() == ErrorCode::NotFound => {
+                let configured = repo.branch_upstream_name(&refname);
+                configured_upstream(match &configured {
+                    Ok(buf) => Ok(buf.as_str().unwrap_or("")),
+                    Err(e) => Err(e.code()),
+                })
+            },
+            // Any other libgit2 failure says nothing about the upstream.
+            Err(_) => None,
         };
         // A branch we could not answer for gets no entry, so the row paints
         // no badge rather than a wrong one.
@@ -133,8 +138,29 @@ fn tracked_state(
     }
 }
 
+/// Classify a branch whose tracking ref did not resolve.  A name in config
+/// means an upstream was configured and its ref is gone; `NotFound` means
+/// none was ever configured.  Every other failure leaves the question
+/// unanswered, and an unanswered branch gets no entry — the same rule
+/// `tracked_state` applies to a graph walk it could not complete.
+fn configured_upstream(name: Result<&str, ErrorCode>) -> Option<UpstreamState> {
+    match name {
+        Ok(name) => Some(UpstreamState::Gone { upstream: shorten(name) }),
+        Err(ErrorCode::NotFound) => Some(UpstreamState::Untracked),
+        Err(_) => None,
+    }
+}
+
+/// Tracking a local branch through remote `"."` yields a `refs/heads/` name,
+/// so both namespaces have to come off for the badge to read the way the
+/// `for-each-ref` path renders the same upstream.
 fn shorten(refname: &str) -> String {
-    refname.strip_prefix("refs/remotes/").unwrap_or(refname).to_string()
+    for prefix in ["refs/remotes/", "refs/heads/"] {
+        if let Some(rest) = refname.strip_prefix(prefix) {
+            return rest.to_string();
+        }
+    }
+    refname.to_string()
 }
 
 #[cfg(test)]
@@ -165,6 +191,30 @@ mod tests {
         );
         assert_eq!(map["dead"], UpstreamState::Gone { upstream: "origin/dead".into() });
         assert_eq!(map["solo"], UpstreamState::Untracked);
+    }
+
+    /// A libgit2 failure other than `NotFound` says nothing about whether an
+    /// upstream was configured, so it must not resolve to `Untracked` — that
+    /// would paint a definite badge from an unreadable repository.
+    #[test]
+    fn only_a_not_found_config_lookup_means_untracked() {
+        assert_eq!(
+            configured_upstream(Ok("refs/remotes/origin/x")),
+            Some(UpstreamState::Gone { upstream: "origin/x".into() })
+        );
+        assert_eq!(configured_upstream(Err(ErrorCode::NotFound)), Some(UpstreamState::Untracked));
+        for code in [ErrorCode::GenericError, ErrorCode::Invalid, ErrorCode::Locked] {
+            assert_eq!(configured_upstream(Err(code)), None, "{code:?} must not fabricate a state");
+        }
+    }
+
+    /// A branch tracking another local branch through remote `"."` has a
+    /// `refs/heads/…` upstream.  The badge shows this name to the user, so it
+    /// must read the way the WSL and live paths render it.
+    #[test]
+    fn a_local_tracking_upstream_shortens_like_a_remote_one() {
+        assert_eq!(shorten("refs/heads/main"), "main");
+        assert_eq!(shorten("refs/remotes/origin/main"), "origin/main");
     }
 
     /// `|` is legal in a ref name, which is why the format is tab-delimited —

--- a/alacritree/src/upstream.rs
+++ b/alacritree/src/upstream.rs
@@ -1,5 +1,7 @@
 //! Branch upstream state for the sidebar badge.
 
+use std::collections::HashMap;
+
 /// What a branch's configured upstream is doing.  Nothing here contacts a
 /// remote, so every state describes local refs only.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,6 +30,68 @@ impl UpstreamState {
     }
 }
 
+/// Parse the tab-delimited output of
+/// `git for-each-ref --format='%(refname:short)%09%(upstream:short)%09%(upstream:track,nobracket)'`.
+/// The track field is empty for a level branch, absent-upstream branches
+/// carry an empty upstream, and `gone` marks a configured upstream whose ref
+/// no longer resolves. Callers must run git under `LC_ALL=C`: the track
+/// vocabulary is localized.
+pub fn parse_for_each_ref(bytes: &[u8]) -> HashMap<String, UpstreamState> {
+    let text = String::from_utf8_lossy(bytes);
+    let mut map = HashMap::new();
+    for line in text.lines() {
+        let mut fields = line.split('\t');
+        let (Some(branch), Some(upstream), Some(track)) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        if branch.is_empty() {
+            continue;
+        }
+        if let Some(state) = classify(upstream, track) {
+            map.insert(branch.to_string(), state);
+        }
+    }
+    map
+}
+
+fn classify(upstream: &str, track: &str) -> Option<UpstreamState> {
+    if upstream.is_empty() {
+        return Some(UpstreamState::Untracked);
+    }
+    let upstream = upstream.to_string();
+    match track.trim() {
+        "" => Some(UpstreamState::Level { upstream }),
+        "gone" => Some(UpstreamState::Gone { upstream }),
+        track => match parse_track_counts(track) {
+            Some((ahead, behind)) => Some(UpstreamState::Diverged { upstream, ahead, behind }),
+            // A track string we cannot read means a git whose vocabulary
+            // changed. No entry, so the row paints nothing — better than
+            // "0 ahead, 0 behind" on a branch that is neither.
+            None => None,
+        },
+    }
+}
+
+/// `ahead 2`, `behind 3`, or `ahead 2, behind 3`. `None` when no clause
+/// parsed, which is the only signal that the vocabulary was not what
+/// `LC_ALL=C` promised.
+fn parse_track_counts(track: &str) -> Option<(usize, usize)> {
+    let mut ahead = 0;
+    let mut behind = 0;
+    let mut parsed = false;
+    for part in track.split(',') {
+        let mut words = part.split_whitespace();
+        match (words.next(), words.next().and_then(|n| n.parse().ok())) {
+            (Some("ahead"), Some(n)) => (ahead, parsed) = (n, true),
+            (Some("behind"), Some(n)) => (behind, parsed) = (n, true),
+            _ => return None,
+        }
+    }
+    parsed.then_some((ahead, behind))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,5 +112,55 @@ mod tests {
             Some("origin/x")
         );
         assert_eq!(UpstreamState::Untracked.upstream_name(), None);
+    }
+
+    #[test]
+    fn parses_every_upstream_state() {
+        let out = b"level\torigin/level\t\n\
+                    ahead\torigin/ahead\tahead 2\n\
+                    behind\torigin/behind\tbehind 3\n\
+                    both\torigin/both\tahead 2, behind 3\n\
+                    dead\torigin/dead\tgone\n\
+                    solo\t\t\n";
+        let map = parse_for_each_ref(out);
+        assert_eq!(map["level"], UpstreamState::Level { upstream: "origin/level".into() });
+        assert_eq!(
+            map["ahead"],
+            UpstreamState::Diverged { upstream: "origin/ahead".into(), ahead: 2, behind: 0 }
+        );
+        assert_eq!(
+            map["behind"],
+            UpstreamState::Diverged { upstream: "origin/behind".into(), ahead: 0, behind: 3 }
+        );
+        assert_eq!(
+            map["both"],
+            UpstreamState::Diverged { upstream: "origin/both".into(), ahead: 2, behind: 3 }
+        );
+        assert_eq!(map["dead"], UpstreamState::Gone { upstream: "origin/dead".into() });
+        assert_eq!(map["solo"], UpstreamState::Untracked);
+    }
+
+    /// `|` is legal in a ref name, which is why the format is tab-delimited —
+    /// git forbids ASCII control characters in refs.
+    #[test]
+    fn a_branch_name_containing_a_pipe_survives() {
+        let map = parse_for_each_ref(b"feat|x\torigin/feat|x\t\n");
+        assert_eq!(map["feat|x"], UpstreamState::Level { upstream: "origin/feat|x".into() });
+    }
+
+    #[test]
+    fn malformed_and_empty_input_yield_no_entries() {
+        assert!(parse_for_each_ref(b"").is_empty());
+        assert!(parse_for_each_ref(b"\n\n").is_empty());
+        assert!(parse_for_each_ref(b"no-tabs-at-all\n").is_empty());
+    }
+
+    /// A track string we cannot read must produce no entry at all.  Falling
+    /// through to `Diverged { ahead: 0, behind: 0 }` would paint the divergence
+    /// glyph and a "0 ahead, 0 behind" tooltip on a branch that is neither.
+    #[test]
+    fn an_unreadable_track_string_yields_no_entry() {
+        assert!(parse_for_each_ref(b"b\torigin/b\tvorne 2\n").is_empty());
+        assert!(parse_for_each_ref(b"b\torigin/b\tahead many\n").is_empty());
     }
 }

--- a/alacritree/src/upstream.rs
+++ b/alacritree/src/upstream.rs
@@ -21,17 +21,6 @@ pub enum UpstreamState {
     Untracked,
 }
 
-impl UpstreamState {
-    pub fn upstream_name(&self) -> Option<&str> {
-        match self {
-            UpstreamState::Level { upstream }
-            | UpstreamState::Diverged { upstream, .. }
-            | UpstreamState::Gone { upstream } => Some(upstream),
-            UpstreamState::Untracked => None,
-        }
-    }
-}
-
 /// Parse the tab-delimited output of
 /// `git for-each-ref --format='%(refname:short)%09%(upstream:short)%09%(upstream:track,nobracket)'`.
 /// The track field is empty for a level branch, absent-upstream branches
@@ -151,24 +140,6 @@ fn shorten(refname: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn upstream_name_is_exposed_for_tracked_states_only() {
-        assert_eq!(
-            UpstreamState::Level { upstream: "origin/x".into() }.upstream_name(),
-            Some("origin/x")
-        );
-        assert_eq!(
-            UpstreamState::Diverged { upstream: "origin/x".into(), ahead: 1, behind: 2 }
-                .upstream_name(),
-            Some("origin/x")
-        );
-        assert_eq!(
-            UpstreamState::Gone { upstream: "origin/x".into() }.upstream_name(),
-            Some("origin/x")
-        );
-        assert_eq!(UpstreamState::Untracked.upstream_name(), None);
-    }
 
     #[test]
     fn parses_every_upstream_state() {

--- a/alacritree/src/upstream.rs
+++ b/alacritree/src/upstream.rs
@@ -285,7 +285,12 @@ mod git2_tests {
     #[test]
     fn classifies_level_ahead_behind_and_diverged() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = Repository::init(dir.path()).unwrap();
+        // The upstreams below are named, so the branch the first commit lands
+        // on has to be too: a plain `init` takes it from `init.defaultBranch`,
+        // which is `master` wherever the developer has not set it.
+        let mut opts = git2::RepositoryInitOptions::new();
+        opts.initial_head("main");
+        let repo = Repository::init_opts(dir.path(), &opts).unwrap();
         let base = commit_empty(&repo);
 
         // `main` never moves, so `level` stays level and `ahead` only grows

--- a/alacritree/src/upstream.rs
+++ b/alacritree/src/upstream.rs
@@ -1,0 +1,52 @@
+//! Branch upstream state for the sidebar badge.
+
+/// What a branch's configured upstream is doing.  Nothing here contacts a
+/// remote, so every state describes local refs only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpstreamState {
+    /// Tracks `upstream` and matches it.
+    Level { upstream: String },
+    /// Tracks `upstream` and differs from it.
+    Diverged { upstream: String, ahead: usize, behind: usize },
+    /// `branch.<name>.remote` and `.merge` name `upstream`, but no such
+    /// reference exists locally.  A merged-and-deleted remote branch looks
+    /// like this only once something has pruned.
+    Gone { upstream: String },
+    /// No upstream is configured.  Not the same as "never pushed": `git push
+    /// origin <branch>` without `-u` pushes without configuring one.
+    Untracked,
+}
+
+impl UpstreamState {
+    pub fn upstream_name(&self) -> Option<&str> {
+        match self {
+            UpstreamState::Level { upstream }
+            | UpstreamState::Diverged { upstream, .. }
+            | UpstreamState::Gone { upstream } => Some(upstream),
+            UpstreamState::Untracked => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upstream_name_is_exposed_for_tracked_states_only() {
+        assert_eq!(
+            UpstreamState::Level { upstream: "origin/x".into() }.upstream_name(),
+            Some("origin/x")
+        );
+        assert_eq!(
+            UpstreamState::Diverged { upstream: "origin/x".into(), ahead: 1, behind: 2 }
+                .upstream_name(),
+            Some("origin/x")
+        );
+        assert_eq!(
+            UpstreamState::Gone { upstream: "origin/x".into() }.upstream_name(),
+            Some("origin/x")
+        );
+        assert_eq!(UpstreamState::Untracked.upstream_name(), None);
+    }
+}

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -522,13 +522,18 @@ table that styles it further:
 
 ```toml
 [ui.icons]
-upstream_gone = { glyph = "⌫", color = "#ff5555", bold = true, italic = false, size = 14 }
+upstream_gone = { glyph = "⌫", color = "#ff5555", bold = true, italic = false, size = 8 }
 ```
 
 `glyph` is optional in table form — a table with no `glyph` key keeps that
 icon's default glyph and only applies the styling. `size` is in logical
 pixels, measured before `ui_scale`, and is clamped to the space the sidebar
-row reserves for that icon, so it cannot grow past its slot.
+row reserves for that icon, so it cannot grow past its slot. Status markers
+and badges — `upstream_gone` above, and 11 other `[ui.icons]` keys covering
+worktree/session/home icons, PR badges, and the other upstream states — paint
+in a 10 px slot with a 10 px default, so `size` on those can only shrink.
+Only the project expand/collapse arrow (16 px slot, 12 px default) and the
+sidebar search icon can grow past their defaults.
 
 ### Shell launch profiles
 

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -346,7 +346,10 @@ sidebar_tooltips   = "elided"    # when a sidebar row spells its full name out
 icon_tooltips      = true        # whether a sidebar icon explains itself on
                                  # hover (default true) — what a button does
                                  # ("add project", "close session", …) and what
-                                 # a status badge reports, on both sidebars
+                                 # a status badge reports: the agent running in
+                                 # a row, a row asking to be looked at, a
+                                 # branch's PR and upstream state, and the
+                                 # letter a git panel row leads with
                                  # independent of sidebar_tooltips, which is
                                  # about a name the row had to cut off: an
                                  # icon's hint never depends on panel width

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -297,6 +297,10 @@ sidebar_background = "#1c1c1c"
 sidebar_foreground = "#d8d8d8"
 sidebar_border     = "#2a2a2a"
 sidebar_accent     = "#6a9fb5"
+sidebar_attention  = "#f1c40f"   # optional; unset derives the attention badge
+                                 # from the palette's normal[3] (ANSI yellow),
+                                 # the same fallback pattern sidebar_accent
+                                 # uses for its own default (normal[4], blue)
 notifications      = true   # desktop notification when a hidden session bells;
                             # clicking it focuses the session that pinged
 attention_grace_ms = 0      # hold pings this long and drop them if the session
@@ -356,6 +360,18 @@ pr_status          = false  # poll `gh` for each branch's open PR, which drives
                             # below (default false)
 pr_status_concurrency = 8   # cap concurrent `gh` PR lookups; default 8,
                             # clamped to a minimum of 1
+upstream_status    = false  # paint a badge on each worktree row for its
+                            # branch's upstream state — level, diverged, gone,
+                            # or untracked (default false; also gates whether
+                            # the state is computed at all, so it costs
+                            # nothing when off)
+                            # Local refs only: nothing fetches, so a branch
+                            # deleted on the remote still reads as tracked
+                            # until something prunes locally.
+                            # extensions.worktreeConfig is unsupported: a
+                            # linked worktree that overrides branch.* in its
+                            # own config.worktree is read from the project
+                            # root instead, so that override is not seen.
 delta_path         = "delta"     # explicit delta binary for the diff pane;
                                  # unset discovers it on PATH
 worktree_name      = "$name ${pr: }"  # template for worktree row labels:
@@ -368,6 +384,9 @@ project_name       = "$name"     # same for project rows ($name, $path). A
 [ui.font]                   # chrome only — sidebars and modals, not the grid
 family = "Inter"            # unset derives from [font]
 size   = 12.0               # points, same unit as [font] size
+bold_family        = "Inter Display"  # unset falls back to family
+italic_family      = "Inter"          # unset falls back to family
+bold_italic_family = "Inter Display"  # unset falls back to family
 
 [ui.session_display]        # startup defaults; key bindings toggle both at runtime
 sidebar_always = false      # keep a sidebar session row even with one session
@@ -392,7 +411,12 @@ italic = false
 [ui.path_style.parent]      # emphasis for the leading directories
 color  = "#8a8a8a"
 
-[ui.icons]                  # sidebar glyph overrides (e.g. Nerd Font icons)
+[ui.icons]                  # sidebar glyph overrides (e.g. Nerd Font icons).
+                             # Each key takes a bare string (glyph only, as
+                             # below) or a table that also styles color,
+                             # weight, slant, and size — see "Icon styling"
+                             # below. The bare-string form keeps working
+                             # unchanged.
 search = "⌕"                # glyph prefixing the sidebar search prompt
 worktree_main = "●"         # the project's main checkout
 worktree = "○"
@@ -404,6 +428,10 @@ pr_open = "⬤"               # the four PR glyphs need pr_status = true; they
 pr_draft = "◯"              # differ by colour, so overriding one shape is
 pr_merged = "⬤"             # usually not what you want
 pr_closed = "⬤"
+upstream_level = "✓"        # the four upstream glyphs need upstream_status =
+upstream_diverged = "⇅"     # true; each carries its own default color from
+upstream_gone = "⌫"         # the theme, which a table override replaces
+upstream_untracked = "↑"
 
 [ui.drop]                   # what dragging files onto the window does
 enabled       = true        # master switch; false ignores every drop
@@ -486,6 +514,21 @@ tables are read by the same `Raw*` structs, so those parts of an existing
 `alacritty.toml` carry over. The structs cover the fields alacritree acts on
 rather than Alacritty's full schema — see `config.rs` for what a given table
 actually accepts.
+
+### Icon styling
+
+Every `[ui.icons]` key takes either a bare glyph string, as shown above, or a
+table that styles it further:
+
+```toml
+[ui.icons]
+upstream_gone = { glyph = "⌫", color = "#ff5555", bold = true, italic = false, size = 14 }
+```
+
+`glyph` is optional in table form — a table with no `glyph` key keeps that
+icon's default glyph and only applies the styling. `size` is in logical
+pixels, measured before `ui_scale`, and is clamped to the space the sidebar
+row reserves for that icon, so it cannot grow past its slot.
 
 ### Shell launch profiles
 


### PR DESCRIPTION
Adds an upstream status badge to sidebar worktree rows, plus the icon-styling
and font plumbing it needs. All three parts are off by default — with no config
changes the sidebar renders exactly as it does today.

Stacked on #165; the diff below includes [1]–[6]. This branch merges #165, so
that one lands first.

## Upstream badge — `[ui] upstream_status` (default `false`)

Worktree rows gain a badge showing how the branch stands against its upstream,
left of the PR badge:

| Badge | Meaning |
|---|---|
| `✓` | level with upstream |
| `⇅` | diverged — hover spells out ahead/behind |
| `⌫` | upstream configured but no longer exists |
| `↑` | no upstream configured |

Two acquisition backends: a `git2` branch walk natively, and one additional
`git for-each-ref` section in the existing WSL discovery batch, shell-gated so
it does not run when the feature is off. All linked worktrees of a project
share `refs/heads`, so one walk answers for every row.

A branch whose state cannot be determined — detached HEAD, an unwalkable graph
— gets no badge rather than a guessed one.

Nothing fetches, and badges refresh with the project rather than on a timer, so
`✓` means level as of the last fetch.

## Icons inside a row now answer on hover

The badge table above promises that `⇅` spells out ahead/behind on hover. It
did not, and neither did any other icon sitting inside a worktree, session, or
home row — including every trailing button. The hint text was always attached;
what the icons lost was the hover mark. A row allocates its frame at end-of-
show, so the retroactive `interact` that senses the whole row registers after
its children in egui's z-order and claims the pointer from them.

Each row now records the rect and hint of every icon it paints and answers for
whichever one the pointer is over, leaving the rest of the row to the name
tooltip. That makes the ahead/behind hover real, and the same applies to the PR
badge and the trailing buttons.

## Status icons say what they report

With the recovery in place, the icons that report rather than act get hints
they never had:

| Icon | Hint |
|---|---|
| Git panel row letter — `A M D R ? !` | the change kind spelled out (`modified`, `untracked`, …) |
| Agent glyph in a row's leading slot | `claude is running` — also codex, gemini, aider, cursor-agent, continue |
| Attention dot | `needs attention` — on session, worktree, home, and collapsed project rows |

A bare `M` or `!` says nothing to a reader who does not already know porcelain,
and the leading slot previously offered no way to ask what its glyph stood for.

`Session::agent_glyph` also picks up a decorative glyph from the session's own
title, which can be any non-ASCII character. Those name no agent, so that slot
stays silent rather than claiming one — only glyphs from alacritree's own
process table produce a hint.

Every hint here honours `[ui] icon_tooltips` (added in #165, default `true`),
so a config that silences icon hints silences all of them.

## Icon styling — `[ui.icons]`

Entries now accept a style table as well as a bare string:

```toml
[ui.icons]
worktree = "◆"
upstream_gone = { glyph = "⌫", color = "#ff5555", bold = true }
```

Bare strings parse exactly as before. Adds `[ui] sidebar_attention` to colour
the attention state.

Status-marker glyphs paint in a fixed 10 px slot, so `size` above that is
clamped.

## UI font variants — `[ui.font]`

`bold_family`, `italic_family`, and `bold_italic_family` extend the UI font
chain, so styled icons can reach real bold/italic faces.

Worth knowing: with none of these set, `bold = true` on an icon resolves
through the terminal's bold family. If the terminal font has no true bold
sibling, that renders as its regular face — a different typeface rather than a
heavier one. Set `bold_family` explicitly if you want guaranteed weight.

## Tests

852 passing. Coverage includes the four-state divergence matrix against real
repositories, the WSL section-index contract, `for-each-ref` parsing, the
acquisition gate in both directions, and paint-time assertions that every icon
is unchanged when unconfigured. The hover recovery is covered by row-level
tests that paint a real row, rest the pointer on each icon in turn, and read
the tooltip back out of its own layer. The attention dot paints a circle rather
than text, so its test learns the slot position from a render carrying the
agent glyph, then hovers that point with the dot in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
