### PR TITLE
homebrew: bump alacritree to v0.9.0

### DIFF
--- a/Formula/alacritree.rb
+++ b/Formula/alacritree.rb
@@ -1,7 +1,7 @@
 class Alacritree < Formula
   desc "Alacritty fork with worktree-aware sidebars"
   homepage "https://github.com/mathix420/alacritree"
-  version "0.8.1"
+  version "0.9.0"
   license "Apache-2.0"
 
   # Linked dynamically through the `fontconfig` Rust crate (alacritty's font
@@ -22,7 +22,7 @@ class Alacritree < Formula
   on_macos do
     on_arm do
       url "https://github.com/mathix420/alacritree/releases/download/v#{version}/alacritree-aarch64-apple-darwin.tar.gz"
-      sha256 "68e82b77b48734a355072639be44df1c98333c2a22cb1cc3e361fd77e4d20d03"
+      sha256 "f0a124a337d34a922cb6c297b5f4df507a0e2d6f1f84aed127a7bc105baa133c"
     end
   end
 


### PR DESCRIPTION
Automated formula bump triggered by the release of `v0.9.0`.