### PR TITLE
fix(mcp): find socket without XDG_RUNTIME_DIR

### DIFF
--- a/alacritree/Cargo.toml
+++ b/alacritree/Cargo.toml
@@ -65,6 +65,9 @@ nucleo-matcher = "0.3"
 tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
+# Linux socket discovery uses the effective uid when a GUI launcher omits
+# XDG_RUNTIME_DIR. macOS uses libc for foreground-agent detection.
+libc = "0.2"
 # Used for font matching: matches what alacritty does via crossfont so that
 # fontconfig <alias> rules and weight/slant substitution behave identically
 # in both terminals.  Pinned to 0.8 because that's the latest line that links
@@ -105,10 +108,6 @@ tauri-winrt-notification = "0.7"
 # Cargo unions target features, so this enables dlopen only on macOS, leaving the
 # `cfg(unix)` fontconfig dep above to link normally on Linux.
 fontconfig = { version = "0.8", features = ["dlopen"] }
-# Foreground-agent detection: `proc_pidinfo` supplies the process group,
-# foreground group, and command name Linux reads from /proc, and
-# `sysctl(KERN_PROCARGS2)` the command line.
-libc = "0.2"
 # UserNotifications framework, used instead of notify-rust because its
 # NSUserNotification backend is defunct on modern macOS: delivery silently
 # fails for unbundled processes and clicks are never surfaced.  Requires

--- a/alacritree/src/ipc.rs
+++ b/alacritree/src/ipc.rs
@@ -500,10 +500,31 @@ fn socket_path() -> PathBuf {
 /// `socket_dir` (which also falls back to tmp on macOS).
 #[cfg(unix)]
 pub fn socket_dir() -> PathBuf {
-    std::env::var_os("XDG_RUNTIME_DIR")
-        .map(|dir| PathBuf::from(dir).join("alacritree"))
+    runtime_dir(std::env::var_os("XDG_RUNTIME_DIR").as_deref())
+        .map(|dir| dir.join("alacritree"))
         .and_then(|path| std::fs::create_dir_all(&path).ok().map(|_| path))
         .unwrap_or_else(std::env::temp_dir)
+}
+
+/// Resolve the runtime directory even when a GUI launcher strips the XDG
+/// environment. Linux defines the default as `/run/user/$UID`; using the
+/// effective uid keeps a desktop-launched MCP bridge in the same socket
+/// directory as an alacritree window launched from a shell.
+#[cfg(unix)]
+fn runtime_dir(xdg_runtime_dir: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
+    xdg_runtime_dir.filter(|dir| !dir.is_empty()).map(PathBuf::from).or_else(platform_runtime_dir)
+}
+
+#[cfg(target_os = "linux")]
+fn platform_runtime_dir() -> Option<PathBuf> {
+    // SAFETY: `geteuid` takes no arguments and has no safety preconditions.
+    let uid = unsafe { libc::geteuid() };
+    Some(PathBuf::from("/run/user").join(uid.to_string()))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn platform_runtime_dir() -> Option<PathBuf> {
+    None
 }
 
 /// The named-pipe filesystem, which is also a directory: listing it is how a
@@ -527,6 +548,16 @@ mod tests {
     use super::*;
 
     use crate::session::SESSION_ID_ENV;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn socket_discovery_survives_a_missing_xdg_runtime_dir() {
+        // A GUI-launched MCP client does not necessarily forward
+        // XDG_RUNTIME_DIR to stdio servers. Both processes must still derive
+        // the conventional per-user directory.
+        let uid = unsafe { libc::geteuid() };
+        assert_eq!(runtime_dir(None), Some(PathBuf::from(format!("/run/user/{uid}"))));
+    }
 
     #[test]
     fn wslenv_gains_the_socket_exactly_once() {


### PR DESCRIPTION
## What changed

- fall back to `/run/user/$UID` on Linux when `XDG_RUNTIME_DIR` is absent
- keep the existing temporary-directory fallback on other Unix platforms
- add a regression test for GUI-launched stdio MCP clients

## Why

GUI hosts such as Codex may launch `alacritree mcp` without forwarding `XDG_RUNTIME_DIR`. The bridge then scanned `/tmp` while the running Alacritree window listened under `/run/user/$UID/alacritree`, causing every tool call to report that no instance was running.

This lets the bridge and window derive the same socket directory without requiring client-specific environment configuration.

## Validation

- `cargo test -p alacritree ipc::tests -- --nocapture`
- `cargo test -p alacritree mcp::tests -- --nocapture`
- built the binary and verified `env -u XDG_RUNTIME_DIR alacritree doctor` reports `/run/user/1000/alacritree` and an answering instance
