### PR TITLE
fix(sidebar): tell the truth about a worktree whose checkout is gone [2]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -988,11 +988,13 @@ impl AlacritreeApp {
     /// drops a result the backend could not vouch for and keeps `expanded`,
     /// the shell override, and the label either way.
     fn poll_project_refreshes(&mut self) {
+        let occupied: HashSet<PathBuf> =
+            self.sessions.iter().filter_map(|s| s.working_directory.clone()).collect();
         let projects = &mut self.projects;
         self.project_refreshes.poll(|root, found| {
             match projects.iter_mut().find(|p| p.root == *root) {
                 Some(project) => {
-                    project.apply(found);
+                    project.apply(found, &occupied);
                     Ok(project_json(project))
                 },
                 None => Err(format!("{} is not a project in the sidebar", root.display())),
@@ -1156,7 +1158,9 @@ impl AlacritreeApp {
         // The dir can vanish between discovery marking the row live and the
         // click. Switching first would strand the user on a dead workspace
         // with a failed spawn — stay put and let the sidebar re-mark the row.
-        if !path.is_dir() {
+        // Shells already running there are the exception: they outlive the
+        // directory, and this row is the only way back to them.
+        if !path.is_dir() && !self.workspace_has_sessions(&Some(path.to_path_buf())) {
             self.error_dialog =
                 Some("worktree directory is missing — prune it from the sidebar".to_string());
             if let Some(idx) =
@@ -1183,8 +1187,9 @@ impl AlacritreeApp {
         if self.active_session_index().is_some() {
             return;
         }
-        if let Err(e) = self.spawn_session(ctx, self.current_workspace.clone()) {
-            self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+        let ws = self.current_workspace.clone();
+        if let Err(e) = self.spawn_session(ctx, ws.clone()) {
+            self.report_spawn_failure(ctx, &ws, &e);
             return;
         }
         // Filling in a missing active entry is self-healing, not navigation.
@@ -1235,8 +1240,8 @@ impl AlacritreeApp {
         if verdict != CloseFallback::Stay
             && self.config.ui.last_session_close == LastSessionClose::Respawn
         {
-            if let Err(e) = self.spawn_session(ctx, workspace) {
-                self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+            if let Err(e) = self.spawn_session(ctx, workspace.clone()) {
+                self.report_spawn_failure(ctx, &workspace, &e);
             }
             return;
         }
@@ -1365,6 +1370,22 @@ impl AlacritreeApp {
         Ok(target)
     }
 
+    /// Report a failed spawn, and re-run discovery when the cause was a
+    /// vanished checkout: git may have forgotten the worktree entirely, in
+    /// which case the row should go rather than keep offering a shell that
+    /// cannot start.
+    fn report_spawn_failure(&mut self, ctx: &Context, ws: &WorkspaceKey, e: &std::io::Error) {
+        self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+        let Some(path) = ws.as_deref().filter(|p| !p.is_dir()) else {
+            return;
+        };
+        if let Some(idx) =
+            self.projects.iter().position(|p| p.worktrees.iter().any(|w| w.path == path))
+        {
+            self.refresh_project(ctx, idx);
+        }
+    }
+
     fn workspace_session_indices(&self, ws: &WorkspaceKey) -> Vec<usize> {
         self.sessions
             .iter()
@@ -1454,9 +1475,10 @@ impl AlacritreeApp {
         let mut order: Vec<WorkspaceKey> = vec![None];
         for project in &self.projects {
             for wt in &project.worktrees {
-                // Prunable rows can't host a shell; cycling into one would
-                // just bounce off the activate guard on every keypress.
-                if !wt.prunable {
+                // Prunable rows can't host a *new* shell; cycling into one
+                // would just bounce off the activate guard on every keypress.
+                // One that still holds shells is a real stop on the ring.
+                if !wt.prunable || self.workspace_has_sessions(&Some(wt.path.clone())) {
                     order.push(Some(wt.path.clone()));
                 }
             }
@@ -2471,8 +2493,8 @@ impl AlacritreeApp {
             },
             BindingAction::Named(NamedAction::SpawnNewInstance) => {
                 let ws = self.current_workspace.clone();
-                if let Err(e) = self.spawn_session(ctx, ws) {
-                    self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+                if let Err(e) = self.spawn_session(ctx, ws.clone()) {
+                    self.report_spawn_failure(ctx, &ws, &e);
                 }
             },
             BindingAction::Named(NamedAction::Quit) => {
@@ -3039,8 +3061,8 @@ impl AlacritreeApp {
         if spawn_default {
             let ctx = ui.ctx().clone();
             let ws = self.current_workspace.clone();
-            if let Err(e) = self.spawn_session(&ctx, ws) {
-                self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+            if let Err(e) = self.spawn_session(&ctx, ws.clone()) {
+                self.report_spawn_failure(&ctx, &ws, &e);
             }
         }
         if let Some(name) = spawn_profile {
@@ -3760,11 +3782,11 @@ impl AlacritreeApp {
             // hands the workspace back rather than stranding the user on one
             // with no shell — the same reasoning as `activate_worktree`.
             let previous = std::mem::replace(&mut self.current_workspace, ws.clone());
-            match self.spawn_session(ctx, ws) {
+            match self.spawn_session(ctx, ws.clone()) {
                 Ok(_) => workspace_activated = true,
                 Err(e) => {
                     self.current_workspace = previous;
-                    self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+                    self.report_spawn_failure(ctx, &ws, &e);
                 },
             }
         }
@@ -6517,7 +6539,9 @@ fn worktree_row(
         ui.scroll_to_rect(full_rect, None);
     }
     WorktreeAction {
-        activate: !deleting && resp.clicked() && !delete_clicked && !spawn_clicked && !wt.prunable,
+        // A prunable row is still worth clicking when shells are homed there;
+        // `activate_worktree` turns the ones that aren't into the prune hint.
+        activate: !deleting && resp.clicked() && !delete_clicked && !spawn_clicked,
         delete: delete_clicked,
         spawn: spawn_clicked,
         set_base: set_base_clicked,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -46,6 +46,7 @@ use crate::state::{self, PersistedProject};
 use crate::terminal_view;
 use crate::upstream::UpstreamState;
 use crate::worktree::{self as wt, CreateRequest, Progress};
+use crate::worktree_liveness;
 use crate::wsl::{self, ShellChoice};
 use crate::wsl_helper::{self, WslProbe};
 
@@ -354,6 +355,12 @@ fn project_filter_toggles(pr_status: bool) -> &'static [char] {
 /// The toggle identities the git panel accepts: modified, deleted, untracked.
 const GIT_FILTER_TOGGLES: &[char] = &['m', 'd', 'u'];
 
+/// How long after the user's last event the worktree liveness tick keeps
+/// asking for frames.  Long enough that a `git worktree remove` typed at a
+/// prompt finishes and greys its row; short enough that a window left open
+/// goes back to producing no frames at all.
+const PROBE_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// The projects-panel toggle a named action flips, or `None` for an action that
 /// is not one of its filters.  `PanelFilter::toggle` ignores an identity it does
 /// not allow and dispatch falls through on an unmatched action, so nothing at
@@ -562,6 +569,15 @@ pub struct AlacritreeApp {
     /// `pending_project_refresh` — resolved off the UI thread, adopted in
     /// `wsl_delta_path`.
     pending_delta: HashMap<String, Receiver<Option<String>>>,
+    /// Row styling only — never `Worktree::prunable`, which the delete flow
+    /// reads to choose between removing a worktree and pruning it.
+    liveness: worktree_liveness::LivenessCache,
+    /// The probe worker in flight, if any.  One at a time: a path slower than
+    /// the interval stretches freshness rather than queueing more work.
+    liveness_probe: Option<Receiver<Vec<(PathBuf, worktree_liveness::Liveness)>>>,
+    /// When the user last gave the app an event.  Timed wake-ups are armed
+    /// only just after one, so an app left open overnight goes fully quiet.
+    last_input: Instant,
     /// Rows behind the last-built focus snapshot. Paint reuses this until the
     /// next rebuild instead of recomputing the projection every frame.
     sidebar_rows_cache: Option<Vec<SidebarRow>>,
@@ -876,6 +892,9 @@ impl AlacritreeApp {
             project_refreshes: Default::default(),
             wsl_delta_paths: HashMap::new(),
             pending_delta: HashMap::new(),
+            liveness: Default::default(),
+            liveness_probe: None,
+            last_input: Instant::now(),
             sidebar_rows_cache: None,
             sidebar_focus_prev: None,
             sidebar_anchor: None,
@@ -974,6 +993,53 @@ impl AlacritreeApp {
             ctx.request_repaint();
         });
         self.project_refreshes.start(root, rx);
+    }
+
+    /// Keep the worktree rows the sidebar just drew honest about whether their
+    /// checkout is still there.  Discovery only re-runs when something asks it
+    /// to, so a `git worktree remove` typed into one of our own sessions would
+    /// otherwise leave the row looking live until the user pressed refresh.
+    ///
+    /// `request_repaint_after` is what carries the tick across a terminal that
+    /// has gone quiet — egui paints on demand, so without it the probe would
+    /// never run a second time.  It is armed only for a short window after the
+    /// user last touched the app, because an unconditional 1.5 s wake-up is
+    /// not just a repaint: every frame runs `StatusCache::poll` and
+    /// `PrCache::poll` from the git sidebar's paint, both on the same
+    /// staleness interval, so a permanent heartbeat would spawn a git status
+    /// walk and a `gh` lookup forever on an app nobody is using.
+    fn poll_worktree_liveness(&mut self, ctx: &Context, drawn: &[PathBuf]) {
+        let now = Instant::now();
+        match self.liveness_probe.as_ref().map(Receiver::try_recv) {
+            Some(Ok(results)) => {
+                self.liveness.adopt(results, now);
+                self.liveness_probe = None;
+            },
+            // A worker still running is the backpressure: a path slower than
+            // the interval stretches freshness instead of stacking up probes,
+            // and its own `request_repaint` brings us back here.
+            Some(Err(TryRecvError::Empty)) => return,
+            Some(Err(TryRecvError::Disconnected)) => self.liveness_probe = None,
+            None => {},
+        }
+
+        if !drawn.is_empty() {
+            let batch = self.liveness.batch(drawn);
+            let (tx, rx) = mpsc::channel();
+            let ctx = ctx.clone();
+            std::thread::spawn(move || {
+                let results =
+                    batch.iter().map(|p| (p.clone(), worktree_liveness::probe(p))).collect();
+                let _ = tx.send(results);
+                ctx.request_repaint();
+            });
+            self.liveness_probe = Some(rx);
+            return;
+        }
+
+        if self.config.ui.worktree_liveness && self.last_input.elapsed() < PROBE_GRACE {
+            ctx.request_repaint_after(self.liveness.wait(now));
+        }
     }
 
     /// Re-run worktree discovery for every project — the keyboard/IPC
@@ -3072,6 +3138,15 @@ impl AlacritreeApp {
     }
 
     fn show_project_sidebar(&mut self, ctx: &Context, panel_frame: Frame) -> egui::Rect {
+        // Only rows that actually paint are worth a liveness probe, and which
+        // ones those are is not known until the tree, its filters and its
+        // collapsed projects have all had their say.  Deciding *before* the
+        // walk that this frame is not a probe frame is what keeps the other
+        // ~89 frames of every 90 from collecting anything at all.
+        let probing = self.config.ui.worktree_liveness
+            && self.liveness_probe.is_none()
+            && self.liveness.wants_probe(Instant::now());
+        let drawn_worktrees: std::cell::RefCell<Vec<PathBuf>> = Default::default();
         let activate_request: std::cell::Cell<Option<PathBuf>> = std::cell::Cell::new(None);
         let delete_request: std::cell::Cell<Option<PathBuf>> = std::cell::Cell::new(None);
         let create_request: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
@@ -3645,9 +3720,23 @@ impl AlacritreeApp {
                                 );
                                 let wt_scroll = scrolls(is_cursor);
                                 let is_deleting = deleting_paths.contains(&wt.path);
+                                // A `\\wsl.localhost\` stat boots the distro's
+                                // 9P server, so probing one would restart a VM
+                                // the user had shut down and hold it resident
+                                // for as long as its worktrees are listed.
+                                // WSL rows keep discovery's word.
+                                if probing
+                                    && matches!(
+                                        wsl::classify(&wt.path),
+                                        wsl::Location::Windows(_)
+                                    )
+                                {
+                                    drawn_worktrees.borrow_mut().push(wt.path.clone());
+                                }
                                 let action = worktree_row(
                                     ui,
                                     wt,
+                                    self.liveness.missing(&wt.path),
                                     worktree_labels
                                         .get(idx)
                                         .and_then(|v| v.get(wt_idx))
@@ -3790,6 +3879,7 @@ impl AlacritreeApp {
                 },
             }
         }
+        self.poll_worktree_liveness(ctx, &drawn_worktrees.into_inner());
         if self.config.ui.sidebar_click_focus {
             // A click that picks a workspace or session means "go work
             // there", so it focuses the terminal; other panel clicks focus
@@ -6348,6 +6438,11 @@ fn upstream_badge<'a>(
 fn worktree_row(
     ui: &mut egui::Ui,
     wt: &Worktree,
+    // What the liveness probe has seen since discovery ran, if anything.
+    // `Some` overrides `wt.prunable` in both directions; `None` leaves it
+    // standing.  Kept out of the flag itself because that also picks between
+    // `git worktree remove` and a prune, and a probe must never decide that.
+    missing: Option<bool>,
     display_name: &str,
     pr: Option<&PrInfo>,
     is_active: bool,
@@ -6372,6 +6467,9 @@ fn worktree_row(
     // The leading and trailing groups run as sibling closures, so the status
     // slot's hint travels out separately and joins the rest afterwards.
     let mut status_hint = None;
+    // Discovery's word, corrected by whatever the probe has seen since.  The
+    // main worktree is never offered for pruning, so it never greys either.
+    let prunable = missing.map_or(wt.prunable, |gone| gone && !wt.is_main);
     // right: 0 keeps the worktree `×` at the same x as the project row's `×`,
     // which has no frame margin and sits flush against the panel's outer padding.
     let frame = Frame::default().inner_margin(Margin { left: 16, right: 0, top: 3, bottom: 3 });
@@ -6382,7 +6480,7 @@ fn worktree_row(
             } else {
                 (&icons.worktree, DEFAULT_WORKTREE_ICON)
             };
-            let name_color = if wt.prunable || deleting {
+            let name_color = if prunable || deleting {
                 theme.text_muted
             } else if is_active {
                 theme.text
@@ -6421,11 +6519,8 @@ fn worktree_row(
                         return;
                     }
                     if !wt.is_main {
-                        let hover = if wt.prunable {
-                            "prune worktree"
-                        } else {
-                            "delete worktree and branch"
-                        };
+                        let hover =
+                            if prunable { "prune worktree" } else { "delete worktree and branch" };
                         let btn = styled_icon_button(
                             ui,
                             &icons.delete_worktree,
@@ -6492,7 +6587,7 @@ fn worktree_row(
         hints.add(rect, hint);
     }
     let resp = hints.apply(resp, theme.icon_tooltips, |resp| {
-        if wt.prunable {
+        if prunable {
             resp.on_hover_text("worktree directory is missing — × prunes it")
         } else {
             name_tooltip(resp, display_name, name_elided, theme.sidebar_tooltips)
@@ -8098,6 +8193,9 @@ impl eframe::App for AlacritreeApp {
             .as_ref()
             .map(|_| (std::time::Instant::now(), crate::frame_log::output_wait()));
         self.grid_paint = std::time::Duration::ZERO;
+        if ctx.input(|i| !i.events.is_empty()) {
+            self.last_input = Instant::now();
+        }
         self.phases.restart();
         self.glyph_cache.begin_frame(ctx);
         self.poll_project_refreshes();
@@ -9996,7 +10094,8 @@ mod tests {
 
         let texts = texts_while_hovering(140.0, |ui| {
             worktree_row(
-                ui, &wt, &wt.name, None, true, false, false, false, None, false, &icons, &theme,
+                ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                &theme,
             );
         });
 
@@ -10156,7 +10255,8 @@ mod tests {
         let output = ctx.run(input, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 worktree_row(
-                    ui, &wt, &wt.name, None, true, false, false, false, None, false, &icons, &theme,
+                    ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                    &theme,
                 );
             });
         });
@@ -10279,6 +10379,7 @@ mod tests {
             worktree_row(
                 ui,
                 &wt,
+                None,
                 &wt.name,
                 Some(&pr),
                 true,
@@ -10587,7 +10688,8 @@ mod tests {
         let output = ctx.run(input, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 worktree_row(
-                    ui, &wt, &wt.name, None, true, false, false, false, None, false, &icons, &theme,
+                    ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                    &theme,
                 );
             });
         });
@@ -10640,7 +10742,8 @@ mod tests {
 
             let texts = texts_while_hovering(140.0, |ui| {
                 worktree_row(
-                    ui, &wt, name, None, true, false, false, false, None, false, &icons, &theme,
+                    ui, &wt, None, name, None, true, false, false, false, None, false, &icons,
+                    &theme,
                 );
             });
 
@@ -10702,6 +10805,7 @@ mod tests {
                 worktree_row(
                     ui,
                     &wt,
+                    None,
                     &wt.name,
                     Some(&pr),
                     true,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1603,10 +1603,8 @@ impl AlacritreeApp {
         let mut order: Vec<WorkspaceKey> = vec![None];
         for project in &self.projects {
             for wt in &project.worktrees {
-                // Prunable rows can't host a *new* shell; cycling into one
-                // would just bounce off the activate guard on every keypress.
-                // One that still holds shells is a real stop on the ring.
-                if !wt.prunable || self.workspace_has_sessions(&Some(wt.path.clone())) {
+                let has_sessions = self.workspace_has_sessions(&Some(wt.path.clone()));
+                if worktree_is_switchable(wt, self.liveness.missing(&wt.path), has_sessions) {
                     order.push(Some(wt.path.clone()));
                 }
             }
@@ -6531,7 +6529,7 @@ fn worktree_row(
     let mut status_hint = None;
     // Discovery's word, corrected by whatever the probe has seen since.  The
     // main worktree is never offered for pruning, so it never greys either.
-    let prunable = missing.map_or(wt.prunable, |gone| gone && !wt.is_main);
+    let prunable = worktree_looks_gone(wt, missing);
     // right: 0 keeps the worktree `×` at the same x as the project row's `×`,
     // which has no frame margin and sits flush against the panel's outer padding.
     let frame = Frame::default().inner_margin(Margin { left: 16, right: 0, top: 3, bottom: 3 });
@@ -6703,6 +6701,18 @@ fn worktree_row(
         spawn: spawn_clicked,
         set_base: set_base_clicked,
     }
+}
+
+/// The liveness cache corrects discovery for paint and navigation only. Keep
+/// this shared so a row that has just gone grey cannot remain a dead stop in
+/// the workspace ring. Main checkouts are never prune candidates, even when
+/// their project is a non-git directory with no .git entry.
+fn worktree_looks_gone(wt: &Worktree, missing: Option<bool>) -> bool {
+    missing.map_or(wt.prunable, |gone| gone && !wt.is_main)
+}
+
+fn worktree_is_switchable(wt: &Worktree, missing: Option<bool>, has_sessions: bool) -> bool {
+    !worktree_looks_gone(wt, missing) || has_sessions
 }
 
 struct SessionRowAction {
@@ -8552,6 +8562,35 @@ mod tests {
 
     fn ws(p: &str) -> WorkspaceKey {
         Some(PathBuf::from(p))
+    }
+
+    #[test]
+    fn a_grey_worktree_only_stays_in_the_workspace_ring_while_it_holds_sessions() {
+        let wt = Worktree {
+            name: "gone".into(),
+            path: PathBuf::from("/repo-worktrees/gone"),
+            branch: Some("feature".into()),
+            is_main: false,
+            prunable: false,
+            upstream: None,
+        };
+
+        assert!(!worktree_is_switchable(&wt, Some(true), false));
+        assert!(worktree_is_switchable(&wt, Some(true), true));
+    }
+
+    #[test]
+    fn a_main_checkout_never_looks_prunable_from_the_row_probe() {
+        let wt = Worktree {
+            name: "main".into(),
+            path: PathBuf::from("/plain-project"),
+            branch: None,
+            is_main: true,
+            prunable: false,
+            upstream: None,
+        };
+
+        assert!(!worktree_looks_gone(&wt, Some(true)));
     }
 
     /// Apply `move_target` to a concrete list so the drag semantics (drop

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1078,9 +1078,19 @@ impl AlacritreeApp {
         ctx: &Context,
         working_directory: WorkspaceKey,
     ) -> std::io::Result<SessionId> {
-        // Before the PTY exists, so the shell can't race `doppler run`
-        // against the scope write.
         if let Some(dir) = &working_directory {
+            // A checkout git has forgotten is refused here rather than in
+            // `Session::spawn`, which can only see whether the directory
+            // exists — a half-finished `git worktree remove` leaves one that
+            // does.  Refusing here is what keeps the greyed row's promise.
+            if self.worktree_gone(dir) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("worktree is no longer checked out: {}", dir.display()),
+                ));
+            }
+            // Before the PTY exists, so the shell can't race `doppler run`
+            // against the scope write.
             self.sync_doppler_scopes(dir.clone());
         }
         let (shell, wsl_probe) = self.resolve_shell(&working_directory);
@@ -1231,7 +1241,7 @@ impl AlacritreeApp {
         // with a failed spawn — stay put and let the sidebar re-mark the row.
         // Shells already running there are the exception: they outlive the
         // directory, and this row is the only way back to them.
-        if !path.is_dir() && !self.workspace_has_sessions(&Some(path.to_path_buf())) {
+        if self.worktree_gone(path) && !self.workspace_has_sessions(&Some(path.to_path_buf())) {
             self.error_dialog =
                 Some("worktree directory is missing — prune it from the sidebar".to_string());
             if let Some(idx) =
@@ -1376,7 +1386,7 @@ impl AlacritreeApp {
         // Discovery marking can be stale; a dir deleted since the last
         // refresh should still get the prune flow, not a doomed
         // `git worktree remove`.
-        let prunable = wt.prunable || !wt.path.is_dir();
+        let prunable = wt.prunable || worktree_liveness::is_gone(&wt.path);
         self.pending_delete = Some(DeleteRequest {
             project_idx,
             worktree_path: wt.path.clone(),
@@ -1441,13 +1451,31 @@ impl AlacritreeApp {
         Ok(target)
     }
 
+    /// Whether the sidebar worktree at `path` is one git no longer recognises,
+    /// which is the single question the row's styling, this guard and the
+    /// delete flow all ask — a greyed row that still spawns a shell would be
+    /// the inconsistency this exists to remove.
+    ///
+    /// Main checkouts and non-git project roots have no `.git` link to lose,
+    /// so they fall back to the directory itself; so does a path no project
+    /// lists, which is the safe default for a caller we cannot place.
+    fn worktree_gone(&self, path: &Path) -> bool {
+        let linked = self
+            .projects
+            .iter()
+            .flat_map(|p| &p.worktrees)
+            .find(|wt| wt.path == path)
+            .is_some_and(|wt| !wt.is_main);
+        if linked { worktree_liveness::is_gone(path) } else { !path.is_dir() }
+    }
+
     /// Report a failed spawn, and re-run discovery when the cause was a
     /// vanished checkout: git may have forgotten the worktree entirely, in
     /// which case the row should go rather than keep offering a shell that
     /// cannot start.
     fn report_spawn_failure(&mut self, ctx: &Context, ws: &WorkspaceKey, e: &std::io::Error) {
         self.error_dialog = Some(format!("failed to spawn shell: {e}"));
-        let Some(path) = ws.as_deref().filter(|p| !p.is_dir()) else {
+        let Some(path) = ws.as_deref().filter(|p| self.worktree_gone(p)) else {
             return;
         };
         if let Some(idx) =

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -507,10 +507,11 @@ pub struct AlacritreeApp {
     row_labels: crate::row_label::LabelTemplates,
     config: Config,
     theme: Theme,
-    last_error: Option<String>,
-    /// A modal popup carrying a failure message the user must dismiss —
-    /// louder than `last_error`, used when a background action (e.g. a
-    /// worktree delete) fails after its dialog already closed.
+    /// A modal popup carrying a failure message the user must dismiss.  Every
+    /// failure that has no inline home lands here — a background action (e.g. a
+    /// worktree delete) that failed after its dialog closed, or a shell that
+    /// would not spawn.  Dismissing it leaves the app usable, which an error
+    /// painted over the terminal would not.
     error_dialog: Option<String>,
     quit_dialog_open: bool,
     pending_delete: Option<DeleteRequest>,
@@ -847,7 +848,6 @@ impl AlacritreeApp {
             row_labels,
             config,
             theme,
-            last_error: None,
             error_dialog: None,
             quit_dialog_open: false,
             pending_delete: None,
@@ -897,7 +897,7 @@ impl AlacritreeApp {
         }
 
         if let Err(e) = app.spawn_session(&cc.egui_ctx, None) {
-            app.last_error = Some(format!("failed to spawn shell: {e}"));
+            app.error_dialog = Some(format!("failed to spawn shell: {e}"));
         }
 
         app
@@ -1048,7 +1048,7 @@ impl AlacritreeApp {
             }
             self.active_session.insert(workspace, id);
         } else if let Err(e) = self.spawn_scratchpad(ctx, workspace) {
-            self.last_error = Some(format!("failed to open scratchpad: {e}"));
+            self.error_dialog = Some(format!("failed to open scratchpad: {e}"));
             return;
         }
         self.focus_terminal();
@@ -1104,13 +1104,13 @@ impl AlacritreeApp {
     fn spawn_profile_session(&mut self, ctx: &Context, name: &str) {
         let Some(profile) = self.config.profile(name) else {
             log::warn!("no shell profile named `{name}`");
-            self.last_error = Some(format!("no shell profile named `{name}`"));
+            self.error_dialog = Some(format!("no shell profile named `{name}`"));
             return;
         };
         let (shell, wsl_probe) = profile_session_shell(profile);
         let ws = self.current_workspace.clone();
         if let Err(e) = self.spawn_session_with_shell(ctx, ws, shell, wsl_probe) {
-            self.last_error = Some(format!("failed to spawn profile `{name}`: {e}"));
+            self.error_dialog = Some(format!("failed to spawn profile `{name}`: {e}"));
         }
     }
 
@@ -1157,9 +1157,6 @@ impl AlacritreeApp {
         // click. Switching first would strand the user on a dead workspace
         // with a failed spawn — stay put and let the sidebar re-mark the row.
         if !path.is_dir() {
-            // This is recoverable from the sidebar, so use the dismissible
-            // dialog instead of replacing the terminal with `last_error`
-            // forever.
             self.error_dialog =
                 Some("worktree directory is missing — prune it from the sidebar".to_string());
             if let Some(idx) =
@@ -1187,7 +1184,7 @@ impl AlacritreeApp {
             return;
         }
         if let Err(e) = self.spawn_session(ctx, self.current_workspace.clone()) {
-            self.last_error = Some(format!("failed to spawn shell: {e}"));
+            self.error_dialog = Some(format!("failed to spawn shell: {e}"));
             return;
         }
         // Filling in a missing active entry is self-healing, not navigation.
@@ -1239,7 +1236,7 @@ impl AlacritreeApp {
             && self.config.ui.last_session_close == LastSessionClose::Respawn
         {
             if let Err(e) = self.spawn_session(ctx, workspace) {
-                self.last_error = Some(format!("failed to spawn shell: {e}"));
+                self.error_dialog = Some(format!("failed to spawn shell: {e}"));
             }
             return;
         }
@@ -2475,7 +2472,7 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::SpawnNewInstance) => {
                 let ws = self.current_workspace.clone();
                 if let Err(e) = self.spawn_session(ctx, ws) {
-                    self.last_error = Some(format!("failed to spawn shell: {e}"));
+                    self.error_dialog = Some(format!("failed to spawn shell: {e}"));
                 }
             },
             BindingAction::Named(NamedAction::Quit) => {
@@ -2516,7 +2513,7 @@ impl AlacritreeApp {
                             "SpawnProfile{n}: only {} profiles configured",
                             self.config.profiles.len()
                         );
-                        self.last_error = Some(format!("SpawnProfile{n}: no such profile"));
+                        self.error_dialog = Some(format!("SpawnProfile{n}: no such profile"));
                     },
                 }
             },
@@ -3043,7 +3040,7 @@ impl AlacritreeApp {
             let ctx = ui.ctx().clone();
             let ws = self.current_workspace.clone();
             if let Err(e) = self.spawn_session(&ctx, ws) {
-                self.last_error = Some(format!("failed to spawn shell: {e}"));
+                self.error_dialog = Some(format!("failed to spawn shell: {e}"));
             }
         }
         if let Some(name) = spawn_profile {
@@ -3759,12 +3756,17 @@ impl AlacritreeApp {
         }
         if let Some(ws) = spawn_shell_request.take() {
             // Spawning activates the workspace and the new session, matching
-            // Ctrl+T and worktree-creation's open-on-done.
-            self.current_workspace = ws.clone();
-            if let Err(e) = self.spawn_session(ctx, ws) {
-                self.last_error = Some(format!("failed to spawn shell: {e}"));
+            // Ctrl+T and worktree-creation's open-on-done.  A failed spawn
+            // hands the workspace back rather than stranding the user on one
+            // with no shell — the same reasoning as `activate_worktree`.
+            let previous = std::mem::replace(&mut self.current_workspace, ws.clone());
+            match self.spawn_session(ctx, ws) {
+                Ok(_) => workspace_activated = true,
+                Err(e) => {
+                    self.current_workspace = previous;
+                    self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+                },
             }
-            workspace_activated = true;
         }
         if self.config.ui.sidebar_click_focus {
             // A click that picks a workspace or session means "go work
@@ -4241,7 +4243,7 @@ impl AlacritreeApp {
                 self.active_session.insert(Some(workspace), id);
             },
             Err(e) => {
-                self.last_error = Some(format!("failed to open diff: {e}"));
+                self.error_dialog = Some(format!("failed to open diff: {e}"));
             },
         }
     }
@@ -8146,26 +8148,14 @@ impl eframe::App for AlacritreeApp {
             .show(ctx, |ui| {
                 self.show_tab_strip(ui);
 
-                if let Some(err) = self.last_error.as_deref() {
-                    // A preedit can only be finalized or cancelled by the terminal
-                    // view's event drain, so without a session view to run it the
-                    // preedit would go stale and keep shortcuts suppressed forever.
-                    self.ime.clear();
-                    ui.label(
-                        RichText::new(err)
-                            .color(rgb_to_color32(self.config.palette.normal[1]))
-                            .monospace(),
-                    );
-                    return;
-                }
-
                 if self.active_session_index().is_none() {
                     self.adopt_active_session();
                 }
 
                 let Some(idx) = self.active_session_index() else {
-                    // Same rationale as the last_error branch above: without an
-                    // active session view, no code path can advance the preedit.
+                    // A preedit can only be finalized or cancelled by the terminal
+                    // view's event drain, so without a session view to run it the
+                    // preedit would go stale and keep shortcuts suppressed forever.
                     self.ime.clear();
                     ui.label(
                         RichText::new("no session — Ctrl+T to open one").color(theme.text_dim),

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1014,6 +1014,11 @@ impl AlacritreeApp {
             Some(Ok(results)) => {
                 self.liveness.adopt(results, now);
                 self.liveness_probe = None;
+                // This runs after the rows painted, so the answers that just
+                // landed are one frame late. Without asking for that frame the
+                // new styling waits out a whole interval, or never arrives at
+                // all once the grace window has closed.
+                ctx.request_repaint();
             },
             // A worker still running is the backpressure: a path slower than
             // the interval stretches freshness instead of stacking up probes,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1004,11 +1004,17 @@ impl AlacritreeApp {
     /// has gone quiet — egui paints on demand, so without it the probe would
     /// never run a second time.  It is armed only for a short window after the
     /// user last touched the app, because an unconditional 1.5 s wake-up is
-    /// not just a repaint: every frame runs `StatusCache::poll` and
-    /// `PrCache::poll` from the git sidebar's paint, both on the same
-    /// staleness interval, so a permanent heartbeat would spawn a git status
-    /// walk and a `gh` lookup forever on an app nobody is using.
-    fn poll_worktree_liveness(&mut self, ctx: &Context, drawn: &[PathBuf]) {
+    /// not just a repaint: every frame runs `StatusCache::poll` from the git
+    /// sidebar's paint on the same staleness interval, so a permanent
+    /// heartbeat would spawn a git status walk forever on an app nobody is
+    /// using.
+    ///
+    /// `probing` is the sidebar's decision, not a re-derivation: only it knows
+    /// whether the walk that produced `drawn` was collecting at all, and an
+    /// empty `drawn` on a probe frame ("nothing eligible painted") has to
+    /// restart the interval where an empty `drawn` on any other frame must
+    /// leave it alone.
+    fn poll_worktree_liveness(&mut self, ctx: &Context, probing: bool, drawn: &[PathBuf]) {
         let now = Instant::now();
         match self.liveness_probe.as_ref().map(Receiver::try_recv) {
             Some(Ok(results)) => {
@@ -1028,22 +1034,30 @@ impl AlacritreeApp {
             None => {},
         }
 
-        if !drawn.is_empty() {
+        if probing {
             let batch = self.liveness.batch(drawn);
-            let (tx, rx) = mpsc::channel();
-            let ctx = ctx.clone();
-            std::thread::spawn(move || {
-                let results =
-                    batch.iter().map(|p| (p.clone(), worktree_liveness::probe(p))).collect();
-                let _ = tx.send(results);
-                ctx.request_repaint();
-            });
-            self.liveness_probe = Some(rx);
-            return;
+            if batch.is_empty() {
+                // No worker will land to close the interval, so close it here.
+                self.liveness.adopt(Vec::new(), now);
+            } else {
+                let (tx, rx) = mpsc::channel();
+                let ctx = ctx.clone();
+                std::thread::spawn(move || {
+                    let results =
+                        batch.iter().map(|p| (p.clone(), worktree_liveness::probe(p))).collect();
+                    let _ = tx.send(results);
+                    ctx.request_repaint();
+                });
+                self.liveness_probe = Some(rx);
+                return;
+            }
         }
 
-        if self.config.ui.worktree_liveness && self.last_input.elapsed() < PROBE_GRACE {
-            ctx.request_repaint_after(self.liveness.wait(now));
+        if self.config.ui.worktree_liveness
+            && self.last_input.elapsed() < PROBE_GRACE
+            && let Some(wait) = self.liveness.wait(now)
+        {
+            ctx.request_repaint_after(wait);
         }
     }
 
@@ -1058,13 +1072,19 @@ impl AlacritreeApp {
     /// Adopt completed background discoveries through `Project::apply`, which
     /// drops a result the backend could not vouch for and keeps `expanded`,
     /// the shell override, and the label either way.
+    ///
+    /// Runs every frame, so the occupied-directory set is built inside the
+    /// callback: hoisting it would clone every session's path on every repaint
+    /// terminal output happened to trigger, for the discoveries that are not
+    /// running.
     fn poll_project_refreshes(&mut self) {
-        let occupied: HashSet<PathBuf> =
-            self.sessions.iter().filter_map(|s| s.working_directory.clone()).collect();
+        let sessions = &self.sessions;
         let projects = &mut self.projects;
         self.project_refreshes.poll(|root, found| {
             match projects.iter_mut().find(|p| p.root == *root) {
                 Some(project) => {
+                    let occupied: HashSet<PathBuf> =
+                        sessions.iter().filter_map(|s| s.working_directory.clone()).collect();
                     project.apply(found, &occupied);
                     Ok(project_json(project))
                 },
@@ -1077,6 +1097,21 @@ impl AlacritreeApp {
         &mut self,
         ctx: &Context,
         working_directory: WorkspaceKey,
+    ) -> std::io::Result<SessionId> {
+        let (shell, wsl_probe) = self.resolve_shell(&working_directory);
+        self.spawn_session_with_shell(ctx, working_directory, shell, wsl_probe)
+    }
+
+    /// The one path every shell reaches, which is why the checkout guard and
+    /// the Doppler sync live here rather than in `spawn_session`: a named
+    /// profile arrives with its shell already chosen and would otherwise open
+    /// in a checkout Ctrl+T refuses.
+    fn spawn_session_with_shell(
+        &mut self,
+        ctx: &Context,
+        working_directory: WorkspaceKey,
+        shell: Option<Shell>,
+        wsl_probe: Option<WslProbe>,
     ) -> std::io::Result<SessionId> {
         if let Some(dir) = &working_directory {
             // A checkout git has forgotten is refused here rather than in
@@ -1093,17 +1128,6 @@ impl AlacritreeApp {
             // against the scope write.
             self.sync_doppler_scopes(dir.clone());
         }
-        let (shell, wsl_probe) = self.resolve_shell(&working_directory);
-        self.spawn_session_with_shell(ctx, working_directory, shell, wsl_probe)
-    }
-
-    fn spawn_session_with_shell(
-        &mut self,
-        ctx: &Context,
-        working_directory: WorkspaceKey,
-        shell: Option<Shell>,
-        wsl_probe: Option<WslProbe>,
-    ) -> std::io::Result<SessionId> {
         let session = Session::spawn(
             ctx.clone(),
             &self.config,
@@ -1459,13 +1483,18 @@ impl AlacritreeApp {
     /// Main checkouts and non-git project roots have no `.git` link to lose,
     /// so they fall back to the directory itself; so does a path no project
     /// lists, which is the safe default for a caller we cannot place.
+    ///
+    /// The same path can be listed by two projects, so any row that calls it a
+    /// linked worktree decides.  Taking the first match instead would let
+    /// sidebar order pick the weaker test, and the husk of a linked checkout
+    /// would read as alive.
     fn worktree_gone(&self, path: &Path) -> bool {
         let linked = self
             .projects
             .iter()
             .flat_map(|p| &p.worktrees)
-            .find(|wt| wt.path == path)
-            .is_some_and(|wt| !wt.is_main);
+            .filter(|wt| wt.path == path)
+            .any(|wt| !wt.is_main);
         if linked { worktree_liveness::is_gone(path) } else { !path.is_dir() }
     }
 
@@ -3912,7 +3941,7 @@ impl AlacritreeApp {
                 },
             }
         }
-        self.poll_worktree_liveness(ctx, &drawn_worktrees.into_inner());
+        self.poll_worktree_liveness(ctx, probing, &drawn_worktrees.into_inner());
         if self.config.ui.sidebar_click_focus {
             // A click that picks a workspace or session means "go work
             // there", so it focuses the terminal; other panel clicks focus

--- a/alacritree/src/color_glyph.rs
+++ b/alacritree/src/color_glyph.rs
@@ -17,7 +17,6 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use egui::{ColorImage, Context, TextureHandle, TextureOptions};
 use swash::FontRef;
@@ -46,9 +45,10 @@ impl CachedColorGlyph {
 pub struct ColorGlyphCache {
     /// The fallback chain in egui's own consultation order.
     chain: Vec<ChainFace>,
-    /// Font files behind the chain, read on first use.  A `None` marks a file
-    /// that could not be read, so a broken font is not re-read every frame.
-    files: HashMap<PathBuf, Option<Arc<Vec<u8>>>>,
+    /// Font files behind the chain, borrowed from the mappings `fonts` already
+    /// holds.  A `None` marks a file that would not map, so a broken font is
+    /// not retried on every cache miss.
+    files: HashMap<PathBuf, Option<&'static [u8]>>,
     /// Which chain entry, if any, draws this character in colour.  `None` means
     /// egui's own glyph pipeline owns it.
     source: HashMap<char, Option<usize>>,
@@ -144,7 +144,7 @@ impl ColorGlyphCache {
             let Some(data) = load(&mut self.files, &face.path) else {
                 continue;
             };
-            let claims = FontRef::from_index(&data, face.face_index as usize)
+            let claims = FontRef::from_index(data, face.face_index as usize)
                 .is_some_and(|font| font.charmap().map(c) != 0);
             if claims {
                 return Some(i);
@@ -171,7 +171,7 @@ impl ColorGlyphCache {
         cells: u32,
     ) -> Option<(ColorImage, i32, i32)> {
         let data = load(&mut self.files, &face.path)?;
-        let font = FontRef::from_index(&data, face.face_index as usize)?;
+        let font = FontRef::from_index(data, face.face_index as usize)?;
         let glyph = font.charmap().map(c);
 
         // Ask for the glyph at the cell's height.  Outline-backed colour glyphs
@@ -245,20 +245,20 @@ impl ColorGlyphCache {
 const COLOR_SOURCES: &[Source] =
     &[Source::ColorOutline(0), Source::ColorBitmap(StrikeWith::BestFit)];
 
-/// Read a font file once and keep it, so the chain's larger faces are not
-/// re-read on every cache miss.  A file that cannot be read is remembered as
-/// unreadable rather than retried.
-fn load(files: &mut HashMap<PathBuf, Option<Arc<Vec<u8>>>>, path: &Path) -> Option<Arc<Vec<u8>>> {
-    files
-        .entry(path.to_path_buf())
-        .or_insert_with(|| match std::fs::read(path) {
-            Ok(bytes) => Some(Arc::new(bytes)),
-            Err(e) => {
-                log::debug!("could not read colour font {}: {e}", path.display());
-                None
-            },
-        })
-        .clone()
+/// Borrow the mapping `fonts::map_font_file` already holds for the face rather
+/// than reading the file again: the chain's faces are handed to egui as
+/// mappings, and a second owned copy of a 792 MB collection is 792 MB of
+/// private memory that nothing evicts.
+fn load(files: &mut HashMap<PathBuf, Option<&'static [u8]>>, path: &Path) -> Option<&'static [u8]> {
+    *files.entry(path.to_path_buf()).or_insert_with(|| match crate::fonts::map_font_file(path) {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            // Every face in the chain mapped during install and `FONT_MAPS`
+            // never evicts, so arriving here means the two have diverged.
+            log::warn!("colour font {} is in the chain but will not map: {e}", path.display());
+            None
+        },
+    })
 }
 
 /// Bilinear resample of an RGBA buffer.  Colour bitmap strikes arrive at the
@@ -305,6 +305,12 @@ fn scale_rgba(src: &[u8], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32) -> Vec
 mod tests {
     use super::*;
     use crate::config::{FontConfig, UiFont};
+
+    /// The crate's own baked face, written to a unique path per test.
+    /// `fonts::FONT_MAPS` is global and never cleared, so a test that asserts
+    /// something *about* mapping has to own the path it asserts on.
+    const FIXTURE: &[u8] =
+        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/alacritree-symbols.ttf"));
 
     fn metrics() -> Metrics {
         Metrics { average_advance: 9.0, line_height: 20.0, descent: -4.0 }
@@ -476,5 +482,24 @@ mod tests {
         assert_eq!(cache.entries.len(), 1, "budget was not enforced");
         assert!(cache.bytes > 0);
         assert_eq!(cache.entries.len(), cache.used.len(), "eviction leaked LRU bookkeeping");
+    }
+
+    /// Every chain face is already memory-mapped by `fonts::map_font_file`.
+    /// Reading it again cost 960 MB of private memory on a chain whose primary
+    /// is a 792 MB collection, so pointer identity — not equal contents — is
+    /// what this has to assert.
+    #[test]
+    fn load_returns_the_mapping_rather_than_a_copy() {
+        let path = std::env::temp_dir().join("alacritree_test_color_glyph_load.ttf");
+        std::fs::write(&path, FIXTURE).unwrap();
+
+        let mapped = crate::fonts::map_font_file(&path).expect("the fixture maps");
+        let mut files = HashMap::new();
+        let loaded = load(&mut files, &path).expect("the fixture loads");
+
+        assert!(
+            std::ptr::eq(mapped.as_ptr(), loaded.as_ptr()),
+            "load copied the file instead of borrowing the mapping"
+        );
     }
 }

--- a/alacritree/src/color_glyph.rs
+++ b/alacritree/src/color_glyph.rs
@@ -50,7 +50,8 @@ pub struct ColorGlyphCache {
     /// not retried on every cache miss.
     files: HashMap<PathBuf, Option<&'static [u8]>>,
     /// Which chain entry, if any, draws this character in colour.  `None` means
-    /// egui's own glyph pipeline owns it.
+    /// egui's own glyph pipeline owns it.  The index is what a re-render after
+    /// a budget eviction uses instead of walking the chain again.
     source: HashMap<char, Option<usize>>,
     entries: HashMap<char, CachedColorGlyph>,
     /// Monotonic tick per lookup, so eviction can pick the coldest entry
@@ -61,6 +62,11 @@ pub struct ColorGlyphCache {
     budget: usize,
     cell_size: (u32, u32),
     scale: ScaleContext,
+    /// Chain walks performed, so a test can prove a post-eviction re-render
+    /// answers from `source` instead of re-parsing every earlier face's cmap.
+    /// `usize` rather than an atomic because `claiming_index` takes `&mut self`.
+    #[cfg(test)]
+    chain_walks: usize,
 }
 
 impl ColorGlyphCache {
@@ -76,6 +82,8 @@ impl ColorGlyphCache {
             budget: budget_mb.saturating_mul(1024 * 1024),
             cell_size: (0, 0),
             scale: ScaleContext::new(),
+            #[cfg(test)]
+            chain_walks: 0,
         }
     }
 
@@ -109,16 +117,24 @@ impl ColorGlyphCache {
             self.used.insert(c, now);
             return self.entries.get(&c);
         }
-        // A character already known to have no colour artwork costs one lookup;
-        // the whole grid takes this path on every frame.
-        if self.source.get(&c) == Some(&None) {
-            return None;
-        }
-
         // Only the claiming face is considered.  Looking further down the chain
         // would rasterize from a font egui had already passed over, so the two
         // renderers would disagree about which face owns the character.
-        let index = self.claiming_index(c)?;
+        let index = match self.source.get(&c) {
+            // Known monochrome: egui's own glyph pipeline draws it.  The whole
+            // grid takes this path on every frame, so it costs one lookup.
+            Some(None) => return None,
+            // Re-render after a budget eviction.  The chain is fixed at
+            // construction, so the recorded index still names the same face.
+            Some(Some(i)) => *i,
+            None => match self.claiming_index(c) {
+                Some(i) => i,
+                None => {
+                    self.source.insert(c, None);
+                    return None;
+                },
+            },
+        };
         let face = self.chain[index].clone();
         let glyph = self.rasterize(ctx, c, &face, cell, cells.max(1));
 
@@ -139,6 +155,10 @@ impl ColorGlyphCache {
 
     /// Index of the first face whose cmap claims `c` — the same face egui picks.
     fn claiming_index(&mut self, c: char) -> Option<usize> {
+        #[cfg(test)]
+        {
+            self.chain_walks += 1;
+        }
         for i in 0..self.chain.len() {
             let face = self.chain[i].clone();
             let Some(data) = load(&mut self.files, &face.path) else {
@@ -501,5 +521,65 @@ mod tests {
             std::ptr::eq(mapped.as_ptr(), loaded.as_ptr()),
             "load copied the file instead of borrowing the mapping"
         );
+    }
+
+    /// A character no face in the chain claims must be recorded as egui's, or
+    /// the whole chain is re-walked for it on every frame it is on screen.
+    #[test]
+    fn an_unclaimed_character_is_memoized() {
+        let ctx = Context::default();
+        let path = std::env::temp_dir().join("alacritree_test_unclaimed_memo.ttf");
+        std::fs::write(&path, FIXTURE).unwrap();
+        let chain = vec![ChainFace { path, face_index: 0, color_only: false }];
+        let mut cache = ColorGlyphCache::new(chain, 10);
+
+        // The baked symbols face carries box drawing and chrome glyphs only.
+        let unclaimed = '\u{4E00}';
+        assert!(
+            cache.resolve_claiming_face(unclaimed).is_none(),
+            "the fixture claims U+4E00; this test would prove nothing"
+        );
+
+        assert!(cache.get(&ctx, unclaimed, &metrics(), 1).is_none());
+        assert_eq!(
+            cache.source.get(&unclaimed),
+            Some(&None),
+            "an unclaimed character was not recorded, so every frame re-walks the chain"
+        );
+    }
+
+    /// After an eviction the glyph must be re-rasterized from the chain index
+    /// already recorded for it, not rediscovered by re-parsing the chain.
+    #[test]
+    fn a_post_eviction_rerender_skips_the_chain_walk() {
+        let ctx = Context::default();
+        let Some(chain) = chain_with_color_fonts(&ctx) else {
+            log::warn!("no colour emoji font installed; nothing to assert");
+            return;
+        };
+
+        // `chain_with_color_fonts` proves renderability for U+1F600 alone, so
+        // the second glyph is found rather than assumed.  A throwaway cache
+        // keeps the probe out of the cache under test.
+        let mut probe = ColorGlyphCache::new(chain.clone(), 10);
+        let renderable: Vec<char> = ['\u{1F600}', '\u{1F601}', '\u{2764}', '\u{1F44D}']
+            .into_iter()
+            .filter(|c| probe.get(&ctx, *c, &metrics(), 2).is_some())
+            .collect();
+        if renderable.len() < 2 {
+            log::warn!("fewer than two renderable colour glyphs here; nothing to assert");
+            return;
+        }
+        let (first, second) = (renderable[0], renderable[1]);
+
+        // One byte of budget: each insert evicts everything but itself.
+        let mut cache = ColorGlyphCache { budget: 1, ..ColorGlyphCache::new(chain, 0) };
+        assert!(cache.get(&ctx, first, &metrics(), 2).is_some(), "first glyph did not rasterize");
+        assert!(cache.get(&ctx, second, &metrics(), 2).is_some(), "second glyph did not rasterize");
+        assert!(!cache.entries.contains_key(&first), "the first glyph was not evicted");
+
+        let walks = cache.chain_walks;
+        assert!(cache.get(&ctx, first, &metrics(), 2).is_some(), "re-render after eviction failed");
+        assert_eq!(cache.chain_walks, walks, "the chain was re-walked after an eviction");
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -897,6 +897,12 @@ pub struct UiTheme {
     /// from local refs only — nothing fetches, so a branch deleted on the remote
     /// still reads as tracked until something prunes.
     pub upstream_status: bool,
+    /// Re-check on a 1.5 s tick whether each listed worktree's checkout is
+    /// still on disk, so a `git worktree remove` typed into one of our own
+    /// sessions greys the row without waiting for a manual refresh.  On by
+    /// default; the escape hatch exists because the probe is a `stat` per
+    /// listed row and an exotic filesystem could make that expensive.
+    pub worktree_liveness: bool,
     /// `[ui] pr_status_concurrency`: max `gh` lookups in flight at once.
     /// Defaults to 8; clamped to ≥ 1, since a cold cache spawns one lookup
     /// per eligible worktree in a single frame and an unbounded cap would
@@ -953,6 +959,7 @@ impl Default for UiTheme {
             session_display: SessionDisplay::default(),
             pr_status: false,
             upstream_status: false,
+            worktree_liveness: true,
             pr_status_concurrency: DEFAULT_CONCURRENCY,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
@@ -1711,6 +1718,7 @@ struct RawUi {
     scrollbar: Option<String>,
     pr_status: Option<bool>,
     upstream_status: Option<bool>,
+    worktree_liveness: Option<bool>,
     /// Max `gh` lookups in flight at once.  Defaults to 8; clamped to ≥ 1.
     pr_status_concurrency: Option<usize>,
     font: RawUiFont,
@@ -1886,6 +1894,7 @@ impl RawConfig {
             },
             pr_status: self.ui.pr_status.unwrap_or(false),
             upstream_status: self.ui.upstream_status.unwrap_or(false),
+            worktree_liveness: self.ui.worktree_liveness.unwrap_or(true),
             pr_status_concurrency: self
                 .ui
                 .pr_status_concurrency

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -1143,7 +1143,7 @@ fn gather_fallback_faces(
 /// and a second `install_terminal_fonts` reuses the mappings of the first.
 static FONT_MAPS: OnceLock<Mutex<HashMap<PathBuf, &'static [u8]>>> = OnceLock::new();
 
-fn map_font_file(path: &Path) -> std::io::Result<&'static [u8]> {
+pub(crate) fn map_font_file(path: &Path) -> std::io::Result<&'static [u8]> {
     let mut maps = FONT_MAPS
         .get_or_init(Default::default)
         .lock()

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -2286,6 +2286,10 @@ mod tests {
         gather_fallback_faces("Consolas", None, Variant::Normal, &skip, 8, &fonts);
 
         assert_eq!(face_coverage_parses(), 0, "a seed already in the scan was parsed anyway");
+        assert!(
+            fonts.seed_coverage.borrow().contains_key(&(seed.path.clone(), seed.face_index)),
+            "the seed was never resolved, so a parse count of zero proves nothing"
+        );
     }
 
     /// A seed the scan cannot answer for is parsed at most once per install,

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -1128,10 +1128,7 @@ fn face_coverage_parses() -> usize {
 /// both path and face index, so the match is exact — face 0 of a collection
 /// file can be an unrelated family.
 #[cfg(not(unix))]
-fn scanned_seed_coverage(
-    fonts: &SystemFonts,
-    face: &ResolvedFace,
-) -> Option<coverage::Coverage> {
+fn scanned_seed_coverage(fonts: &SystemFonts, face: &ResolvedFace) -> Option<coverage::Coverage> {
     fonts
         .scanned_coverage()
         .iter()

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -14,6 +14,8 @@
 //! symbols and box-drawing characters that aren't in the primary face.
 
 use std::cell::OnceCell;
+#[cfg(not(unix))]
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -109,6 +111,10 @@ struct SystemFonts {
     coverage: OnceCell<Vec<(coverage::Candidate, coverage::Coverage)>>,
     #[cfg(not(unix))]
     cache_location: CacheLocation,
+    /// `RefCell` rather than `OnceCell` because the map is keyed and grows;
+    /// `&self` access matches `db` and `coverage`.
+    #[cfg(not(unix))]
+    seed_coverage: RefCell<HashMap<(PathBuf, u32), Option<coverage::Coverage>>>,
 }
 
 impl SystemFonts {
@@ -145,6 +151,24 @@ impl SystemFonts {
             };
             scan_coverage(self.db(), cache_path.as_deref())
         })
+    }
+
+    /// Coverage of a resolved seed face, computed at most once per install.
+    /// The four variant seeds and the UI family commonly resolve to the same
+    /// one or two files, and a miss is cached too so an unresolvable seed is
+    /// not retried once per variant.
+    #[cfg(not(unix))]
+    fn seed_coverage(&self, face: &ResolvedFace) -> Option<coverage::Coverage> {
+        let key = (face.path.clone(), face.face_index);
+        if let Some(hit) = self.seed_coverage.borrow().get(&key) {
+            return hit.clone();
+        }
+        // The borrow above is released here, so the fallback parse cannot
+        // panic against the borrow_mut below.
+        let computed = scanned_seed_coverage(self, face)
+            .or_else(|| face_coverage(&face.path, face.face_index));
+        self.seed_coverage.borrow_mut().insert(key, computed.clone());
+        computed
     }
 }
 
@@ -1081,12 +1105,50 @@ fn cmap_coverage(face: &ttf_parser::Face) -> Option<coverage::Coverage> {
     Some(coverage::Coverage::from_codepoints(codepoints))
 }
 
+#[cfg(all(not(unix), test))]
+thread_local! {
+    /// Per-thread because the Windows fallback tests call
+    /// `gather_fallback_faces` concurrently at the default thread count, and a
+    /// process-wide count would fold their parses into whichever test asserts.
+    static FACE_COVERAGE_PARSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(all(not(unix), test))]
+fn reset_face_coverage_parses() {
+    FACE_COVERAGE_PARSES.with(|n| n.set(0));
+}
+
+#[cfg(all(not(unix), test))]
+fn face_coverage_parses() -> usize {
+    FACE_COVERAGE_PARSES.with(|n| n.get())
+}
+
+/// The scan already carries every system face and is disk-cached across
+/// launches, so a seed found here costs no parse at all.  `Candidate` carries
+/// both path and face index, so the match is exact — face 0 of a collection
+/// file can be an unrelated family.
+#[cfg(not(unix))]
+fn scanned_seed_coverage(
+    fonts: &SystemFonts,
+    face: &ResolvedFace,
+) -> Option<coverage::Coverage> {
+    fonts
+        .scanned_coverage()
+        .iter()
+        .find(|(candidate, _)| {
+            candidate.path == face.path && candidate.face_index == face.face_index
+        })
+        .map(|(_, coverage)| coverage.clone())
+}
+
 /// Coverage of an already-resolved primary face, read at its resolved face
 /// index — face 0 of a collection file can be an unrelated family.
 #[cfg(not(unix))]
 fn face_coverage(path: &Path, face_index: u32) -> Option<coverage::Coverage> {
-    let data = std::fs::read(path).ok()?;
-    let parsed = ttf_parser::Face::parse(&data, face_index).ok()?;
+    #[cfg(test)]
+    FACE_COVERAGE_PARSES.with(|n| n.set(n.get() + 1));
+    let data = map_font_file(path).ok()?;
+    let parsed = ttf_parser::Face::parse(data, face_index).ok()?;
     cmap_coverage(&parsed)
 }
 
@@ -1103,7 +1165,7 @@ fn gather_fallback_faces(
     fonts: &SystemFonts,
 ) -> Vec<FallbackFace> {
     let seed_coverage = resolve_face(family, style, variant, fonts)
-        .and_then(|face| face_coverage(&face.path, face.face_index))
+        .and_then(|face| fonts.seed_coverage(&face))
         .unwrap_or_default();
 
     let mut candidates: Vec<_> = fonts
@@ -1161,6 +1223,17 @@ pub(crate) fn map_font_file(path: &Path) -> std::io::Result<&'static [u8]> {
     let bytes: &'static [u8] = Box::leak(Box::new(mmap));
     maps.insert(path.to_path_buf(), bytes);
     Ok(bytes)
+}
+
+/// Whether `path` already has a mapping.  Test-only: nothing in the app needs
+/// to ask, and a release build should not carry the lookup.  Gated on
+/// `not(unix)` because its only caller is Windows-gated; otherwise this
+/// test-only helper is dead code on Linux.
+#[cfg(all(test, not(unix)))]
+fn is_mapped(path: &Path) -> bool {
+    FONT_MAPS.get().is_some_and(|maps| {
+        maps.lock().unwrap_or_else(std::sync::PoisonError::into_inner).contains_key(path)
+    })
 }
 
 fn insert_face(defs: &mut FontDefinitions, id: &str, bytes: &'static [u8], face_index: u32) {
@@ -2188,6 +2261,69 @@ mod tests {
         seen.sort_unstable();
         seen.dedup();
         seen
+    }
+
+    /// A seed the coverage scan already carries must not be parsed again — the
+    /// scan is disk-cached across launches and the parse is a whole-file read.
+    #[cfg(not(unix))]
+    #[test]
+    fn a_seed_present_in_the_scan_is_not_parsed_again() {
+        let fonts = SystemFonts::with_cache_dir(None);
+        let Some(seed) = resolve_face("Consolas", None, Variant::Normal, &fonts) else {
+            log::warn!("Consolas is not installed; nothing to assert");
+            return;
+        };
+        // A seed missing from the scan would pass this by falling through, so
+        // its presence is the precondition, not an assumption.
+        assert!(
+            fonts.scanned_coverage().iter().any(|(candidate, _)| candidate.path == seed.path
+                && candidate.face_index == seed.face_index),
+            "the seed is absent from the scan; this test would prove nothing"
+        );
+
+        reset_face_coverage_parses();
+        let skip = HashSet::new();
+        gather_fallback_faces("Consolas", None, Variant::Normal, &skip, 8, &fonts);
+
+        assert_eq!(face_coverage_parses(), 0, "a seed already in the scan was parsed anyway");
+    }
+
+    /// A seed the scan cannot answer for is parsed at most once per install,
+    /// however many variant chains ask for it.
+    #[cfg(not(unix))]
+    #[test]
+    fn a_seed_outside_the_scan_is_parsed_once_per_install() {
+        let fonts = SystemFonts::with_cache_dir(None);
+        let path = write_parseable_font("alacritree_test_seed_memo.ttf");
+        let family = path.to_str().expect("the temp path is utf-8");
+        let seed = resolve_face(family, None, Variant::Normal, &fonts).expect("a path resolves");
+        // An explicit path is not automatically outside the scan: a system
+        // font's own path resolves the same way, and the scan contains it.
+        assert!(
+            !fonts.scanned_coverage().iter().any(|(candidate, _)| candidate.path == seed.path
+                && candidate.face_index == seed.face_index),
+            "the fixture is in the scan; this test would prove nothing"
+        );
+
+        reset_face_coverage_parses();
+        let skip = HashSet::new();
+        gather_fallback_faces(family, None, Variant::Normal, &skip, 8, &fonts);
+        gather_fallback_faces(family, None, Variant::Normal, &skip, 8, &fonts);
+
+        assert_eq!(face_coverage_parses(), 1, "the seed was re-parsed for the second chain");
+    }
+
+    /// The fallback parse borrows the mapping like every other font read in
+    /// this module, rather than pulling a whole collection onto the heap.
+    #[cfg(not(unix))]
+    #[test]
+    fn face_coverage_maps_the_file_instead_of_reading_it() {
+        let path = write_parseable_font("alacritree_test_face_coverage_maps.ttf");
+        assert!(!is_mapped(&path), "the fixture path must be untouched by other tests");
+
+        let _ = face_coverage(&path, 0);
+
+        assert!(is_mapped(&path), "face_coverage read the file instead of mapping it");
     }
 }
 

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -52,6 +52,7 @@ mod terminal_view;
 mod test_util;
 mod upstream;
 mod worktree;
+mod worktree_liveness;
 mod wsl;
 mod wsl_helper;
 

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -167,7 +167,7 @@ impl Project {
                     .clone()
                     .or_else(|| rec.head.as_ref().map(|h| h.chars().take(7).collect()));
                 let wt_name = if i == 0 { "main".to_string() } else { display_name(&path) };
-                let prunable = i != 0 && !path.is_dir();
+                let prunable = i != 0 && crate::worktree_liveness::is_gone(&path);
                 let upstream = rec.branch.as_deref().and_then(|b| upstreams.get(b).cloned());
                 Worktree { name: wt_name, path, branch, is_main: i == 0, prunable, upstream }
             })
@@ -224,10 +224,12 @@ impl Project {
                     let upstream = lookup(&branch, detached);
                     worktrees.push(Worktree {
                         name: name.to_string(),
-                        // Directory existence, not git2's `is_prunable`, is
-                        // the signal: a *locked* worktree with a missing dir
-                        // is not git-prunable but still can't host a shell.
-                        prunable: !path.is_dir(),
+                        // The checkout's own `.git`, not git2's `is_prunable`: a
+                        // *locked* worktree with a missing checkout is not
+                        // git-prunable but still cannot host a shell, and a
+                        // half-finished remove leaves the directory behind
+                        // without it.
+                        prunable: crate::worktree_liveness::is_gone(&path),
                         path,
                         branch,
                         is_main: false,

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -1,6 +1,6 @@
 //! Enumerate sidebar-added directories and their git worktrees.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use git2::Repository;
@@ -260,11 +260,25 @@ impl Project {
     /// deletion.  `expanded`, `shell_override`, and `label` are user state and
     /// are never touched either way.  One list, so a field cannot be adopted by
     /// the synchronous refresh and dropped by the background one.
-    pub fn apply(&mut self, found: Discovered) {
+    /// `occupied` names the worktrees that still host a live session.  Git
+    /// forgets a worktree the moment it is pruned, but its shells keep
+    /// running, and a row is the only way to reach them — so a dropped
+    /// worktree with sessions is kept as prunable rather than removed.
+    pub fn apply(&mut self, found: Discovered, occupied: &HashSet<PathBuf>) {
         if !found.authoritative {
             return;
         }
-        self.worktrees = found.project.worktrees;
+        let mut worktrees = found.project.worktrees;
+        let stranded: Vec<Worktree> = self
+            .worktrees
+            .drain(..)
+            .filter(|wt| {
+                occupied.contains(&wt.path) && !worktrees.iter().any(|fresh| fresh.path == wt.path)
+            })
+            .map(|wt| Worktree { prunable: true, upstream: None, ..wt })
+            .collect();
+        worktrees.extend(stranded);
+        self.worktrees = worktrees;
         self.default_branch = found.project.default_branch;
         self.home = found.project.home;
     }
@@ -540,10 +554,13 @@ mod tests {
         ];
 
         let before = project.worktrees.clone();
-        project.apply(Discovered {
-            project: Project::placeholder(project.root.clone()),
-            authoritative: false,
-        });
+        project.apply(
+            Discovered {
+                project: Project::placeholder(project.root.clone()),
+                authoritative: false,
+            },
+            &HashSet::new(),
+        );
 
         assert_eq!(project.worktrees.len(), before.len());
         assert_eq!(project.worktrees[1].name, "feature");
@@ -561,10 +578,57 @@ mod tests {
         fresh.worktrees.clear();
         fresh.default_branch = Some("main".to_string());
 
-        project.apply(Discovered { project: fresh, authoritative: true });
+        project.apply(Discovered { project: fresh, authoritative: true }, &HashSet::new());
 
         assert!(project.worktrees.is_empty());
         assert_eq!(project.default_branch.as_deref(), Some("main"));
+    }
+
+    /// `git worktree prune` drops the worktree from discovery while its shells
+    /// keep running.  Dropping the row too would leave them with nowhere to be
+    /// reached from.
+    #[test]
+    fn apply_keeps_a_dropped_worktree_that_still_holds_sessions() {
+        let mut project = Project::placeholder(PathBuf::from("/repo"));
+        project.worktrees = vec![Worktree {
+            name: "gone".to_string(),
+            path: PathBuf::from("/repo-worktrees/gone"),
+            branch: Some("feature".to_string()),
+            is_main: false,
+            prunable: false,
+            upstream: None,
+        }];
+
+        let mut fresh = Project::placeholder(PathBuf::from("/repo"));
+        fresh.worktrees.clear();
+        let occupied = HashSet::from([PathBuf::from("/repo-worktrees/gone")]);
+
+        project.apply(Discovered::found(fresh), &occupied);
+
+        let kept = project.worktrees.first().expect("the row survives its checkout");
+        assert_eq!(kept.path, PathBuf::from("/repo-worktrees/gone"));
+        assert_eq!(kept.branch.as_deref(), Some("feature"), "the branch still names the row");
+        assert!(kept.prunable, "but it can no longer host a new shell");
+    }
+
+    #[test]
+    fn apply_drops_a_worktree_once_its_last_session_is_gone() {
+        let mut project = Project::placeholder(PathBuf::from("/repo"));
+        project.worktrees = vec![Worktree {
+            name: "gone".to_string(),
+            path: PathBuf::from("/repo-worktrees/gone"),
+            branch: None,
+            is_main: false,
+            prunable: true,
+            upstream: None,
+        }];
+
+        let mut fresh = Project::placeholder(PathBuf::from("/repo"));
+        fresh.worktrees.clear();
+
+        project.apply(Discovered::found(fresh), &HashSet::new());
+
+        assert!(project.worktrees.is_empty());
     }
 
     #[test]
@@ -767,7 +831,7 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         fresh.default_branch = Some("main".to_string());
         fresh.home = Some("/home/lev".to_string());
 
-        existing.apply(Discovered::found(fresh));
+        existing.apply(Discovered::found(fresh), &HashSet::new());
 
         assert_eq!(existing.home.as_deref(), Some("/home/lev"));
         assert_eq!(existing.default_branch.as_deref(), Some("main"));

--- a/alacritree/src/worktree_liveness.rs
+++ b/alacritree/src/worktree_liveness.rs
@@ -94,37 +94,39 @@ impl LivenessCache {
     }
 
     /// Take the batch to probe, forgetting every path the sidebar no longer
-    /// draws.  All visible paths go in together: they are checked on one
-    /// worker, so splitting them by individual freshness would buy nothing.
+    /// draws — including all of them, when a filter or a collapsed project
+    /// leaves nothing eligible.  All visible paths go in together: they are
+    /// checked on one worker, so splitting them by individual freshness would
+    /// buy nothing.
     pub fn batch(&mut self, visible: &[PathBuf]) -> Vec<PathBuf> {
         self.states.retain(|path, _| visible.contains(path));
         visible.to_vec()
     }
 
-    /// An `Unknown` result keeps whatever the last definite answer was: a
-    /// distro that stops answering must not silently grey out every row it
-    /// owns.  The interval restarts either way, so an unreachable path is
-    /// retried on the tick rather than on every frame.
+    /// An `Unknown` result replaces the last answer rather than preserving
+    /// it.  Keeping it would leave the row claiming a checkout is gone while
+    /// `is_gone` — which has no memory, and refuses to call an unreadable path
+    /// missing — lets that same path spawn a shell.  Forgetting instead makes
+    /// both say "cannot tell" and hands the row back to discovery's word.
+    ///
+    /// A round that probed nothing still restarts the interval, so a frame
+    /// with no eligible rows cannot leave `wants_probe` true forever.
     pub fn adopt(&mut self, results: Vec<(PathBuf, Liveness)>, now: Instant) {
         for (path, state) in results {
-            match state {
-                Liveness::Unknown => {
-                    self.states.entry(path).or_insert(Liveness::Unknown);
-                },
-                definite => {
-                    self.states.insert(path, definite);
-                },
-            }
+            self.states.insert(path, state);
         }
         self.next_probe = Some(now + FRESH_FOR);
     }
 
-    /// How long until the next batch is due, for `request_repaint_after`.
+    /// How long until the next batch is due, for `request_repaint_after`, or
+    /// `None` when no batch has ever run and there is nothing to wake up for.
     /// Without that wake-up the sidebar would only re-probe when something
     /// else happened to draw a frame, and a worktree deleted from an otherwise
-    /// idle terminal would stay marked live indefinitely.
-    pub fn wait(&self, now: Instant) -> Duration {
-        self.next_probe.map_or(Duration::ZERO, |due| due.saturating_duration_since(now))
+    /// idle terminal would stay marked live indefinitely.  The `Option` is
+    /// what keeps "no deadline" from collapsing into a zero wait, which
+    /// `request_repaint_after` reads as "repaint now" — every frame, forever.
+    pub fn wait(&self, now: Instant) -> Option<Duration> {
+        self.next_probe.map(|due| due.saturating_duration_since(now))
     }
 }
 
@@ -190,22 +192,37 @@ mod tests {
         assert_eq!(cache.missing(&p("/a")), Some(true));
     }
 
-    /// A distro that stops answering turns every path it owns `Unknown`.
-    /// Letting that grey the rows would report a deleted worktree every time
-    /// WSL hiccups.
+    /// A distro that stops answering turns every path it owns `Unknown`.  The
+    /// row has to stop claiming those checkouts are gone, because `is_gone`
+    /// has already stopped refusing to spawn shells in them.
     #[test]
-    fn an_unknown_result_leaves_the_last_answer_standing() {
+    fn an_unknown_result_forgets_the_last_answer() {
         let now = Instant::now();
         let mut cache = LivenessCache::default();
         cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
 
         cache.adopt(vec![(p("/a"), Liveness::Unknown)], now + FRESH_FOR);
 
-        assert_eq!(cache.missing(&p("/a")), Some(true), "the last definite answer stands");
+        assert_eq!(cache.missing(&p("/a")), None, "neither greyed nor vouched for");
         assert!(
             !cache.wants_probe(now + FRESH_FOR),
             "but the failed probe still restarts the tick"
         );
+    }
+
+    /// A frame whose rows are all collapsed, filtered away or on WSL probes
+    /// nothing.  Leaving the interval open would keep `wait` at zero, and the
+    /// caller's `request_repaint_after` would then ask for the next frame on
+    /// every frame.
+    #[test]
+    fn a_round_that_probed_nothing_still_restarts_the_interval() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+
+        cache.adopt(Vec::new(), now);
+
+        assert!(!cache.wants_probe(now + FRESH_FOR / 2));
+        assert_eq!(cache.wait(now), Some(FRESH_FOR));
     }
 
     /// `git worktree add` on the same path brings the checkout back; the row
@@ -236,10 +253,12 @@ mod tests {
     fn the_wait_counts_down_to_the_next_batch() {
         let now = Instant::now();
         let mut cache = LivenessCache::default();
+        assert_eq!(cache.wait(now), None, "nothing to wake up for before the first batch");
+
         cache.adopt(vec![(p("/a"), Liveness::Present)], now);
 
-        assert_eq!(cache.wait(now + FRESH_FOR / 2), FRESH_FOR / 2);
+        assert_eq!(cache.wait(now + FRESH_FOR / 2), Some(FRESH_FOR / 2));
         // An overdue tick asks for the next frame, not a negative span.
-        assert_eq!(cache.wait(now + FRESH_FOR * 2), Duration::ZERO);
+        assert_eq!(cache.wait(now + FRESH_FOR * 2), Some(Duration::ZERO));
     }
 }

--- a/alacritree/src/worktree_liveness.rs
+++ b/alacritree/src/worktree_liveness.rs
@@ -1,0 +1,205 @@
+//! Whether a worktree's checkout is still on disk, for the sidebar's benefit.
+//!
+//! `Project::discover` owns `Worktree::prunable` and stays the only writer of
+//! it: the delete flow reads that flag to choose between `git worktree remove`
+//! and a prune, and `Project::apply` reads it to decide which rows survive a
+//! refresh.  This cache never touches it.  It answers one question — "should
+//! this row paint as gone?" — so a wrong answer costs a frame of styling and
+//! can never pick a destructive branch.  Every action stats the path itself at
+//! the moment it runs.
+//!
+//! Cost is the whole design.  Probing is a syscall per path, and on a
+//! `\\wsl.localhost\` UNC path that is a 9P round trip, so probes run on a
+//! worker, one batch at a time, only for rows the sidebar is drawing, and only
+//! once per interval.  `wants_probe` is what the paint path asks first: on the
+//! other ~89 frames of every 90 it is false and nothing here allocates.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// How long a batch of results stands before the visible rows are checked
+/// again.  Matches `git_status::StatusCache`, which answers the same "did this
+/// worktree change under us" question at the same human timescale.
+pub const FRESH_FOR: Duration = Duration::from_millis(1500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Liveness {
+    Present,
+    Missing,
+    /// The probe failed for a reason other than "not found" — a distro that
+    /// did not answer, a permission error.  Distinct from `Missing` because a
+    /// filesystem that cannot be reached is not a filesystem without the
+    /// directory, and greying the row on that would be a lie.
+    Unknown,
+}
+
+/// Read `path`'s state.  `metadata` rather than `is_dir` so the difference
+/// between "not there" and "could not tell" survives: `is_dir` folds every
+/// error into `false`.
+pub fn probe(path: &Path) -> Liveness {
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_dir() => Liveness::Present,
+        // Something is there but cannot host a shell, which is all the flag
+        // governs.
+        Ok(_) => Liveness::Missing,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Liveness::Missing,
+        Err(_) => Liveness::Unknown,
+    }
+}
+
+/// Probe results keyed by worktree path, plus when the next batch is due.
+/// Entries live only as long as the sidebar keeps drawing their path, so a
+/// project the user removes does not leave its worktrees behind.
+#[derive(Default)]
+pub struct LivenessCache {
+    states: HashMap<PathBuf, Liveness>,
+    /// `None` until the first batch lands, which is what makes the first
+    /// painted frame probe rather than wait out an interval.
+    next_probe: Option<Instant>,
+}
+
+impl LivenessCache {
+    /// Whether `path` is gone, or `None` when no definite answer exists and
+    /// the row should keep discovery's word.  A definite answer overrides that
+    /// word in *both* directions: a checkout restored under a path discovery
+    /// last saw as pruned has to lose the grey, or this fixes one stale
+    /// direction and leaves its mirror image behind.
+    pub fn missing(&self, path: &Path) -> Option<bool> {
+        match self.states.get(path)? {
+            Liveness::Present => Some(false),
+            Liveness::Missing => Some(true),
+            Liveness::Unknown => None,
+        }
+    }
+
+    /// Whether the interval has elapsed.  The sidebar asks this *before* it
+    /// starts collecting the paths it draws, so a steady frame does no work
+    /// and makes no allocation on this path at all.
+    pub fn wants_probe(&self, now: Instant) -> bool {
+        self.next_probe.is_none_or(|due| now >= due)
+    }
+
+    /// Take the batch to probe, forgetting every path the sidebar no longer
+    /// draws.  All visible paths go in together: they are checked on one
+    /// worker, so splitting them by individual freshness would buy nothing.
+    pub fn batch(&mut self, visible: &[PathBuf]) -> Vec<PathBuf> {
+        self.states.retain(|path, _| visible.contains(path));
+        visible.to_vec()
+    }
+
+    /// An `Unknown` result keeps whatever the last definite answer was: a
+    /// distro that stops answering must not silently grey out every row it
+    /// owns.  The interval restarts either way, so an unreachable path is
+    /// retried on the tick rather than on every frame.
+    pub fn adopt(&mut self, results: Vec<(PathBuf, Liveness)>, now: Instant) {
+        for (path, state) in results {
+            match state {
+                Liveness::Unknown => {
+                    self.states.entry(path).or_insert(Liveness::Unknown);
+                },
+                definite => {
+                    self.states.insert(path, definite);
+                },
+            }
+        }
+        self.next_probe = Some(now + FRESH_FOR);
+    }
+
+    /// How long until the next batch is due, for `request_repaint_after`.
+    /// Without that wake-up the sidebar would only re-probe when something
+    /// else happened to draw a frame, and a worktree deleted from an otherwise
+    /// idle terminal would stay marked live indefinitely.
+    pub fn wait(&self, now: Instant) -> Duration {
+        self.next_probe.map_or(Duration::ZERO, |due| due.saturating_duration_since(now))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn the_first_frame_probes_rather_than_waiting_out_an_interval() {
+        assert!(LivenessCache::default().wants_probe(Instant::now()));
+    }
+
+    #[test]
+    fn a_batch_holds_the_interval_shut_until_it_expires() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Present)], now);
+
+        assert!(!cache.wants_probe(now + FRESH_FOR / 2), "the steady frame does nothing");
+        assert!(cache.wants_probe(now + FRESH_FOR));
+    }
+
+    #[test]
+    fn only_a_definite_answer_greys_the_row() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+
+        cache.adopt(vec![(p("/a"), Liveness::Present)], now);
+        assert_eq!(cache.missing(&p("/a")), Some(false));
+
+        cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
+        assert_eq!(cache.missing(&p("/a")), Some(true));
+    }
+
+    /// A distro that stops answering turns every path it owns `Unknown`.
+    /// Letting that grey the rows would report a deleted worktree every time
+    /// WSL hiccups.
+    #[test]
+    fn an_unknown_result_leaves_the_last_answer_standing() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
+
+        cache.adopt(vec![(p("/a"), Liveness::Unknown)], now + FRESH_FOR);
+
+        assert_eq!(cache.missing(&p("/a")), Some(true), "the last definite answer stands");
+        assert!(
+            !cache.wants_probe(now + FRESH_FOR),
+            "but the failed probe still restarts the tick"
+        );
+    }
+
+    /// `git worktree add` on the same path brings the checkout back; the row
+    /// has to lose the grey again rather than stay marked gone.
+    #[test]
+    fn a_path_that_reappears_goes_back_to_present() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
+
+        cache.adopt(vec![(p("/a"), Liveness::Present)], now + FRESH_FOR);
+
+        assert_eq!(cache.missing(&p("/a")), Some(false));
+    }
+
+    #[test]
+    fn a_path_the_sidebar_stopped_drawing_is_forgotten() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
+
+        assert_eq!(cache.batch(&[p("/b")]), vec![p("/b")]);
+
+        assert_eq!(cache.missing(&p("/a")), None, "the entry went with the row");
+    }
+
+    #[test]
+    fn the_wait_counts_down_to_the_next_batch() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Present)], now);
+
+        assert_eq!(cache.wait(now + FRESH_FOR / 2), FRESH_FOR / 2);
+        // An overdue tick asks for the next frame, not a negative span.
+        assert_eq!(cache.wait(now + FRESH_FOR * 2), Duration::ZERO);
+    }
+}

--- a/alacritree/src/worktree_liveness.rs
+++ b/alacritree/src/worktree_liveness.rs
@@ -52,6 +52,15 @@ pub fn probe(path: &Path) -> Liveness {
     }
 }
 
+/// Whether git would call this checkout gone.  The single question the row,
+/// the activate guard, the spawn guard and discovery all ask, so a greyed row
+/// and a refused shell never disagree about the same directory.  A probe that
+/// could not tell answers `false`: an unreachable filesystem must not turn
+/// into a refusal.
+pub fn is_gone(path: &Path) -> bool {
+    probe(path) == Liveness::Missing
+}
+
 /// Probe results keyed by worktree path, plus when the next batch is due.
 /// Entries live only as long as the sidebar keeps drawing their path, so a
 /// project the user removes does not leave its worktrees behind.

--- a/alacritree/src/worktree_liveness.rs
+++ b/alacritree/src/worktree_liveness.rs
@@ -34,15 +34,19 @@ pub enum Liveness {
     Unknown,
 }
 
-/// Read `path`'s state.  `metadata` rather than `is_dir` so the difference
-/// between "not there" and "could not tell" survives: `is_dir` folds every
-/// error into `false`.
+/// Whether `path` is still a worktree checkout, which is `.git`'s presence
+/// rather than the directory's.  `git worktree remove` deletes the contents
+/// first and only then the directory itself, so a remove that loses the last
+/// step — the usual outcome on Windows, where a shell sitting in the directory
+/// pins it — leaves an empty husk behind.  Git calls that worktree gone and
+/// refuses to remove it twice ("validation failed: '<path>/.git' does not
+/// exist"); stat'ing the directory would call it alive.
+///
+/// `metadata` rather than `exists` so the difference between "not there" and
+/// "could not tell" survives: `exists` folds every error into `false`.
 pub fn probe(path: &Path) -> Liveness {
-    match std::fs::metadata(path) {
-        Ok(meta) if meta.is_dir() => Liveness::Present,
-        // Something is there but cannot host a shell, which is all the flag
-        // governs.
-        Ok(_) => Liveness::Missing,
+    match std::fs::metadata(path.join(".git")) {
+        Ok(_) => Liveness::Present,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Liveness::Missing,
         Err(_) => Liveness::Unknown,
     }
@@ -121,6 +125,33 @@ mod tests {
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
+    }
+
+    #[test]
+    fn a_checkout_with_its_git_link_is_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".git"), "gitdir: /somewhere/.git/worktrees/x").unwrap();
+
+        assert_eq!(probe(dir.path()), Liveness::Present);
+    }
+
+    /// `git worktree remove` deletes the contents and only then the directory,
+    /// so on Windows a shell sitting in it leaves this behind.  Git treats the
+    /// worktree as gone; stat'ing the directory would not.
+    #[test]
+    fn the_husk_left_by_a_half_finished_remove_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert_eq!(probe(dir.path()), Liveness::Missing);
+    }
+
+    #[test]
+    fn a_checkout_deleted_outright_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        drop(dir);
+
+        assert_eq!(probe(&path), Liveness::Missing);
     }
 
     #[test]


### PR DESCRIPTION
Deleting a worktree from inside one of its own shells leaves the sidebar
lying. On Windows `git worktree remove` deletes the contents — `.git`
included — and then fails to remove the directory itself, because a shell
sitting in it holds the handle. Git considers that worktree gone. The row
kept offering it, and clicking it produced an error pane that replaced the
terminal permanently, with no way back.

## What changed

**The error is dismissible.** A failed spawn shows a modal you can close
and hands the workspace back, instead of stranding you on one with no
shell.

**A vanished checkout is judged by its `.git`, not its directory.** An
empty husk is what a half-finished remove leaves behind; `is_dir` calls it
alive and git calls it gone. The row's styling, the activate guard, the
spawn guard and the delete flow all ask that one question now, so a greyed
row and a refused shell never disagree.

**Rows that lost their checkout go grey rather than disappearing** while
they still hold sessions, so the shells living there stay reachable.

Liveness is a `stat` per visible row, so it runs on a worker, only for rows
the sidebar actually painted, once per 1.5 s tick, and never for
`\wsl.localhost\` paths — stat'ing one boots the distro's 9P server and
would hold a VM resident for as long as its worktrees are listed. The tick
is armed only for 10 s after the last input, so an idle window costs
nothing. `[ui] worktree_liveness = false` turns it off.

## Review

Two independent reviewers (Codex `gpt-5.6-sol`, and a second model
red-teaming the diff) went over the branch; the last commit acts on what
they found:

- A probe frame that painted nothing eligible left the interval open, so
  `wait` returned zero and `request_repaint_after` asked for the next frame
  on every frame — a continuous repaint for the whole grace window. `wait`
  now returns `Option<Duration>`.
- `poll_project_refreshes` cloned every session's working directory into a
  set on every frame before checking whether any discovery had finished.
- Named profiles reached the terminal below the vanished-checkout guard and
  could open a shell where Ctrl+T refuses.
- `worktree_gone` took the first sidebar row matching a path, so two
  projects listing the same path made the answer depend on sidebar order.
- An `Unknown` probe kept the row claiming a checkout was gone while the
  spawn guard, which will not call an unreadable path missing, allowed it.

---

Written with Claude Opus 5 in Claude Code.
