### PR TITLE
feat(font): grow over-wide icons into trailing blanks [5]

### DIFF
--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -988,11 +988,13 @@ impl AlacritreeApp {
     /// drops a result the backend could not vouch for and keeps `expanded`,
     /// the shell override, and the label either way.
     fn poll_project_refreshes(&mut self) {
+        let occupied: HashSet<PathBuf> =
+            self.sessions.iter().filter_map(|s| s.working_directory.clone()).collect();
         let projects = &mut self.projects;
         self.project_refreshes.poll(|root, found| {
             match projects.iter_mut().find(|p| p.root == *root) {
                 Some(project) => {
-                    project.apply(found);
+                    project.apply(found, &occupied);
                     Ok(project_json(project))
                 },
                 None => Err(format!("{} is not a project in the sidebar", root.display())),
@@ -1156,7 +1158,9 @@ impl AlacritreeApp {
         // The dir can vanish between discovery marking the row live and the
         // click. Switching first would strand the user on a dead workspace
         // with a failed spawn — stay put and let the sidebar re-mark the row.
-        if !path.is_dir() {
+        // Shells already running there are the exception: they outlive the
+        // directory, and this row is the only way back to them.
+        if !path.is_dir() && !self.workspace_has_sessions(&Some(path.to_path_buf())) {
             self.error_dialog =
                 Some("worktree directory is missing — prune it from the sidebar".to_string());
             if let Some(idx) =
@@ -1183,8 +1187,9 @@ impl AlacritreeApp {
         if self.active_session_index().is_some() {
             return;
         }
-        if let Err(e) = self.spawn_session(ctx, self.current_workspace.clone()) {
-            self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+        let ws = self.current_workspace.clone();
+        if let Err(e) = self.spawn_session(ctx, ws.clone()) {
+            self.report_spawn_failure(ctx, &ws, &e);
             return;
         }
         // Filling in a missing active entry is self-healing, not navigation.
@@ -1235,8 +1240,8 @@ impl AlacritreeApp {
         if verdict != CloseFallback::Stay
             && self.config.ui.last_session_close == LastSessionClose::Respawn
         {
-            if let Err(e) = self.spawn_session(ctx, workspace) {
-                self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+            if let Err(e) = self.spawn_session(ctx, workspace.clone()) {
+                self.report_spawn_failure(ctx, &workspace, &e);
             }
             return;
         }
@@ -1365,6 +1370,22 @@ impl AlacritreeApp {
         Ok(target)
     }
 
+    /// Report a failed spawn, and re-run discovery when the cause was a
+    /// vanished checkout: git may have forgotten the worktree entirely, in
+    /// which case the row should go rather than keep offering a shell that
+    /// cannot start.
+    fn report_spawn_failure(&mut self, ctx: &Context, ws: &WorkspaceKey, e: &std::io::Error) {
+        self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+        let Some(path) = ws.as_deref().filter(|p| !p.is_dir()) else {
+            return;
+        };
+        if let Some(idx) =
+            self.projects.iter().position(|p| p.worktrees.iter().any(|w| w.path == path))
+        {
+            self.refresh_project(ctx, idx);
+        }
+    }
+
     fn workspace_session_indices(&self, ws: &WorkspaceKey) -> Vec<usize> {
         self.sessions
             .iter()
@@ -1454,9 +1475,10 @@ impl AlacritreeApp {
         let mut order: Vec<WorkspaceKey> = vec![None];
         for project in &self.projects {
             for wt in &project.worktrees {
-                // Prunable rows can't host a shell; cycling into one would
-                // just bounce off the activate guard on every keypress.
-                if !wt.prunable {
+                // Prunable rows can't host a *new* shell; cycling into one
+                // would just bounce off the activate guard on every keypress.
+                // One that still holds shells is a real stop on the ring.
+                if !wt.prunable || self.workspace_has_sessions(&Some(wt.path.clone())) {
                     order.push(Some(wt.path.clone()));
                 }
             }
@@ -2471,8 +2493,8 @@ impl AlacritreeApp {
             },
             BindingAction::Named(NamedAction::SpawnNewInstance) => {
                 let ws = self.current_workspace.clone();
-                if let Err(e) = self.spawn_session(ctx, ws) {
-                    self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+                if let Err(e) = self.spawn_session(ctx, ws.clone()) {
+                    self.report_spawn_failure(ctx, &ws, &e);
                 }
             },
             BindingAction::Named(NamedAction::Quit) => {
@@ -3039,8 +3061,8 @@ impl AlacritreeApp {
         if spawn_default {
             let ctx = ui.ctx().clone();
             let ws = self.current_workspace.clone();
-            if let Err(e) = self.spawn_session(&ctx, ws) {
-                self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+            if let Err(e) = self.spawn_session(&ctx, ws.clone()) {
+                self.report_spawn_failure(&ctx, &ws, &e);
             }
         }
         if let Some(name) = spawn_profile {
@@ -3760,11 +3782,11 @@ impl AlacritreeApp {
             // hands the workspace back rather than stranding the user on one
             // with no shell — the same reasoning as `activate_worktree`.
             let previous = std::mem::replace(&mut self.current_workspace, ws.clone());
-            match self.spawn_session(ctx, ws) {
+            match self.spawn_session(ctx, ws.clone()) {
                 Ok(_) => workspace_activated = true,
                 Err(e) => {
                     self.current_workspace = previous;
-                    self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+                    self.report_spawn_failure(ctx, &ws, &e);
                 },
             }
         }
@@ -6517,7 +6539,9 @@ fn worktree_row(
         ui.scroll_to_rect(full_rect, None);
     }
     WorktreeAction {
-        activate: !deleting && resp.clicked() && !delete_clicked && !spawn_clicked && !wt.prunable,
+        // A prunable row is still worth clicking when shells are homed there;
+        // `activate_worktree` turns the ones that aren't into the prune hint.
+        activate: !deleting && resp.clicked() && !delete_clicked && !spawn_clicked,
         delete: delete_clicked,
         spawn: spawn_clicked,
         set_base: set_base_clicked,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -46,6 +46,7 @@ use crate::state::{self, PersistedProject};
 use crate::terminal_view;
 use crate::upstream::UpstreamState;
 use crate::worktree::{self as wt, CreateRequest, Progress};
+use crate::worktree_liveness;
 use crate::wsl::{self, ShellChoice};
 use crate::wsl_helper::{self, WslProbe};
 
@@ -354,6 +355,12 @@ fn project_filter_toggles(pr_status: bool) -> &'static [char] {
 /// The toggle identities the git panel accepts: modified, deleted, untracked.
 const GIT_FILTER_TOGGLES: &[char] = &['m', 'd', 'u'];
 
+/// How long after the user's last event the worktree liveness tick keeps
+/// asking for frames.  Long enough that a `git worktree remove` typed at a
+/// prompt finishes and greys its row; short enough that a window left open
+/// goes back to producing no frames at all.
+const PROBE_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// The projects-panel toggle a named action flips, or `None` for an action that
 /// is not one of its filters.  `PanelFilter::toggle` ignores an identity it does
 /// not allow and dispatch falls through on an unmatched action, so nothing at
@@ -562,6 +569,15 @@ pub struct AlacritreeApp {
     /// `pending_project_refresh` — resolved off the UI thread, adopted in
     /// `wsl_delta_path`.
     pending_delta: HashMap<String, Receiver<Option<String>>>,
+    /// Row styling only — never `Worktree::prunable`, which the delete flow
+    /// reads to choose between removing a worktree and pruning it.
+    liveness: worktree_liveness::LivenessCache,
+    /// The probe worker in flight, if any.  One at a time: a path slower than
+    /// the interval stretches freshness rather than queueing more work.
+    liveness_probe: Option<Receiver<Vec<(PathBuf, worktree_liveness::Liveness)>>>,
+    /// When the user last gave the app an event.  Timed wake-ups are armed
+    /// only just after one, so an app left open overnight goes fully quiet.
+    last_input: Instant,
     /// Rows behind the last-built focus snapshot. Paint reuses this until the
     /// next rebuild instead of recomputing the projection every frame.
     sidebar_rows_cache: Option<Vec<SidebarRow>>,
@@ -876,6 +892,9 @@ impl AlacritreeApp {
             project_refreshes: Default::default(),
             wsl_delta_paths: HashMap::new(),
             pending_delta: HashMap::new(),
+            liveness: Default::default(),
+            liveness_probe: None,
+            last_input: Instant::now(),
             sidebar_rows_cache: None,
             sidebar_focus_prev: None,
             sidebar_anchor: None,
@@ -974,6 +993,53 @@ impl AlacritreeApp {
             ctx.request_repaint();
         });
         self.project_refreshes.start(root, rx);
+    }
+
+    /// Keep the worktree rows the sidebar just drew honest about whether their
+    /// checkout is still there.  Discovery only re-runs when something asks it
+    /// to, so a `git worktree remove` typed into one of our own sessions would
+    /// otherwise leave the row looking live until the user pressed refresh.
+    ///
+    /// `request_repaint_after` is what carries the tick across a terminal that
+    /// has gone quiet — egui paints on demand, so without it the probe would
+    /// never run a second time.  It is armed only for a short window after the
+    /// user last touched the app, because an unconditional 1.5 s wake-up is
+    /// not just a repaint: every frame runs `StatusCache::poll` and
+    /// `PrCache::poll` from the git sidebar's paint, both on the same
+    /// staleness interval, so a permanent heartbeat would spawn a git status
+    /// walk and a `gh` lookup forever on an app nobody is using.
+    fn poll_worktree_liveness(&mut self, ctx: &Context, drawn: &[PathBuf]) {
+        let now = Instant::now();
+        match self.liveness_probe.as_ref().map(Receiver::try_recv) {
+            Some(Ok(results)) => {
+                self.liveness.adopt(results, now);
+                self.liveness_probe = None;
+            },
+            // A worker still running is the backpressure: a path slower than
+            // the interval stretches freshness instead of stacking up probes,
+            // and its own `request_repaint` brings us back here.
+            Some(Err(TryRecvError::Empty)) => return,
+            Some(Err(TryRecvError::Disconnected)) => self.liveness_probe = None,
+            None => {},
+        }
+
+        if !drawn.is_empty() {
+            let batch = self.liveness.batch(drawn);
+            let (tx, rx) = mpsc::channel();
+            let ctx = ctx.clone();
+            std::thread::spawn(move || {
+                let results =
+                    batch.iter().map(|p| (p.clone(), worktree_liveness::probe(p))).collect();
+                let _ = tx.send(results);
+                ctx.request_repaint();
+            });
+            self.liveness_probe = Some(rx);
+            return;
+        }
+
+        if self.config.ui.worktree_liveness && self.last_input.elapsed() < PROBE_GRACE {
+            ctx.request_repaint_after(self.liveness.wait(now));
+        }
     }
 
     /// Re-run worktree discovery for every project — the keyboard/IPC
@@ -3072,6 +3138,15 @@ impl AlacritreeApp {
     }
 
     fn show_project_sidebar(&mut self, ctx: &Context, panel_frame: Frame) -> egui::Rect {
+        // Only rows that actually paint are worth a liveness probe, and which
+        // ones those are is not known until the tree, its filters and its
+        // collapsed projects have all had their say.  Deciding *before* the
+        // walk that this frame is not a probe frame is what keeps the other
+        // ~89 frames of every 90 from collecting anything at all.
+        let probing = self.config.ui.worktree_liveness
+            && self.liveness_probe.is_none()
+            && self.liveness.wants_probe(Instant::now());
+        let drawn_worktrees: std::cell::RefCell<Vec<PathBuf>> = Default::default();
         let activate_request: std::cell::Cell<Option<PathBuf>> = std::cell::Cell::new(None);
         let delete_request: std::cell::Cell<Option<PathBuf>> = std::cell::Cell::new(None);
         let create_request: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
@@ -3645,9 +3720,23 @@ impl AlacritreeApp {
                                 );
                                 let wt_scroll = scrolls(is_cursor);
                                 let is_deleting = deleting_paths.contains(&wt.path);
+                                // A `\\wsl.localhost\` stat boots the distro's
+                                // 9P server, so probing one would restart a VM
+                                // the user had shut down and hold it resident
+                                // for as long as its worktrees are listed.
+                                // WSL rows keep discovery's word.
+                                if probing
+                                    && matches!(
+                                        wsl::classify(&wt.path),
+                                        wsl::Location::Windows(_)
+                                    )
+                                {
+                                    drawn_worktrees.borrow_mut().push(wt.path.clone());
+                                }
                                 let action = worktree_row(
                                     ui,
                                     wt,
+                                    self.liveness.missing(&wt.path),
                                     worktree_labels
                                         .get(idx)
                                         .and_then(|v| v.get(wt_idx))
@@ -3790,6 +3879,7 @@ impl AlacritreeApp {
                 },
             }
         }
+        self.poll_worktree_liveness(ctx, &drawn_worktrees.into_inner());
         if self.config.ui.sidebar_click_focus {
             // A click that picks a workspace or session means "go work
             // there", so it focuses the terminal; other panel clicks focus
@@ -6348,6 +6438,11 @@ fn upstream_badge<'a>(
 fn worktree_row(
     ui: &mut egui::Ui,
     wt: &Worktree,
+    // What the liveness probe has seen since discovery ran, if anything.
+    // `Some` overrides `wt.prunable` in both directions; `None` leaves it
+    // standing.  Kept out of the flag itself because that also picks between
+    // `git worktree remove` and a prune, and a probe must never decide that.
+    missing: Option<bool>,
     display_name: &str,
     pr: Option<&PrInfo>,
     is_active: bool,
@@ -6372,6 +6467,9 @@ fn worktree_row(
     // The leading and trailing groups run as sibling closures, so the status
     // slot's hint travels out separately and joins the rest afterwards.
     let mut status_hint = None;
+    // Discovery's word, corrected by whatever the probe has seen since.  The
+    // main worktree is never offered for pruning, so it never greys either.
+    let prunable = missing.map_or(wt.prunable, |gone| gone && !wt.is_main);
     // right: 0 keeps the worktree `×` at the same x as the project row's `×`,
     // which has no frame margin and sits flush against the panel's outer padding.
     let frame = Frame::default().inner_margin(Margin { left: 16, right: 0, top: 3, bottom: 3 });
@@ -6382,7 +6480,7 @@ fn worktree_row(
             } else {
                 (&icons.worktree, DEFAULT_WORKTREE_ICON)
             };
-            let name_color = if wt.prunable || deleting {
+            let name_color = if prunable || deleting {
                 theme.text_muted
             } else if is_active {
                 theme.text
@@ -6421,11 +6519,8 @@ fn worktree_row(
                         return;
                     }
                     if !wt.is_main {
-                        let hover = if wt.prunable {
-                            "prune worktree"
-                        } else {
-                            "delete worktree and branch"
-                        };
+                        let hover =
+                            if prunable { "prune worktree" } else { "delete worktree and branch" };
                         let btn = styled_icon_button(
                             ui,
                             &icons.delete_worktree,
@@ -6492,7 +6587,7 @@ fn worktree_row(
         hints.add(rect, hint);
     }
     let resp = hints.apply(resp, theme.icon_tooltips, |resp| {
-        if wt.prunable {
+        if prunable {
             resp.on_hover_text("worktree directory is missing — × prunes it")
         } else {
             name_tooltip(resp, display_name, name_elided, theme.sidebar_tooltips)
@@ -8098,6 +8193,9 @@ impl eframe::App for AlacritreeApp {
             .as_ref()
             .map(|_| (std::time::Instant::now(), crate::frame_log::output_wait()));
         self.grid_paint = std::time::Duration::ZERO;
+        if ctx.input(|i| !i.events.is_empty()) {
+            self.last_input = Instant::now();
+        }
         self.phases.restart();
         self.glyph_cache.begin_frame(ctx);
         self.poll_project_refreshes();
@@ -9996,7 +10094,8 @@ mod tests {
 
         let texts = texts_while_hovering(140.0, |ui| {
             worktree_row(
-                ui, &wt, &wt.name, None, true, false, false, false, None, false, &icons, &theme,
+                ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                &theme,
             );
         });
 
@@ -10156,7 +10255,8 @@ mod tests {
         let output = ctx.run(input, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 worktree_row(
-                    ui, &wt, &wt.name, None, true, false, false, false, None, false, &icons, &theme,
+                    ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                    &theme,
                 );
             });
         });
@@ -10279,6 +10379,7 @@ mod tests {
             worktree_row(
                 ui,
                 &wt,
+                None,
                 &wt.name,
                 Some(&pr),
                 true,
@@ -10587,7 +10688,8 @@ mod tests {
         let output = ctx.run(input, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 worktree_row(
-                    ui, &wt, &wt.name, None, true, false, false, false, None, false, &icons, &theme,
+                    ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                    &theme,
                 );
             });
         });
@@ -10640,7 +10742,8 @@ mod tests {
 
             let texts = texts_while_hovering(140.0, |ui| {
                 worktree_row(
-                    ui, &wt, name, None, true, false, false, false, None, false, &icons, &theme,
+                    ui, &wt, None, name, None, true, false, false, false, None, false, &icons,
+                    &theme,
                 );
             });
 
@@ -10702,6 +10805,7 @@ mod tests {
                 worktree_row(
                     ui,
                     &wt,
+                    None,
                     &wt.name,
                     Some(&pr),
                     true,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1078,9 +1078,19 @@ impl AlacritreeApp {
         ctx: &Context,
         working_directory: WorkspaceKey,
     ) -> std::io::Result<SessionId> {
-        // Before the PTY exists, so the shell can't race `doppler run`
-        // against the scope write.
         if let Some(dir) = &working_directory {
+            // A checkout git has forgotten is refused here rather than in
+            // `Session::spawn`, which can only see whether the directory
+            // exists — a half-finished `git worktree remove` leaves one that
+            // does.  Refusing here is what keeps the greyed row's promise.
+            if self.worktree_gone(dir) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("worktree is no longer checked out: {}", dir.display()),
+                ));
+            }
+            // Before the PTY exists, so the shell can't race `doppler run`
+            // against the scope write.
             self.sync_doppler_scopes(dir.clone());
         }
         let (shell, wsl_probe) = self.resolve_shell(&working_directory);
@@ -1231,7 +1241,7 @@ impl AlacritreeApp {
         // with a failed spawn — stay put and let the sidebar re-mark the row.
         // Shells already running there are the exception: they outlive the
         // directory, and this row is the only way back to them.
-        if !path.is_dir() && !self.workspace_has_sessions(&Some(path.to_path_buf())) {
+        if self.worktree_gone(path) && !self.workspace_has_sessions(&Some(path.to_path_buf())) {
             self.error_dialog =
                 Some("worktree directory is missing — prune it from the sidebar".to_string());
             if let Some(idx) =
@@ -1376,7 +1386,7 @@ impl AlacritreeApp {
         // Discovery marking can be stale; a dir deleted since the last
         // refresh should still get the prune flow, not a doomed
         // `git worktree remove`.
-        let prunable = wt.prunable || !wt.path.is_dir();
+        let prunable = wt.prunable || worktree_liveness::is_gone(&wt.path);
         self.pending_delete = Some(DeleteRequest {
             project_idx,
             worktree_path: wt.path.clone(),
@@ -1441,13 +1451,31 @@ impl AlacritreeApp {
         Ok(target)
     }
 
+    /// Whether the sidebar worktree at `path` is one git no longer recognises,
+    /// which is the single question the row's styling, this guard and the
+    /// delete flow all ask — a greyed row that still spawns a shell would be
+    /// the inconsistency this exists to remove.
+    ///
+    /// Main checkouts and non-git project roots have no `.git` link to lose,
+    /// so they fall back to the directory itself; so does a path no project
+    /// lists, which is the safe default for a caller we cannot place.
+    fn worktree_gone(&self, path: &Path) -> bool {
+        let linked = self
+            .projects
+            .iter()
+            .flat_map(|p| &p.worktrees)
+            .find(|wt| wt.path == path)
+            .is_some_and(|wt| !wt.is_main);
+        if linked { worktree_liveness::is_gone(path) } else { !path.is_dir() }
+    }
+
     /// Report a failed spawn, and re-run discovery when the cause was a
     /// vanished checkout: git may have forgotten the worktree entirely, in
     /// which case the row should go rather than keep offering a shell that
     /// cannot start.
     fn report_spawn_failure(&mut self, ctx: &Context, ws: &WorkspaceKey, e: &std::io::Error) {
         self.error_dialog = Some(format!("failed to spawn shell: {e}"));
-        let Some(path) = ws.as_deref().filter(|p| !p.is_dir()) else {
+        let Some(path) = ws.as_deref().filter(|p| self.worktree_gone(p)) else {
             return;
         };
         if let Some(idx) =

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -507,10 +507,11 @@ pub struct AlacritreeApp {
     row_labels: crate::row_label::LabelTemplates,
     config: Config,
     theme: Theme,
-    last_error: Option<String>,
-    /// A modal popup carrying a failure message the user must dismiss —
-    /// louder than `last_error`, used when a background action (e.g. a
-    /// worktree delete) fails after its dialog already closed.
+    /// A modal popup carrying a failure message the user must dismiss.  Every
+    /// failure that has no inline home lands here — a background action (e.g. a
+    /// worktree delete) that failed after its dialog closed, or a shell that
+    /// would not spawn.  Dismissing it leaves the app usable, which an error
+    /// painted over the terminal would not.
     error_dialog: Option<String>,
     quit_dialog_open: bool,
     pending_delete: Option<DeleteRequest>,
@@ -847,7 +848,6 @@ impl AlacritreeApp {
             row_labels,
             config,
             theme,
-            last_error: None,
             error_dialog: None,
             quit_dialog_open: false,
             pending_delete: None,
@@ -897,7 +897,7 @@ impl AlacritreeApp {
         }
 
         if let Err(e) = app.spawn_session(&cc.egui_ctx, None) {
-            app.last_error = Some(format!("failed to spawn shell: {e}"));
+            app.error_dialog = Some(format!("failed to spawn shell: {e}"));
         }
 
         app
@@ -1048,7 +1048,7 @@ impl AlacritreeApp {
             }
             self.active_session.insert(workspace, id);
         } else if let Err(e) = self.spawn_scratchpad(ctx, workspace) {
-            self.last_error = Some(format!("failed to open scratchpad: {e}"));
+            self.error_dialog = Some(format!("failed to open scratchpad: {e}"));
             return;
         }
         self.focus_terminal();
@@ -1104,13 +1104,13 @@ impl AlacritreeApp {
     fn spawn_profile_session(&mut self, ctx: &Context, name: &str) {
         let Some(profile) = self.config.profile(name) else {
             log::warn!("no shell profile named `{name}`");
-            self.last_error = Some(format!("no shell profile named `{name}`"));
+            self.error_dialog = Some(format!("no shell profile named `{name}`"));
             return;
         };
         let (shell, wsl_probe) = profile_session_shell(profile);
         let ws = self.current_workspace.clone();
         if let Err(e) = self.spawn_session_with_shell(ctx, ws, shell, wsl_probe) {
-            self.last_error = Some(format!("failed to spawn profile `{name}`: {e}"));
+            self.error_dialog = Some(format!("failed to spawn profile `{name}`: {e}"));
         }
     }
 
@@ -1157,9 +1157,6 @@ impl AlacritreeApp {
         // click. Switching first would strand the user on a dead workspace
         // with a failed spawn — stay put and let the sidebar re-mark the row.
         if !path.is_dir() {
-            // This is recoverable from the sidebar, so use the dismissible
-            // dialog instead of replacing the terminal with `last_error`
-            // forever.
             self.error_dialog =
                 Some("worktree directory is missing — prune it from the sidebar".to_string());
             if let Some(idx) =
@@ -1187,7 +1184,7 @@ impl AlacritreeApp {
             return;
         }
         if let Err(e) = self.spawn_session(ctx, self.current_workspace.clone()) {
-            self.last_error = Some(format!("failed to spawn shell: {e}"));
+            self.error_dialog = Some(format!("failed to spawn shell: {e}"));
             return;
         }
         // Filling in a missing active entry is self-healing, not navigation.
@@ -1239,7 +1236,7 @@ impl AlacritreeApp {
             && self.config.ui.last_session_close == LastSessionClose::Respawn
         {
             if let Err(e) = self.spawn_session(ctx, workspace) {
-                self.last_error = Some(format!("failed to spawn shell: {e}"));
+                self.error_dialog = Some(format!("failed to spawn shell: {e}"));
             }
             return;
         }
@@ -2475,7 +2472,7 @@ impl AlacritreeApp {
             BindingAction::Named(NamedAction::SpawnNewInstance) => {
                 let ws = self.current_workspace.clone();
                 if let Err(e) = self.spawn_session(ctx, ws) {
-                    self.last_error = Some(format!("failed to spawn shell: {e}"));
+                    self.error_dialog = Some(format!("failed to spawn shell: {e}"));
                 }
             },
             BindingAction::Named(NamedAction::Quit) => {
@@ -2516,7 +2513,7 @@ impl AlacritreeApp {
                             "SpawnProfile{n}: only {} profiles configured",
                             self.config.profiles.len()
                         );
-                        self.last_error = Some(format!("SpawnProfile{n}: no such profile"));
+                        self.error_dialog = Some(format!("SpawnProfile{n}: no such profile"));
                     },
                 }
             },
@@ -3043,7 +3040,7 @@ impl AlacritreeApp {
             let ctx = ui.ctx().clone();
             let ws = self.current_workspace.clone();
             if let Err(e) = self.spawn_session(&ctx, ws) {
-                self.last_error = Some(format!("failed to spawn shell: {e}"));
+                self.error_dialog = Some(format!("failed to spawn shell: {e}"));
             }
         }
         if let Some(name) = spawn_profile {
@@ -3759,12 +3756,17 @@ impl AlacritreeApp {
         }
         if let Some(ws) = spawn_shell_request.take() {
             // Spawning activates the workspace and the new session, matching
-            // Ctrl+T and worktree-creation's open-on-done.
-            self.current_workspace = ws.clone();
-            if let Err(e) = self.spawn_session(ctx, ws) {
-                self.last_error = Some(format!("failed to spawn shell: {e}"));
+            // Ctrl+T and worktree-creation's open-on-done.  A failed spawn
+            // hands the workspace back rather than stranding the user on one
+            // with no shell — the same reasoning as `activate_worktree`.
+            let previous = std::mem::replace(&mut self.current_workspace, ws.clone());
+            match self.spawn_session(ctx, ws) {
+                Ok(_) => workspace_activated = true,
+                Err(e) => {
+                    self.current_workspace = previous;
+                    self.error_dialog = Some(format!("failed to spawn shell: {e}"));
+                },
             }
-            workspace_activated = true;
         }
         if self.config.ui.sidebar_click_focus {
             // A click that picks a workspace or session means "go work
@@ -4241,7 +4243,7 @@ impl AlacritreeApp {
                 self.active_session.insert(Some(workspace), id);
             },
             Err(e) => {
-                self.last_error = Some(format!("failed to open diff: {e}"));
+                self.error_dialog = Some(format!("failed to open diff: {e}"));
             },
         }
     }
@@ -8146,26 +8148,14 @@ impl eframe::App for AlacritreeApp {
             .show(ctx, |ui| {
                 self.show_tab_strip(ui);
 
-                if let Some(err) = self.last_error.as_deref() {
-                    // A preedit can only be finalized or cancelled by the terminal
-                    // view's event drain, so without a session view to run it the
-                    // preedit would go stale and keep shortcuts suppressed forever.
-                    self.ime.clear();
-                    ui.label(
-                        RichText::new(err)
-                            .color(rgb_to_color32(self.config.palette.normal[1]))
-                            .monospace(),
-                    );
-                    return;
-                }
-
                 if self.active_session_index().is_none() {
                     self.adopt_active_session();
                 }
 
                 let Some(idx) = self.active_session_index() else {
-                    // Same rationale as the last_error branch above: without an
-                    // active session view, no code path can advance the preedit.
+                    // A preedit can only be finalized or cancelled by the terminal
+                    // view's event drain, so without a session view to run it the
+                    // preedit would go stale and keep shortcuts suppressed forever.
                     self.ime.clear();
                     ui.label(
                         RichText::new("no session — Ctrl+T to open one").color(theme.text_dim),

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1014,6 +1014,11 @@ impl AlacritreeApp {
             Some(Ok(results)) => {
                 self.liveness.adopt(results, now);
                 self.liveness_probe = None;
+                // This runs after the rows painted, so the answers that just
+                // landed are one frame late. Without asking for that frame the
+                // new styling waits out a whole interval, or never arrives at
+                // all once the grace window has closed.
+                ctx.request_repaint();
             },
             // A worker still running is the backpressure: a path slower than
             // the interval stretches freshness instead of stacking up probes,

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1004,11 +1004,17 @@ impl AlacritreeApp {
     /// has gone quiet — egui paints on demand, so without it the probe would
     /// never run a second time.  It is armed only for a short window after the
     /// user last touched the app, because an unconditional 1.5 s wake-up is
-    /// not just a repaint: every frame runs `StatusCache::poll` and
-    /// `PrCache::poll` from the git sidebar's paint, both on the same
-    /// staleness interval, so a permanent heartbeat would spawn a git status
-    /// walk and a `gh` lookup forever on an app nobody is using.
-    fn poll_worktree_liveness(&mut self, ctx: &Context, drawn: &[PathBuf]) {
+    /// not just a repaint: every frame runs `StatusCache::poll` from the git
+    /// sidebar's paint on the same staleness interval, so a permanent
+    /// heartbeat would spawn a git status walk forever on an app nobody is
+    /// using.
+    ///
+    /// `probing` is the sidebar's decision, not a re-derivation: only it knows
+    /// whether the walk that produced `drawn` was collecting at all, and an
+    /// empty `drawn` on a probe frame ("nothing eligible painted") has to
+    /// restart the interval where an empty `drawn` on any other frame must
+    /// leave it alone.
+    fn poll_worktree_liveness(&mut self, ctx: &Context, probing: bool, drawn: &[PathBuf]) {
         let now = Instant::now();
         match self.liveness_probe.as_ref().map(Receiver::try_recv) {
             Some(Ok(results)) => {
@@ -1028,22 +1034,30 @@ impl AlacritreeApp {
             None => {},
         }
 
-        if !drawn.is_empty() {
+        if probing {
             let batch = self.liveness.batch(drawn);
-            let (tx, rx) = mpsc::channel();
-            let ctx = ctx.clone();
-            std::thread::spawn(move || {
-                let results =
-                    batch.iter().map(|p| (p.clone(), worktree_liveness::probe(p))).collect();
-                let _ = tx.send(results);
-                ctx.request_repaint();
-            });
-            self.liveness_probe = Some(rx);
-            return;
+            if batch.is_empty() {
+                // No worker will land to close the interval, so close it here.
+                self.liveness.adopt(Vec::new(), now);
+            } else {
+                let (tx, rx) = mpsc::channel();
+                let ctx = ctx.clone();
+                std::thread::spawn(move || {
+                    let results =
+                        batch.iter().map(|p| (p.clone(), worktree_liveness::probe(p))).collect();
+                    let _ = tx.send(results);
+                    ctx.request_repaint();
+                });
+                self.liveness_probe = Some(rx);
+                return;
+            }
         }
 
-        if self.config.ui.worktree_liveness && self.last_input.elapsed() < PROBE_GRACE {
-            ctx.request_repaint_after(self.liveness.wait(now));
+        if self.config.ui.worktree_liveness
+            && self.last_input.elapsed() < PROBE_GRACE
+            && let Some(wait) = self.liveness.wait(now)
+        {
+            ctx.request_repaint_after(wait);
         }
     }
 
@@ -1058,13 +1072,19 @@ impl AlacritreeApp {
     /// Adopt completed background discoveries through `Project::apply`, which
     /// drops a result the backend could not vouch for and keeps `expanded`,
     /// the shell override, and the label either way.
+    ///
+    /// Runs every frame, so the occupied-directory set is built inside the
+    /// callback: hoisting it would clone every session's path on every repaint
+    /// terminal output happened to trigger, for the discoveries that are not
+    /// running.
     fn poll_project_refreshes(&mut self) {
-        let occupied: HashSet<PathBuf> =
-            self.sessions.iter().filter_map(|s| s.working_directory.clone()).collect();
+        let sessions = &self.sessions;
         let projects = &mut self.projects;
         self.project_refreshes.poll(|root, found| {
             match projects.iter_mut().find(|p| p.root == *root) {
                 Some(project) => {
+                    let occupied: HashSet<PathBuf> =
+                        sessions.iter().filter_map(|s| s.working_directory.clone()).collect();
                     project.apply(found, &occupied);
                     Ok(project_json(project))
                 },
@@ -1077,6 +1097,21 @@ impl AlacritreeApp {
         &mut self,
         ctx: &Context,
         working_directory: WorkspaceKey,
+    ) -> std::io::Result<SessionId> {
+        let (shell, wsl_probe) = self.resolve_shell(&working_directory);
+        self.spawn_session_with_shell(ctx, working_directory, shell, wsl_probe)
+    }
+
+    /// The one path every shell reaches, which is why the checkout guard and
+    /// the Doppler sync live here rather than in `spawn_session`: a named
+    /// profile arrives with its shell already chosen and would otherwise open
+    /// in a checkout Ctrl+T refuses.
+    fn spawn_session_with_shell(
+        &mut self,
+        ctx: &Context,
+        working_directory: WorkspaceKey,
+        shell: Option<Shell>,
+        wsl_probe: Option<WslProbe>,
     ) -> std::io::Result<SessionId> {
         if let Some(dir) = &working_directory {
             // A checkout git has forgotten is refused here rather than in
@@ -1093,17 +1128,6 @@ impl AlacritreeApp {
             // against the scope write.
             self.sync_doppler_scopes(dir.clone());
         }
-        let (shell, wsl_probe) = self.resolve_shell(&working_directory);
-        self.spawn_session_with_shell(ctx, working_directory, shell, wsl_probe)
-    }
-
-    fn spawn_session_with_shell(
-        &mut self,
-        ctx: &Context,
-        working_directory: WorkspaceKey,
-        shell: Option<Shell>,
-        wsl_probe: Option<WslProbe>,
-    ) -> std::io::Result<SessionId> {
         let session = Session::spawn(
             ctx.clone(),
             &self.config,
@@ -1459,13 +1483,18 @@ impl AlacritreeApp {
     /// Main checkouts and non-git project roots have no `.git` link to lose,
     /// so they fall back to the directory itself; so does a path no project
     /// lists, which is the safe default for a caller we cannot place.
+    ///
+    /// The same path can be listed by two projects, so any row that calls it a
+    /// linked worktree decides.  Taking the first match instead would let
+    /// sidebar order pick the weaker test, and the husk of a linked checkout
+    /// would read as alive.
     fn worktree_gone(&self, path: &Path) -> bool {
         let linked = self
             .projects
             .iter()
             .flat_map(|p| &p.worktrees)
-            .find(|wt| wt.path == path)
-            .is_some_and(|wt| !wt.is_main);
+            .filter(|wt| wt.path == path)
+            .any(|wt| !wt.is_main);
         if linked { worktree_liveness::is_gone(path) } else { !path.is_dir() }
     }
 
@@ -3912,7 +3941,7 @@ impl AlacritreeApp {
                 },
             }
         }
-        self.poll_worktree_liveness(ctx, &drawn_worktrees.into_inner());
+        self.poll_worktree_liveness(ctx, probing, &drawn_worktrees.into_inner());
         if self.config.ui.sidebar_click_focus {
             // A click that picks a workspace or session means "go work
             // there", so it focuses the terminal; other panel clicks focus

--- a/alacritree/src/builtin_font.rs
+++ b/alacritree/src/builtin_font.rs
@@ -103,6 +103,14 @@ const POWERLINE_ROUND_LTR: char = '\u{e0b4}';
 const POWERLINE_ROUND_HOLLOW_LTR: char = '\u{e0b5}';
 const POWERLINE_ROUND_RTL: char = '\u{e0b6}';
 const POWERLINE_ROUND_HOLLOW_RTL: char = '\u{e0b7}';
+const POWERLINE_LOWER_LEFT_TRIANGLE: char = '\u{e0b8}';
+const POWERLINE_BACKSLASH_SEPARATOR: char = '\u{e0b9}';
+const POWERLINE_LOWER_RIGHT_TRIANGLE: char = '\u{e0ba}';
+const POWERLINE_FORWARD_SLASH_SEPARATOR: char = '\u{e0bb}';
+const POWERLINE_UPPER_LEFT_TRIANGLE: char = '\u{e0bc}';
+const POWERLINE_FORWARD_SLASH_SEPARATOR_ALT: char = '\u{e0bd}';
+const POWERLINE_UPPER_RIGHT_TRIANGLE: char = '\u{e0be}';
+const POWERLINE_BACKSLASH_SEPARATOR_ALT: char = '\u{e0bf}';
 
 /// Subset of `crossfont::Metrics` consumed by the built-in renderer.  Only
 /// the three fields actually referenced inside `box_drawing` /
@@ -141,7 +149,7 @@ pub fn is_builtin_glyph(c: char) -> bool {
         '\u{2500}'..='\u{259f}'
             | '\u{1fb00}'..='\u{1fb3b}'
             | '\u{1fb82}'..='\u{1fb8b}'
-            | POWERLINE_TRIANGLE_LTR..=POWERLINE_ROUND_HOLLOW_RTL
+            | POWERLINE_TRIANGLE_LTR..=POWERLINE_BACKSLASH_SEPARATOR_ALT
     )
 }
 
@@ -159,11 +167,15 @@ pub fn builtin_glyph(
         },
         // Powerline symbols: '','','',''
         POWERLINE_TRIANGLE_LTR..=POWERLINE_ARROW_RTL => {
-            powerline_drawing(character, metrics, offset)?
+            powerline_drawing(character, metrics, offset)
         },
         // Rounded powerline caps: '','','',''
         POWERLINE_ROUND_LTR..=POWERLINE_ROUND_HOLLOW_RTL => {
             powerline_round_drawing(character, metrics, offset)
+        },
+        // Corner triangles and diagonal separators: '','','','','','','',''
+        POWERLINE_LOWER_LEFT_TRIANGLE..=POWERLINE_BACKSLASH_SEPARATOR_ALT => {
+            powerline_corner_drawing(character, metrics, offset)
         },
         _ => return None,
     };
@@ -722,60 +734,37 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &FontDelta) -> Builti
     }
 }
 
-fn powerline_drawing(
-    character: char,
-    metrics: &Metrics,
-    offset: &FontDelta,
-) -> Option<BuiltinGlyph> {
-    let height = (metrics.line_height as i32 + offset.y as i32) as usize;
-    let width = (metrics.average_advance as i32 + offset.x as i32) as usize;
-    let extra_thickness = calculate_stroke_size(width) as i32 - 1;
+/// Pointed powerline separators (U+E0B0..=U+E0B3).
+///
+/// Upstream alacritty draws the edges at a fixed 45° and declines the character
+/// outright when that would put the tip outside the cell — a font whose cell is
+/// much taller than it is wide, as a CJK-derived face's half-width cell is.
+/// Declining hands the separator to a fallback face, which sizes it to its own
+/// em rather than the cell and overruns the neighbouring column.  The edges
+/// here converge on the cell's far edge instead, so the tip lands inside the
+/// cell at any aspect ratio and there is no case left to decline.  Windows
+/// Terminal and kitty both build these from cell proportions for the same
+/// reason.
+fn powerline_drawing(character: char, metrics: &Metrics, offset: &FontDelta) -> BuiltinGlyph {
+    let height = (metrics.line_height as i32 + offset.y as i32).max(1) as usize;
+    let width = (metrics.average_advance as i32 + offset.x as i32).max(1) as usize;
 
     let mut canvas = Canvas::new(width, height);
+    let tip_x = width as f32 - 1.;
+    // Half the cell's height, which is also the row the tip sits on.  Clamped
+    // so a one-row cell still has something to divide by.
+    let half_height = ((height as f32 - 1.) / 2.).max(1.);
+    let filled = !matches!(character, POWERLINE_ARROW_LTR | POWERLINE_ARROW_RTL);
+    // An arm's thickness is measured horizontally: the edges of a cell taller
+    // than it is wide are steep, so horizontal is near enough perpendicular.
+    let arm = calculate_stroke_size(width) as f32;
 
-    let slope = 1;
-    let top_y = 1;
-    let bottom_y = height as i32 - top_y - 1;
-
-    // Start with offset `1` and draw until the intersection of the f(x) = slope * x + 1 and
-    // g(x) = H - slope * x - 1 lines. The intersection happens when f(x) = g(x), which is at
-    // x = (H - 2) / (2 * slope).
-    let x_intersection = (height as i32 + 1) / 2 - 1;
-
-    // Don't use built-in font if we'd cut the tip too much, for example when the font is really
-    // narrow.
-    if x_intersection - width as i32 > 1 {
-        return None;
-    }
-
-    let top_line = (0..x_intersection).map(|x| line_equation(slope, x, top_y));
-    let bottom_line = (0..x_intersection).map(|x| line_equation(-slope, x, bottom_y));
-
-    // Inner lines to make arrows thicker.
-    let mut top_inner_line = (0..x_intersection - extra_thickness)
-        .map(|x| line_equation(slope, x, top_y + extra_thickness));
-    let mut bottom_inner_line = (0..x_intersection - extra_thickness)
-        .map(|x| line_equation(-slope, x, bottom_y - extra_thickness));
-
-    // NOTE: top_line and bottom_line have the same amount of iterations.
-    for (p1, p2) in top_line.zip(bottom_line) {
-        if character == POWERLINE_TRIANGLE_LTR || character == POWERLINE_TRIANGLE_RTL {
-            canvas.draw_rect(0., p1.1, p1.0 + 1., 1., COLOR_FILL);
-            canvas.draw_rect(0., p2.1, p2.0 + 1., 1., COLOR_FILL);
-        } else if character == POWERLINE_ARROW_LTR || character == POWERLINE_ARROW_RTL {
-            let p3 = top_inner_line.next().unwrap_or(p2);
-            let p4 = bottom_inner_line.next().unwrap_or(p1);
-
-            // If we can't fit the entire arrow in the cell, we cut off the tip of the arrow by
-            // drawing a rectangle between the two lines.
-            if p1.0 as usize + 1 == width {
-                canvas.draw_rect(p1.0, p1.1, 1., p2.1 - p1.1 + 1., COLOR_FILL);
-                break;
-            } else {
-                canvas.draw_rect(p1.0, p1.1, 1., p3.1 - p1.1 + 1., COLOR_FILL);
-                canvas.draw_rect(p4.0, p4.1, 1., p2.1 - p4.1 + 1., COLOR_FILL);
-            }
-        }
+    for y in 0..height {
+        // Rounded, not truncated: on an even-height cell the apex falls between
+        // two rows, and truncating leaves both of them short of the far edge.
+        let edge = (tip_x * (half_height - (y as f32 - half_height).abs()) / half_height).round();
+        let start = if filled { 0. } else { (edge + 1. - arm).max(0.) };
+        canvas.draw_rect(start, y as f32, edge + 1. - start, 1., COLOR_FILL);
     }
 
     if character == POWERLINE_TRIANGLE_RTL || character == POWERLINE_ARROW_RTL {
@@ -783,14 +772,71 @@ fn powerline_drawing(
     }
 
     let top = height as i32 + metrics.descent as i32;
-    Some(BuiltinGlyph {
+    BuiltinGlyph {
         image: canvas.into_color_image(),
         top,
         left: 0,
         height: height as i32,
         width: width as i32,
         advance: (width as i32, height as i32),
-    })
+    }
+}
+
+/// Fill the half of the cell lying on one side of a diagonal.  `backslash`
+/// picks the top-left-to-bottom-right diagonal over the other one, `fill_left`
+/// which side of it is solid.
+fn fill_diagonal_half(canvas: &mut Canvas, backslash: bool, fill_left: bool) {
+    let right = canvas.width as f32 - 1.;
+    let bottom = (canvas.height as f32 - 1.).max(1.);
+    for y in 0..canvas.height {
+        let along = y as f32 / bottom;
+        let edge = (right * if backslash { along } else { 1. - along }).round();
+        let (start, end) = if fill_left { (0., edge) } else { (edge, right) };
+        canvas.draw_rect(start, y as f32, end - start + 1., 1., COLOR_FILL);
+    }
+}
+
+/// Corner triangles and diagonal separators (U+E0B8..=U+E0BF).  Upstream
+/// alacritty leaves these to the font, where the same em-versus-cell mismatch
+/// that afflicts the pointed separators applies; Windows Terminal and kitty
+/// both draw them.  The block repeats two of its glyphs — U+E0BD is U+E0BB
+/// again and U+E0BF is U+E0B9 again — which is what the block contains, not an
+/// oversight here.
+fn powerline_corner_drawing(
+    character: char,
+    metrics: &Metrics,
+    offset: &FontDelta,
+) -> BuiltinGlyph {
+    let height = (metrics.line_height as i32 + offset.y as i32).max(1) as usize;
+    let width = (metrics.average_advance as i32 + offset.x as i32).max(1) as usize;
+
+    let mut canvas = Canvas::new(width, height);
+    let right = width as f32 - 1.;
+    let bottom = (height as f32 - 1.).max(1.);
+    let backslash = |canvas: &mut Canvas| canvas.draw_line(0., 0., right, bottom);
+    let forward_slash = |canvas: &mut Canvas| canvas.draw_line(0., bottom, right, 0.);
+
+    // In codepoint order, as the block itself runs.
+    match character {
+        POWERLINE_LOWER_LEFT_TRIANGLE => fill_diagonal_half(&mut canvas, true, true),
+        POWERLINE_BACKSLASH_SEPARATOR => backslash(&mut canvas),
+        POWERLINE_LOWER_RIGHT_TRIANGLE => fill_diagonal_half(&mut canvas, false, false),
+        POWERLINE_FORWARD_SLASH_SEPARATOR => forward_slash(&mut canvas),
+        POWERLINE_UPPER_LEFT_TRIANGLE => fill_diagonal_half(&mut canvas, false, true),
+        POWERLINE_FORWARD_SLASH_SEPARATOR_ALT => forward_slash(&mut canvas),
+        POWERLINE_UPPER_RIGHT_TRIANGLE => fill_diagonal_half(&mut canvas, true, false),
+        _ => backslash(&mut canvas), // POWERLINE_BACKSLASH_SEPARATOR_ALT
+    }
+
+    let top = height as i32 + metrics.descent as i32;
+    BuiltinGlyph {
+        image: canvas.into_color_image(),
+        top,
+        left: 0,
+        height: height as i32,
+        width: width as i32,
+        advance: (width as i32, height as i32),
+    }
 }
 
 /// Rounded powerline caps (U+E0B4..=U+E0B7).  Upstream alacritty leaves these
@@ -1141,10 +1187,6 @@ fn calculate_stroke_size(cell_width: usize) -> usize {
     cmp::max((cell_width as f32 / 8.).round() as usize, 1)
 }
 
-fn line_equation(slope: i32, x: i32, offset: i32) -> (f32, f32) {
-    (x as f32, (slope * x + offset) as f32)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1152,12 +1194,14 @@ mod tests {
     const CELL_W: usize = 10;
     const CELL_H: usize = 21;
 
-    fn metrics() -> Metrics {
-        Metrics { average_advance: CELL_W as f64, line_height: CELL_H as f64, descent: 0.0 }
+    fn glyph(c: char) -> BuiltinGlyph {
+        glyph_in(c, CELL_W, CELL_H)
     }
 
-    fn glyph(c: char) -> BuiltinGlyph {
-        builtin_glyph(c, &metrics(), &FontDelta::default(), &FontDelta::default())
+    fn glyph_in(c: char, width: usize, height: usize) -> BuiltinGlyph {
+        let metrics =
+            Metrics { average_advance: width as f64, line_height: height as f64, descent: 0.0 };
+        builtin_glyph(c, &metrics, &FontDelta::default(), &FontDelta::default())
             .unwrap_or_else(|| panic!("U+{:04X} is not drawn by the built-in font", c as u32))
     }
 
@@ -1229,6 +1273,113 @@ mod tests {
         for c in ['\u{e0b0}', '\u{e0b1}', '\u{e0b2}', '\u{e0b3}'] {
             assert!(is_builtin_glyph(c), "U+{:04X} must remain built-in", c as u32);
             glyph(c);
+        }
+    }
+
+    /// A CJK-derived font's half-width cell is far taller than it is wide.  A
+    /// separator drawn at a fixed 45° would put its tip outside such a cell, and
+    /// declining to draw it hands the character to a fallback face that sizes it
+    /// to its own em — twice the column, overrunning the neighbour.
+    #[test]
+    fn pointed_separators_are_drawn_in_a_half_width_cell() {
+        for c in ['\u{e0b0}', '\u{e0b1}', '\u{e0b2}', '\u{e0b3}'] {
+            let glyph = glyph_in(c, 6, 21);
+            assert_eq!(glyph.width, 6, "U+{:04X} width", c as u32);
+            assert_eq!(glyph.height, 21, "U+{:04X} height", c as u32);
+        }
+    }
+
+    /// The tip is what makes a separator meet the next segment cleanly, so it
+    /// has to land on the cell's far edge whatever the cell's proportions are.
+    #[test]
+    fn the_separator_tip_reaches_the_far_cell_edge_at_any_aspect() {
+        for (width, height) in [(21, 21), (10, 21), (6, 21), (7, 21), (4, 12)] {
+            let ltr = glyph_in('\u{e0b0}', width, height);
+            let mid_y = (height - 1) / 2;
+            assert_eq!(
+                alpha_at(&ltr, width - 1, mid_y),
+                255,
+                "U+E0B0 tip missing at mid height in a {width}x{height} cell"
+            );
+
+            let rtl = glyph_in('\u{e0b2}', width, height);
+            assert_eq!(
+                alpha_at(&rtl, 0, mid_y),
+                255,
+                "U+E0B2 tip missing at mid height in a {width}x{height} cell"
+            );
+        }
+    }
+
+    /// The solid separator has to cover the whole column height where it joins
+    /// the segment, or the coloured background shows through as a seam.
+    #[test]
+    fn the_solid_separator_spans_the_full_cell_height() {
+        let glyph = glyph_in('\u{e0b0}', 6, 21);
+        assert_eq!(alpha_at(&glyph, 0, 0), 255, "top-left corner must be filled");
+        assert_eq!(alpha_at(&glyph, 0, 20), 255, "bottom-left corner must be filled");
+    }
+
+    /// Every codepoint the painter is told to route through the bitmap cache
+    /// must actually produce a glyph, or the cell silently renders blank.
+    #[test]
+    fn every_claimed_powerline_codepoint_is_drawn() {
+        for c in ('\u{e0b0}'..='\u{e0bf}').filter(|c| is_builtin_glyph(*c)) {
+            glyph(c);
+        }
+        for c in '\u{e0b0}'..='\u{e0bf}' {
+            assert!(is_builtin_glyph(c), "U+{:04X} must be built-in", c as u32);
+        }
+    }
+
+    /// The corner triangles fill the half of the cell they are named for; the
+    /// opposite corner stays clear so the segment colour shows through.
+    #[test]
+    fn corner_triangles_fill_their_named_corner() {
+        let (left, right, top, bottom) = (0, CELL_W - 1, 0, CELL_H - 1);
+        for (c, filled, empty) in [
+            (POWERLINE_LOWER_LEFT_TRIANGLE, (left, bottom), (right, top)),
+            (POWERLINE_LOWER_RIGHT_TRIANGLE, (right, bottom), (left, top)),
+            (POWERLINE_UPPER_LEFT_TRIANGLE, (left, top), (right, bottom)),
+            (POWERLINE_UPPER_RIGHT_TRIANGLE, (right, top), (left, bottom)),
+        ] {
+            let glyph = glyph(c);
+            assert_eq!(
+                alpha_at(&glyph, filled.0, filled.1),
+                255,
+                "U+{:04X} corner {filled:?} must be filled",
+                c as u32
+            );
+            assert_eq!(
+                alpha_at(&glyph, empty.0, empty.1),
+                0,
+                "U+{:04X} corner {empty:?} must stay empty",
+                c as u32
+            );
+        }
+    }
+
+    /// The diagonal separators run corner to corner.  U+E0BD repeats U+E0BB and
+    /// U+E0BF repeats U+E0B9 — that is what the block contains.
+    #[test]
+    fn diagonal_separators_run_corner_to_corner() {
+        for c in ['\u{e0b9}', '\u{e0bf}'] {
+            let glyph = glyph(c);
+            assert!(alpha_at(&glyph, 0, 0) > 0, "U+{:04X} must start top-left", c as u32);
+            assert!(
+                alpha_at(&glyph, CELL_W - 1, CELL_H - 1) > 0,
+                "U+{:04X} must end bottom-right",
+                c as u32
+            );
+        }
+        for c in ['\u{e0bb}', '\u{e0bd}'] {
+            let glyph = glyph(c);
+            assert!(
+                alpha_at(&glyph, 0, CELL_H - 1) > 0,
+                "U+{:04X} must start bottom-left",
+                c as u32
+            );
+            assert!(alpha_at(&glyph, CELL_W - 1, 0) > 0, "U+{:04X} must end top-right", c as u32);
         }
     }
 }

--- a/alacritree/src/color_glyph.rs
+++ b/alacritree/src/color_glyph.rs
@@ -17,7 +17,6 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use egui::{ColorImage, Context, TextureHandle, TextureOptions};
 use swash::FontRef;
@@ -46,9 +45,10 @@ impl CachedColorGlyph {
 pub struct ColorGlyphCache {
     /// The fallback chain in egui's own consultation order.
     chain: Vec<ChainFace>,
-    /// Font files behind the chain, read on first use.  A `None` marks a file
-    /// that could not be read, so a broken font is not re-read every frame.
-    files: HashMap<PathBuf, Option<Arc<Vec<u8>>>>,
+    /// Font files behind the chain, borrowed from the mappings `fonts` already
+    /// holds.  A `None` marks a file that would not map, so a broken font is
+    /// not retried on every cache miss.
+    files: HashMap<PathBuf, Option<&'static [u8]>>,
     /// Which chain entry, if any, draws this character in colour.  `None` means
     /// egui's own glyph pipeline owns it.
     source: HashMap<char, Option<usize>>,
@@ -144,7 +144,7 @@ impl ColorGlyphCache {
             let Some(data) = load(&mut self.files, &face.path) else {
                 continue;
             };
-            let claims = FontRef::from_index(&data, face.face_index as usize)
+            let claims = FontRef::from_index(data, face.face_index as usize)
                 .is_some_and(|font| font.charmap().map(c) != 0);
             if claims {
                 return Some(i);
@@ -171,7 +171,7 @@ impl ColorGlyphCache {
         cells: u32,
     ) -> Option<(ColorImage, i32, i32)> {
         let data = load(&mut self.files, &face.path)?;
-        let font = FontRef::from_index(&data, face.face_index as usize)?;
+        let font = FontRef::from_index(data, face.face_index as usize)?;
         let glyph = font.charmap().map(c);
 
         // Ask for the glyph at the cell's height.  Outline-backed colour glyphs
@@ -245,20 +245,20 @@ impl ColorGlyphCache {
 const COLOR_SOURCES: &[Source] =
     &[Source::ColorOutline(0), Source::ColorBitmap(StrikeWith::BestFit)];
 
-/// Read a font file once and keep it, so the chain's larger faces are not
-/// re-read on every cache miss.  A file that cannot be read is remembered as
-/// unreadable rather than retried.
-fn load(files: &mut HashMap<PathBuf, Option<Arc<Vec<u8>>>>, path: &Path) -> Option<Arc<Vec<u8>>> {
-    files
-        .entry(path.to_path_buf())
-        .or_insert_with(|| match std::fs::read(path) {
-            Ok(bytes) => Some(Arc::new(bytes)),
-            Err(e) => {
-                log::debug!("could not read colour font {}: {e}", path.display());
-                None
-            },
-        })
-        .clone()
+/// Borrow the mapping `fonts::map_font_file` already holds for the face rather
+/// than reading the file again: the chain's faces are handed to egui as
+/// mappings, and a second owned copy of a 792 MB collection is 792 MB of
+/// private memory that nothing evicts.
+fn load(files: &mut HashMap<PathBuf, Option<&'static [u8]>>, path: &Path) -> Option<&'static [u8]> {
+    *files.entry(path.to_path_buf()).or_insert_with(|| match crate::fonts::map_font_file(path) {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            // Every face in the chain mapped during install and `FONT_MAPS`
+            // never evicts, so arriving here means the two have diverged.
+            log::warn!("colour font {} is in the chain but will not map: {e}", path.display());
+            None
+        },
+    })
 }
 
 /// Bilinear resample of an RGBA buffer.  Colour bitmap strikes arrive at the
@@ -305,6 +305,12 @@ fn scale_rgba(src: &[u8], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32) -> Vec
 mod tests {
     use super::*;
     use crate::config::{FontConfig, UiFont};
+
+    /// The crate's own baked face, written to a unique path per test.
+    /// `fonts::FONT_MAPS` is global and never cleared, so a test that asserts
+    /// something *about* mapping has to own the path it asserts on.
+    const FIXTURE: &[u8] =
+        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/alacritree-symbols.ttf"));
 
     fn metrics() -> Metrics {
         Metrics { average_advance: 9.0, line_height: 20.0, descent: -4.0 }
@@ -476,5 +482,24 @@ mod tests {
         assert_eq!(cache.entries.len(), 1, "budget was not enforced");
         assert!(cache.bytes > 0);
         assert_eq!(cache.entries.len(), cache.used.len(), "eviction leaked LRU bookkeeping");
+    }
+
+    /// Every chain face is already memory-mapped by `fonts::map_font_file`.
+    /// Reading it again cost 960 MB of private memory on a chain whose primary
+    /// is a 792 MB collection, so pointer identity — not equal contents — is
+    /// what this has to assert.
+    #[test]
+    fn load_returns_the_mapping_rather_than_a_copy() {
+        let path = std::env::temp_dir().join("alacritree_test_color_glyph_load.ttf");
+        std::fs::write(&path, FIXTURE).unwrap();
+
+        let mapped = crate::fonts::map_font_file(&path).expect("the fixture maps");
+        let mut files = HashMap::new();
+        let loaded = load(&mut files, &path).expect("the fixture loads");
+
+        assert!(
+            std::ptr::eq(mapped.as_ptr(), loaded.as_ptr()),
+            "load copied the file instead of borrowing the mapping"
+        );
     }
 }

--- a/alacritree/src/color_glyph.rs
+++ b/alacritree/src/color_glyph.rs
@@ -50,7 +50,8 @@ pub struct ColorGlyphCache {
     /// not retried on every cache miss.
     files: HashMap<PathBuf, Option<&'static [u8]>>,
     /// Which chain entry, if any, draws this character in colour.  `None` means
-    /// egui's own glyph pipeline owns it.
+    /// egui's own glyph pipeline owns it.  The index is what a re-render after
+    /// a budget eviction uses instead of walking the chain again.
     source: HashMap<char, Option<usize>>,
     entries: HashMap<char, CachedColorGlyph>,
     /// Monotonic tick per lookup, so eviction can pick the coldest entry
@@ -61,6 +62,11 @@ pub struct ColorGlyphCache {
     budget: usize,
     cell_size: (u32, u32),
     scale: ScaleContext,
+    /// Chain walks performed, so a test can prove a post-eviction re-render
+    /// answers from `source` instead of re-parsing every earlier face's cmap.
+    /// `usize` rather than an atomic because `claiming_index` takes `&mut self`.
+    #[cfg(test)]
+    chain_walks: usize,
 }
 
 impl ColorGlyphCache {
@@ -76,6 +82,8 @@ impl ColorGlyphCache {
             budget: budget_mb.saturating_mul(1024 * 1024),
             cell_size: (0, 0),
             scale: ScaleContext::new(),
+            #[cfg(test)]
+            chain_walks: 0,
         }
     }
 
@@ -109,16 +117,24 @@ impl ColorGlyphCache {
             self.used.insert(c, now);
             return self.entries.get(&c);
         }
-        // A character already known to have no colour artwork costs one lookup;
-        // the whole grid takes this path on every frame.
-        if self.source.get(&c) == Some(&None) {
-            return None;
-        }
-
         // Only the claiming face is considered.  Looking further down the chain
         // would rasterize from a font egui had already passed over, so the two
         // renderers would disagree about which face owns the character.
-        let index = self.claiming_index(c)?;
+        let index = match self.source.get(&c) {
+            // Known monochrome: egui's own glyph pipeline draws it.  The whole
+            // grid takes this path on every frame, so it costs one lookup.
+            Some(None) => return None,
+            // Re-render after a budget eviction.  The chain is fixed at
+            // construction, so the recorded index still names the same face.
+            Some(Some(i)) => *i,
+            None => match self.claiming_index(c) {
+                Some(i) => i,
+                None => {
+                    self.source.insert(c, None);
+                    return None;
+                },
+            },
+        };
         let face = self.chain[index].clone();
         let glyph = self.rasterize(ctx, c, &face, cell, cells.max(1));
 
@@ -139,6 +155,10 @@ impl ColorGlyphCache {
 
     /// Index of the first face whose cmap claims `c` — the same face egui picks.
     fn claiming_index(&mut self, c: char) -> Option<usize> {
+        #[cfg(test)]
+        {
+            self.chain_walks += 1;
+        }
         for i in 0..self.chain.len() {
             let face = self.chain[i].clone();
             let Some(data) = load(&mut self.files, &face.path) else {
@@ -501,5 +521,65 @@ mod tests {
             std::ptr::eq(mapped.as_ptr(), loaded.as_ptr()),
             "load copied the file instead of borrowing the mapping"
         );
+    }
+
+    /// A character no face in the chain claims must be recorded as egui's, or
+    /// the whole chain is re-walked for it on every frame it is on screen.
+    #[test]
+    fn an_unclaimed_character_is_memoized() {
+        let ctx = Context::default();
+        let path = std::env::temp_dir().join("alacritree_test_unclaimed_memo.ttf");
+        std::fs::write(&path, FIXTURE).unwrap();
+        let chain = vec![ChainFace { path, face_index: 0, color_only: false }];
+        let mut cache = ColorGlyphCache::new(chain, 10);
+
+        // The baked symbols face carries box drawing and chrome glyphs only.
+        let unclaimed = '\u{4E00}';
+        assert!(
+            cache.resolve_claiming_face(unclaimed).is_none(),
+            "the fixture claims U+4E00; this test would prove nothing"
+        );
+
+        assert!(cache.get(&ctx, unclaimed, &metrics(), 1).is_none());
+        assert_eq!(
+            cache.source.get(&unclaimed),
+            Some(&None),
+            "an unclaimed character was not recorded, so every frame re-walks the chain"
+        );
+    }
+
+    /// After an eviction the glyph must be re-rasterized from the chain index
+    /// already recorded for it, not rediscovered by re-parsing the chain.
+    #[test]
+    fn a_post_eviction_rerender_skips_the_chain_walk() {
+        let ctx = Context::default();
+        let Some(chain) = chain_with_color_fonts(&ctx) else {
+            log::warn!("no colour emoji font installed; nothing to assert");
+            return;
+        };
+
+        // `chain_with_color_fonts` proves renderability for U+1F600 alone, so
+        // the second glyph is found rather than assumed.  A throwaway cache
+        // keeps the probe out of the cache under test.
+        let mut probe = ColorGlyphCache::new(chain.clone(), 10);
+        let renderable: Vec<char> = ['\u{1F600}', '\u{1F601}', '\u{2764}', '\u{1F44D}']
+            .into_iter()
+            .filter(|c| probe.get(&ctx, *c, &metrics(), 2).is_some())
+            .collect();
+        if renderable.len() < 2 {
+            log::warn!("fewer than two renderable colour glyphs here; nothing to assert");
+            return;
+        }
+        let (first, second) = (renderable[0], renderable[1]);
+
+        // One byte of budget: each insert evicts everything but itself.
+        let mut cache = ColorGlyphCache { budget: 1, ..ColorGlyphCache::new(chain, 0) };
+        assert!(cache.get(&ctx, first, &metrics(), 2).is_some(), "first glyph did not rasterize");
+        assert!(cache.get(&ctx, second, &metrics(), 2).is_some(), "second glyph did not rasterize");
+        assert!(!cache.entries.contains_key(&first), "the first glyph was not evicted");
+
+        let walks = cache.chain_walks;
+        assert!(cache.get(&ctx, first, &metrics(), 2).is_some(), "re-render after eviction failed");
+        assert_eq!(cache.chain_walks, walks, "the chain was re-walked after an eviction");
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -1374,6 +1374,7 @@ struct RawFont {
     /// Also alacritree-only, so it belongs in `alacritree.toml` alongside
     /// `fallback`.
     color_glyphs: Option<bool>,
+    /// Alacritree-only as well, so `alacritree.toml` is its home.
     wide_glyph_growth: Option<bool>,
     color_glyph_cache_mb: Option<usize>,
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -103,6 +103,12 @@ pub struct FontConfig {
     /// through to the first fallback face that has ordinary outlines, so
     /// emoji render monochrome rather than in colour.
     pub color_glyphs: bool,
+    /// Draw an over-wide glyph across the blank cells that follow it instead
+    /// of letting it overrun them.  A Nerd Font icon is sized to its own
+    /// face's em, so on a narrow cell it is wider than the column the
+    /// terminal gave it; kitty grows such a glyph, alacritty and Windows
+    /// Terminal let it overflow.  Off keeps the overflow.
+    pub wide_glyph_growth: bool,
     /// Ceiling on the rasterized colour glyph cache.  The cache is already
     /// bounded by how many codepoints the colour fonts cover (a few thousand),
     /// but that ceiling moves with cell size and with the fallback list, so it
@@ -1054,6 +1060,7 @@ impl Default for FontConfig {
             builtin_box_drawing: true,
             fallback: Vec::new(),
             color_glyphs: true,
+            wide_glyph_growth: false,
             color_glyph_cache_mb: 10,
         }
     }
@@ -1367,6 +1374,7 @@ struct RawFont {
     /// Also alacritree-only, so it belongs in `alacritree.toml` alongside
     /// `fallback`.
     color_glyphs: Option<bool>,
+    wide_glyph_growth: Option<bool>,
     color_glyph_cache_mb: Option<usize>,
 }
 
@@ -1979,6 +1987,9 @@ impl RawConfig {
         }
         if let Some(mb) = self.font.color_glyph_cache_mb {
             font.color_glyph_cache_mb = mb;
+        }
+        if let Some(g) = self.font.wide_glyph_growth {
+            font.wide_glyph_growth = g;
         }
 
         // ---- Cursor ----
@@ -2676,6 +2687,14 @@ mod tests {
     #[test]
     fn font_fallback_defaults_empty() {
         assert!(parse("").font.fallback.is_empty());
+    }
+
+    /// Growth moves glyphs that render acceptably today, so it waits to be
+    /// asked for.
+    #[test]
+    fn wide_glyph_growth_is_off_until_asked_for() {
+        assert!(!parse("").font.wide_glyph_growth);
+        assert!(parse("[font]\nwide_glyph_growth = true").font.wide_glyph_growth);
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -103,12 +103,6 @@ pub struct FontConfig {
     /// through to the first fallback face that has ordinary outlines, so
     /// emoji render monochrome rather than in colour.
     pub color_glyphs: bool,
-    /// Draw an over-wide glyph across the blank cells that follow it instead
-    /// of letting it overrun them.  A Nerd Font icon is sized to its own
-    /// face's em, so on a narrow cell it is wider than the column the
-    /// terminal gave it; kitty grows such a glyph, alacritty and Windows
-    /// Terminal let it overflow.  Off keeps the overflow.
-    pub wide_glyph_growth: bool,
     /// Ceiling on the rasterized colour glyph cache.  The cache is already
     /// bounded by how many codepoints the colour fonts cover (a few thousand),
     /// but that ceiling moves with cell size and with the fallback list, so it
@@ -1060,7 +1054,6 @@ impl Default for FontConfig {
             builtin_box_drawing: true,
             fallback: Vec::new(),
             color_glyphs: true,
-            wide_glyph_growth: false,
             color_glyph_cache_mb: 10,
         }
     }
@@ -1374,8 +1367,6 @@ struct RawFont {
     /// Also alacritree-only, so it belongs in `alacritree.toml` alongside
     /// `fallback`.
     color_glyphs: Option<bool>,
-    /// Alacritree-only as well, so `alacritree.toml` is its home.
-    wide_glyph_growth: Option<bool>,
     color_glyph_cache_mb: Option<usize>,
 }
 
@@ -1988,9 +1979,6 @@ impl RawConfig {
         }
         if let Some(mb) = self.font.color_glyph_cache_mb {
             font.color_glyph_cache_mb = mb;
-        }
-        if let Some(g) = self.font.wide_glyph_growth {
-            font.wide_glyph_growth = g;
         }
 
         // ---- Cursor ----
@@ -2688,14 +2676,6 @@ mod tests {
     #[test]
     fn font_fallback_defaults_empty() {
         assert!(parse("").font.fallback.is_empty());
-    }
-
-    /// Growth moves glyphs that render acceptably today, so it waits to be
-    /// asked for.
-    #[test]
-    fn wide_glyph_growth_is_off_until_asked_for() {
-        assert!(!parse("").font.wide_glyph_growth);
-        assert!(parse("[font]\nwide_glyph_growth = true").font.wide_glyph_growth);
     }
 
     #[test]

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -897,6 +897,12 @@ pub struct UiTheme {
     /// from local refs only — nothing fetches, so a branch deleted on the remote
     /// still reads as tracked until something prunes.
     pub upstream_status: bool,
+    /// Re-check on a 1.5 s tick whether each listed worktree's checkout is
+    /// still on disk, so a `git worktree remove` typed into one of our own
+    /// sessions greys the row without waiting for a manual refresh.  On by
+    /// default; the escape hatch exists because the probe is a `stat` per
+    /// listed row and an exotic filesystem could make that expensive.
+    pub worktree_liveness: bool,
     /// `[ui] pr_status_concurrency`: max `gh` lookups in flight at once.
     /// Defaults to 8; clamped to ≥ 1, since a cold cache spawns one lookup
     /// per eligible worktree in a single frame and an unbounded cap would
@@ -953,6 +959,7 @@ impl Default for UiTheme {
             session_display: SessionDisplay::default(),
             pr_status: false,
             upstream_status: false,
+            worktree_liveness: true,
             pr_status_concurrency: DEFAULT_CONCURRENCY,
             icons: Icons::default(),
             focus_outline: FocusOutline::default(),
@@ -1711,6 +1718,7 @@ struct RawUi {
     scrollbar: Option<String>,
     pr_status: Option<bool>,
     upstream_status: Option<bool>,
+    worktree_liveness: Option<bool>,
     /// Max `gh` lookups in flight at once.  Defaults to 8; clamped to ≥ 1.
     pr_status_concurrency: Option<usize>,
     font: RawUiFont,
@@ -1886,6 +1894,7 @@ impl RawConfig {
             },
             pr_status: self.ui.pr_status.unwrap_or(false),
             upstream_status: self.ui.upstream_status.unwrap_or(false),
+            worktree_liveness: self.ui.worktree_liveness.unwrap_or(true),
             pr_status_concurrency: self
                 .ui
                 .pr_status_concurrency

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -38,6 +38,7 @@ pub const BOLD_ITALIC_FAMILY: &str = "alacritree_bold_italic";
 /// font that already has a glyph keeps rendering it.
 const SYMBOLS_FONT: &[u8] = include_bytes!("../assets/alacritree-symbols.ttf");
 const SYMBOLS_ID: &str = "alacritree_symbols";
+const USER_FALLBACK_ID: &str = "alacritree_fallback_";
 
 const NORMAL_FONT_ID: &str = "alacritree_terminal_normal";
 const BOLD_FONT_ID: &str = "alacritree_terminal_bold";
@@ -590,7 +591,7 @@ fn register_user_fallbacks(
             }
             continue;
         }
-        let id = format!("alacritree_fallback_{}", defs.font_data.len());
+        let id = format!("{USER_FALLBACK_ID}{}", defs.font_data.len());
         let tweak = fallback_tweak(book.primary_height_ratio, bytes, resolved.face_index);
         let data = FontData { index: resolved.face_index, tweak, ..FontData::from_static(bytes) };
         defs.font_data.insert(id.clone(), Arc::new(data));
@@ -947,6 +948,14 @@ fn build_font_definitions(
     let mut defs = FontDefinitions::default();
     let normal_face = (normal_bytes, normal_match.face_index);
 
+    // egui seeds these families with faces of its own, and they are worth
+    // keeping — `Ubuntu-Light` is what draws `√` when the terminal font cannot.
+    // But `Ubuntu-Light` also fills the legacy Adobe PUA slots, where U+F001
+    // and U+F002 hold the `fi`/`fl` ligatures, and Nerd Fonts put icons at
+    // those codepoints.  Left where egui put them they answer before anything
+    // the user configured, so they are lifted out here and appended last.
+    let bundled = take_bundled_faces(&mut defs);
+
     insert_face(&mut defs, NORMAL_FONT_ID, normal_bytes, normal_match.face_index);
     register_default_family(&mut defs, FontFamily::Monospace, NORMAL_FONT_ID);
     register_default_family(&mut defs, FontFamily::Proportional, NORMAL_FONT_ID);
@@ -997,8 +1006,27 @@ fn build_font_definitions(
 
     install_ui_font(&mut defs, ui, fonts);
     install_symbol_fallback(&mut defs, ui);
+    restore_bundled_faces(&mut defs, bundled);
 
     Some((defs, book.chain))
+}
+
+/// The families egui fills in `FontDefinitions::default()`, emptied so that
+/// registration builds each one from the configured faces alone.
+fn take_bundled_faces(defs: &mut FontDefinitions) -> Vec<(FontFamily, Vec<String>)> {
+    [FontFamily::Monospace, FontFamily::Proportional]
+        .into_iter()
+        .map(|family| {
+            let faces = std::mem::take(defs.families.entry(family.clone()).or_default());
+            (family, faces)
+        })
+        .collect()
+}
+
+fn restore_bundled_faces(defs: &mut FontDefinitions, bundled: Vec<(FontFamily, Vec<String>)>) {
+    for (family, faces) in bundled {
+        defs.families.entry(family).or_default().extend(faces);
+    }
 }
 
 /// Append every font from fontconfig's trimmed sort to `target_families` so
@@ -1061,7 +1089,7 @@ fn register_fallback_faces(
             );
             continue;
         }
-        let id = format!("alacritree_fallback_{}", defs.font_data.len());
+        let id = format!("{USER_FALLBACK_ID}{}", defs.font_data.len());
         let tweak = fallback_tweak(book.primary_height_ratio, bytes, face.face_index);
         let data = FontData { index: face.face_index, tweak, ..FontData::from_static(bytes) };
         defs.font_data.insert(id.clone(), Arc::new(data));
@@ -1988,6 +2016,51 @@ mod tests {
 
         assert_eq!(defs.font_data[NORMAL_FONT_ID].index, resolved.face_index);
         assert_eq!(chain[0].face_index, resolved.face_index);
+    }
+
+    #[test]
+    fn egui_bundled_faces_answer_after_the_configured_fallbacks() {
+        // `FontDefinitions::default()` seeds Monospace with epaint's own faces,
+        // and `Ubuntu-Light` among them fills the legacy Adobe PUA slots, where
+        // U+F001 and U+F002 hold the `fi`/`fl` ligatures.  Nerd Fonts put icons
+        // at those codepoints, so a bundled face left ahead of the configured
+        // fallbacks answers first and a magnifier draws as `fl`.  They stay in
+        // the list — epaint ships `Ubuntu-Light` for `√` and friends — but only
+        // once every configured face has had its turn.
+        let bundled = FontDefinitions::default().families[&FontFamily::Monospace].clone();
+        assert!(!bundled.is_empty(), "egui bundles a monospace family");
+
+        let fonts = SystemFonts::with_cache_dir(None);
+        let Some(family) = fonts.db().faces().find_map(|face| {
+            let name = face.families.first().map(|(name, _)| name.clone())?;
+            resolve_face(&name, None, Variant::Normal, &fonts).map(|_| name)
+        }) else {
+            // Nothing installed resolves here; there is no chain to order.
+            return;
+        };
+
+        let path = write_parseable_font("alacritree_test_bundled_last.ttf");
+        let config = crate::config::FontConfig {
+            normal: crate::config::FontFace { family: Some(family), style: None },
+            fallback: vec![path.to_string_lossy().into_owned()],
+            ..Default::default()
+        };
+        let defs =
+            build_font_definitions(&config, &UiFont::default(), &fonts).expect("family resolves").0;
+        std::fs::remove_file(&path).ok();
+
+        let mono = &defs.families[&FontFamily::Monospace];
+        let configured = mono
+            .iter()
+            .position(|id| id.starts_with(USER_FALLBACK_ID))
+            .expect("the configured fallback registered");
+        for id in &bundled {
+            let at = mono
+                .iter()
+                .position(|listed| listed == id)
+                .unwrap_or_else(|| panic!("egui's bundled '{id}' was dropped, not demoted"));
+            assert!(at > configured, "egui's bundled '{id}' answers before a configured fallback");
+        }
     }
 
     #[test]

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -1143,7 +1143,7 @@ fn gather_fallback_faces(
 /// and a second `install_terminal_fonts` reuses the mappings of the first.
 static FONT_MAPS: OnceLock<Mutex<HashMap<PathBuf, &'static [u8]>>> = OnceLock::new();
 
-fn map_font_file(path: &Path) -> std::io::Result<&'static [u8]> {
+pub(crate) fn map_font_file(path: &Path) -> std::io::Result<&'static [u8]> {
     let mut maps = FONT_MAPS
         .get_or_init(Default::default)
         .lock()

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -2286,6 +2286,10 @@ mod tests {
         gather_fallback_faces("Consolas", None, Variant::Normal, &skip, 8, &fonts);
 
         assert_eq!(face_coverage_parses(), 0, "a seed already in the scan was parsed anyway");
+        assert!(
+            fonts.seed_coverage.borrow().contains_key(&(seed.path.clone(), seed.face_index)),
+            "the seed was never resolved, so a parse count of zero proves nothing"
+        );
     }
 
     /// A seed the scan cannot answer for is parsed at most once per install,

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -1128,10 +1128,7 @@ fn face_coverage_parses() -> usize {
 /// both path and face index, so the match is exact — face 0 of a collection
 /// file can be an unrelated family.
 #[cfg(not(unix))]
-fn scanned_seed_coverage(
-    fonts: &SystemFonts,
-    face: &ResolvedFace,
-) -> Option<coverage::Coverage> {
+fn scanned_seed_coverage(fonts: &SystemFonts, face: &ResolvedFace) -> Option<coverage::Coverage> {
     fonts
         .scanned_coverage()
         .iter()

--- a/alacritree/src/fonts.rs
+++ b/alacritree/src/fonts.rs
@@ -14,6 +14,8 @@
 //! symbols and box-drawing characters that aren't in the primary face.
 
 use std::cell::OnceCell;
+#[cfg(not(unix))]
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -109,6 +111,10 @@ struct SystemFonts {
     coverage: OnceCell<Vec<(coverage::Candidate, coverage::Coverage)>>,
     #[cfg(not(unix))]
     cache_location: CacheLocation,
+    /// `RefCell` rather than `OnceCell` because the map is keyed and grows;
+    /// `&self` access matches `db` and `coverage`.
+    #[cfg(not(unix))]
+    seed_coverage: RefCell<HashMap<(PathBuf, u32), Option<coverage::Coverage>>>,
 }
 
 impl SystemFonts {
@@ -145,6 +151,24 @@ impl SystemFonts {
             };
             scan_coverage(self.db(), cache_path.as_deref())
         })
+    }
+
+    /// Coverage of a resolved seed face, computed at most once per install.
+    /// The four variant seeds and the UI family commonly resolve to the same
+    /// one or two files, and a miss is cached too so an unresolvable seed is
+    /// not retried once per variant.
+    #[cfg(not(unix))]
+    fn seed_coverage(&self, face: &ResolvedFace) -> Option<coverage::Coverage> {
+        let key = (face.path.clone(), face.face_index);
+        if let Some(hit) = self.seed_coverage.borrow().get(&key) {
+            return hit.clone();
+        }
+        // The borrow above is released here, so the fallback parse cannot
+        // panic against the borrow_mut below.
+        let computed = scanned_seed_coverage(self, face)
+            .or_else(|| face_coverage(&face.path, face.face_index));
+        self.seed_coverage.borrow_mut().insert(key, computed.clone());
+        computed
     }
 }
 
@@ -1081,12 +1105,50 @@ fn cmap_coverage(face: &ttf_parser::Face) -> Option<coverage::Coverage> {
     Some(coverage::Coverage::from_codepoints(codepoints))
 }
 
+#[cfg(all(not(unix), test))]
+thread_local! {
+    /// Per-thread because the Windows fallback tests call
+    /// `gather_fallback_faces` concurrently at the default thread count, and a
+    /// process-wide count would fold their parses into whichever test asserts.
+    static FACE_COVERAGE_PARSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(all(not(unix), test))]
+fn reset_face_coverage_parses() {
+    FACE_COVERAGE_PARSES.with(|n| n.set(0));
+}
+
+#[cfg(all(not(unix), test))]
+fn face_coverage_parses() -> usize {
+    FACE_COVERAGE_PARSES.with(|n| n.get())
+}
+
+/// The scan already carries every system face and is disk-cached across
+/// launches, so a seed found here costs no parse at all.  `Candidate` carries
+/// both path and face index, so the match is exact — face 0 of a collection
+/// file can be an unrelated family.
+#[cfg(not(unix))]
+fn scanned_seed_coverage(
+    fonts: &SystemFonts,
+    face: &ResolvedFace,
+) -> Option<coverage::Coverage> {
+    fonts
+        .scanned_coverage()
+        .iter()
+        .find(|(candidate, _)| {
+            candidate.path == face.path && candidate.face_index == face.face_index
+        })
+        .map(|(_, coverage)| coverage.clone())
+}
+
 /// Coverage of an already-resolved primary face, read at its resolved face
 /// index — face 0 of a collection file can be an unrelated family.
 #[cfg(not(unix))]
 fn face_coverage(path: &Path, face_index: u32) -> Option<coverage::Coverage> {
-    let data = std::fs::read(path).ok()?;
-    let parsed = ttf_parser::Face::parse(&data, face_index).ok()?;
+    #[cfg(test)]
+    FACE_COVERAGE_PARSES.with(|n| n.set(n.get() + 1));
+    let data = map_font_file(path).ok()?;
+    let parsed = ttf_parser::Face::parse(data, face_index).ok()?;
     cmap_coverage(&parsed)
 }
 
@@ -1103,7 +1165,7 @@ fn gather_fallback_faces(
     fonts: &SystemFonts,
 ) -> Vec<FallbackFace> {
     let seed_coverage = resolve_face(family, style, variant, fonts)
-        .and_then(|face| face_coverage(&face.path, face.face_index))
+        .and_then(|face| fonts.seed_coverage(&face))
         .unwrap_or_default();
 
     let mut candidates: Vec<_> = fonts
@@ -1161,6 +1223,17 @@ pub(crate) fn map_font_file(path: &Path) -> std::io::Result<&'static [u8]> {
     let bytes: &'static [u8] = Box::leak(Box::new(mmap));
     maps.insert(path.to_path_buf(), bytes);
     Ok(bytes)
+}
+
+/// Whether `path` already has a mapping.  Test-only: nothing in the app needs
+/// to ask, and a release build should not carry the lookup.  Gated on
+/// `not(unix)` because its only caller is Windows-gated; otherwise this
+/// test-only helper is dead code on Linux.
+#[cfg(all(test, not(unix)))]
+fn is_mapped(path: &Path) -> bool {
+    FONT_MAPS.get().is_some_and(|maps| {
+        maps.lock().unwrap_or_else(std::sync::PoisonError::into_inner).contains_key(path)
+    })
 }
 
 fn insert_face(defs: &mut FontDefinitions, id: &str, bytes: &'static [u8], face_index: u32) {
@@ -2188,6 +2261,69 @@ mod tests {
         seen.sort_unstable();
         seen.dedup();
         seen
+    }
+
+    /// A seed the coverage scan already carries must not be parsed again — the
+    /// scan is disk-cached across launches and the parse is a whole-file read.
+    #[cfg(not(unix))]
+    #[test]
+    fn a_seed_present_in_the_scan_is_not_parsed_again() {
+        let fonts = SystemFonts::with_cache_dir(None);
+        let Some(seed) = resolve_face("Consolas", None, Variant::Normal, &fonts) else {
+            log::warn!("Consolas is not installed; nothing to assert");
+            return;
+        };
+        // A seed missing from the scan would pass this by falling through, so
+        // its presence is the precondition, not an assumption.
+        assert!(
+            fonts.scanned_coverage().iter().any(|(candidate, _)| candidate.path == seed.path
+                && candidate.face_index == seed.face_index),
+            "the seed is absent from the scan; this test would prove nothing"
+        );
+
+        reset_face_coverage_parses();
+        let skip = HashSet::new();
+        gather_fallback_faces("Consolas", None, Variant::Normal, &skip, 8, &fonts);
+
+        assert_eq!(face_coverage_parses(), 0, "a seed already in the scan was parsed anyway");
+    }
+
+    /// A seed the scan cannot answer for is parsed at most once per install,
+    /// however many variant chains ask for it.
+    #[cfg(not(unix))]
+    #[test]
+    fn a_seed_outside_the_scan_is_parsed_once_per_install() {
+        let fonts = SystemFonts::with_cache_dir(None);
+        let path = write_parseable_font("alacritree_test_seed_memo.ttf");
+        let family = path.to_str().expect("the temp path is utf-8");
+        let seed = resolve_face(family, None, Variant::Normal, &fonts).expect("a path resolves");
+        // An explicit path is not automatically outside the scan: a system
+        // font's own path resolves the same way, and the scan contains it.
+        assert!(
+            !fonts.scanned_coverage().iter().any(|(candidate, _)| candidate.path == seed.path
+                && candidate.face_index == seed.face_index),
+            "the fixture is in the scan; this test would prove nothing"
+        );
+
+        reset_face_coverage_parses();
+        let skip = HashSet::new();
+        gather_fallback_faces(family, None, Variant::Normal, &skip, 8, &fonts);
+        gather_fallback_faces(family, None, Variant::Normal, &skip, 8, &fonts);
+
+        assert_eq!(face_coverage_parses(), 1, "the seed was re-parsed for the second chain");
+    }
+
+    /// The fallback parse borrows the mapping like every other font read in
+    /// this module, rather than pulling a whole collection onto the heap.
+    #[cfg(not(unix))]
+    #[test]
+    fn face_coverage_maps_the_file_instead_of_reading_it() {
+        let path = write_parseable_font("alacritree_test_face_coverage_maps.ttf");
+        assert!(!is_mapped(&path), "the fixture path must be untouched by other tests");
+
+        let _ = face_coverage(&path, 0);
+
+        assert!(is_mapped(&path), "face_coverage read the file instead of mapping it");
     }
 }
 

--- a/alacritree/src/glyph_cache.rs
+++ b/alacritree/src/glyph_cache.rs
@@ -59,6 +59,34 @@ fn glyph_job(ch: char, face: Face, size: f32) -> LayoutJob {
     job
 }
 
+/// How far past its cell a glyph may reach before it counts as over-wide.
+/// Cell width is floored to whole device pixels, so an ordinary glyph's
+/// advance is routinely a fraction wider than the cell derived from it and a
+/// bare comparison would call every glyph on screen over-wide.  WezTerm
+/// allows the same 25% before it acts on a glyph.
+const OVERFLOW_SLACK: f32 = 1.25;
+
+/// Ceiling on how many extra cells one glyph may claim, mirroring kitty's
+/// `MAX_NUM_EXTRA_GLYPHS_PUA`.  A face reporting an absurd advance must not
+/// swallow the rest of the line.
+pub const MAX_EXTRA_CELLS: usize = 4;
+
+/// How many cells a laid-out glyph should be drawn across, given how many
+/// blank cells follow it.
+///
+/// A Nerd Font icon is sized to its own face's em, which on a narrow cell —
+/// a CJK-derived face's half-width advance, say — is wider than the column
+/// the terminal gave it.  kitty grows such a glyph over the blanks that
+/// follow rather than letting it overrun them; blanks are the only cells it
+/// may take, since anything else is a character it would paint over.
+pub fn grown_cells(glyph_w: f32, cell_w: f32, spare: usize) -> usize {
+    if !(glyph_w > cell_w * OVERFLOW_SLACK) || cell_w <= 0.0 {
+        return 1;
+    }
+    let wanted = (glyph_w / cell_w).ceil() as usize;
+    wanted.clamp(1, 1 + spare.min(MAX_EXTRA_CELLS))
+}
+
 /// The font atlas a set of galleys was laid out against.  A galley's mesh
 /// stores atlas positions, so it only means anything while that atlas is the
 /// one being sampled.
@@ -241,6 +269,35 @@ mod tests {
             atlas_pos(&repacked),
             "cache served a galley addressing the discarded atlas"
         );
+    }
+
+    /// The cell is floored to whole device pixels, so an ordinary glyph's
+    /// advance is routinely a shade wider than the cell measured from it.
+    #[test]
+    fn a_glyph_that_fits_its_cell_asks_for_nothing() {
+        assert_eq!(grown_cells(10.0, 10.0, 4), 1);
+        assert_eq!(grown_cells(10.4, 10.0, 4), 1, "inside the slack");
+    }
+
+    /// Growing over a cell that holds a character would draw the glyph on top
+    /// of it, which is worse than the overflow being clipped.
+    #[test]
+    fn an_over_wide_glyph_with_nowhere_to_go_stays_in_its_cell() {
+        assert_eq!(grown_cells(20.0, 10.0, 0), 1);
+    }
+
+    #[test]
+    fn an_over_wide_glyph_takes_only_the_cells_it_needs() {
+        assert_eq!(grown_cells(20.0, 10.0, 1), 2);
+        assert_eq!(grown_cells(20.0, 10.0, 4), 2, "spare cells it does not need");
+        assert_eq!(grown_cells(20.0, 10.0, 3), 2);
+    }
+
+    /// kitty's `MAX_NUM_EXTRA_GLYPHS_PUA`: a glyph reporting an absurd advance
+    /// must not swallow the rest of the line.
+    #[test]
+    fn growth_is_capped_however_much_room_there_is() {
+        assert_eq!(grown_cells(60.0, 10.0, 6), 1 + MAX_EXTRA_CELLS);
     }
 
     #[test]

--- a/alacritree/src/glyph_cache.rs
+++ b/alacritree/src/glyph_cache.rs
@@ -87,6 +87,19 @@ pub fn grown_cells(glyph_w: f32, cell_w: f32, spare: usize) -> usize {
     wanted.clamp(1, 1 + spare.min(MAX_EXTRA_CELLS))
 }
 
+/// How far right to nudge a laid-out glyph so it sits centred on the cells it
+/// was granted.
+///
+/// Never negative.  The span is capped by the blanks actually available, so a
+/// glyph can end up wider than the cells it got; centring on that span would
+/// put it left of its own cell, over the character before it.  Such a glyph
+/// stays where it started and overruns to the right, as it does with growth
+/// off.
+pub fn growth_offset(glyph_w: f32, cell_w: f32, spare: usize) -> f32 {
+    let cells = grown_cells(glyph_w, cell_w, spare);
+    ((cells as f32 * cell_w - glyph_w) / 2.0).max(0.0)
+}
+
 /// The font atlas a set of galleys was laid out against.  A galley's mesh
 /// stores atlas positions, so it only means anything while that atlas is the
 /// one being sampled.
@@ -298,6 +311,26 @@ mod tests {
     #[test]
     fn growth_is_capped_however_much_room_there_is() {
         assert_eq!(grown_cells(60.0, 10.0, 6), 1 + MAX_EXTRA_CELLS);
+    }
+
+    /// The span is capped by the blanks actually available, so a glyph can be
+    /// wider than the cells it was granted.  Centring on that span would put
+    /// it left of its own cell, over the character before it — worse than the
+    /// right-hand overrun growth exists to avoid.
+    #[test]
+    fn a_glyph_too_wide_for_the_room_it_gets_is_not_pulled_left() {
+        assert_eq!(growth_offset(25.0, 10.0, 1), 0.0);
+        assert_eq!(growth_offset(60.0, 10.0, 6), 0.0);
+    }
+
+    #[test]
+    fn a_grown_glyph_sits_centred_on_its_span() {
+        assert_eq!(growth_offset(18.0, 10.0, 1), 1.0);
+    }
+
+    #[test]
+    fn a_glyph_that_fits_is_not_nudged() {
+        assert_eq!(growth_offset(10.0, 10.0, 4), 0.0);
     }
 
     #[test]

--- a/alacritree/src/glyph_cache.rs
+++ b/alacritree/src/glyph_cache.rs
@@ -87,6 +87,26 @@ pub fn grown_cells(glyph_w: f32, cell_w: f32, spare: usize) -> usize {
     wanted.clamp(1, 1 + spare.min(MAX_EXTRA_CELLS))
 }
 
+/// Whether an over-wide glyph for `c` may be drawn across the blanks that
+/// follow it.
+///
+/// Only the private use areas, where Nerd Font and Powerline icons live.  A
+/// letter served by an over-wide fallback face is never a candidate however
+/// far it overruns, which is what makes growing safe to do unconditionally —
+/// kitty draws the same line, restricting it to private-use, symbol and
+/// dingbat codepoints from a non-primary face.
+///
+/// The two ranges held back are kitty's own `narrow_symbols` default.  Those
+/// marks read as part of the segment beside them rather than as icons in
+/// their own right, so a wider one looks wrong where a clipped one only looks
+/// cramped.
+pub fn may_grow(c: char) -> bool {
+    matches!(
+        c,
+        '\u{e000}'..='\u{f8ff}' | '\u{f0000}'..='\u{ffffd}' | '\u{100000}'..='\u{10fffd}'
+    ) && !matches!(c, '\u{e0a0}'..='\u{e0a3}' | '\u{e0c0}'..='\u{e0c7}')
+}
+
 /// How far right to nudge a laid-out glyph so it sits centred on the cells it
 /// was granted.
 ///
@@ -285,6 +305,28 @@ mod tests {
     }
 
     /// The cell is floored to whole device pixels, so an ordinary glyph's
+
+    /// Icons live in the private use areas.  Nothing else grows, whatever
+    /// face served it and however far it overruns.
+    #[test]
+    fn only_private_use_codepoints_grow() {
+        assert!(may_grow('\u{e0b0}'), "a powerline separator");
+        assert!(may_grow('\u{f057}'), "a Nerd Font icon");
+        assert!(may_grow('\u{f0000}'), "supplementary private use");
+        assert!(!may_grow('M'), "a letter");
+        assert!(!may_grow('\u{fb01}'), "a ligature from a presentation-forms block");
+        assert!(!may_grow('\u{4f60}'), "a CJK ideograph");
+    }
+
+    /// kitty's `narrow_symbols` default holds these back: they read as part of
+    /// the segment beside them, so a wider one looks wrong.
+    #[test]
+    fn the_powerline_marks_kitty_holds_back_do_not_grow() {
+        for c in ['\u{e0a0}', '\u{e0a3}', '\u{e0c0}', '\u{e0c7}'] {
+            assert!(!may_grow(c), "U+{:04X} grew", c as u32);
+        }
+        assert!(may_grow('\u{e0a4}'), "the range stops where kitty's does");
+    }
     /// advance is routinely a shade wider than the cell measured from it.
     #[test]
     fn a_glyph_that_fits_its_cell_asks_for_nothing() {

--- a/alacritree/src/main.rs
+++ b/alacritree/src/main.rs
@@ -52,6 +52,7 @@ mod terminal_view;
 mod test_util;
 mod upstream;
 mod worktree;
+mod worktree_liveness;
 mod wsl;
 mod wsl_helper;
 

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -167,7 +167,7 @@ impl Project {
                     .clone()
                     .or_else(|| rec.head.as_ref().map(|h| h.chars().take(7).collect()));
                 let wt_name = if i == 0 { "main".to_string() } else { display_name(&path) };
-                let prunable = i != 0 && !path.is_dir();
+                let prunable = i != 0 && crate::worktree_liveness::is_gone(&path);
                 let upstream = rec.branch.as_deref().and_then(|b| upstreams.get(b).cloned());
                 Worktree { name: wt_name, path, branch, is_main: i == 0, prunable, upstream }
             })
@@ -224,10 +224,12 @@ impl Project {
                     let upstream = lookup(&branch, detached);
                     worktrees.push(Worktree {
                         name: name.to_string(),
-                        // Directory existence, not git2's `is_prunable`, is
-                        // the signal: a *locked* worktree with a missing dir
-                        // is not git-prunable but still can't host a shell.
-                        prunable: !path.is_dir(),
+                        // The checkout's own `.git`, not git2's `is_prunable`: a
+                        // *locked* worktree with a missing checkout is not
+                        // git-prunable but still cannot host a shell, and a
+                        // half-finished remove leaves the directory behind
+                        // without it.
+                        prunable: crate::worktree_liveness::is_gone(&path),
                         path,
                         branch,
                         is_main: false,

--- a/alacritree/src/projects.rs
+++ b/alacritree/src/projects.rs
@@ -1,6 +1,6 @@
 //! Enumerate sidebar-added directories and their git worktrees.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use git2::Repository;
@@ -260,11 +260,25 @@ impl Project {
     /// deletion.  `expanded`, `shell_override`, and `label` are user state and
     /// are never touched either way.  One list, so a field cannot be adopted by
     /// the synchronous refresh and dropped by the background one.
-    pub fn apply(&mut self, found: Discovered) {
+    /// `occupied` names the worktrees that still host a live session.  Git
+    /// forgets a worktree the moment it is pruned, but its shells keep
+    /// running, and a row is the only way to reach them — so a dropped
+    /// worktree with sessions is kept as prunable rather than removed.
+    pub fn apply(&mut self, found: Discovered, occupied: &HashSet<PathBuf>) {
         if !found.authoritative {
             return;
         }
-        self.worktrees = found.project.worktrees;
+        let mut worktrees = found.project.worktrees;
+        let stranded: Vec<Worktree> = self
+            .worktrees
+            .drain(..)
+            .filter(|wt| {
+                occupied.contains(&wt.path) && !worktrees.iter().any(|fresh| fresh.path == wt.path)
+            })
+            .map(|wt| Worktree { prunable: true, upstream: None, ..wt })
+            .collect();
+        worktrees.extend(stranded);
+        self.worktrees = worktrees;
         self.default_branch = found.project.default_branch;
         self.home = found.project.home;
     }
@@ -540,10 +554,13 @@ mod tests {
         ];
 
         let before = project.worktrees.clone();
-        project.apply(Discovered {
-            project: Project::placeholder(project.root.clone()),
-            authoritative: false,
-        });
+        project.apply(
+            Discovered {
+                project: Project::placeholder(project.root.clone()),
+                authoritative: false,
+            },
+            &HashSet::new(),
+        );
 
         assert_eq!(project.worktrees.len(), before.len());
         assert_eq!(project.worktrees[1].name, "feature");
@@ -561,10 +578,57 @@ mod tests {
         fresh.worktrees.clear();
         fresh.default_branch = Some("main".to_string());
 
-        project.apply(Discovered { project: fresh, authoritative: true });
+        project.apply(Discovered { project: fresh, authoritative: true }, &HashSet::new());
 
         assert!(project.worktrees.is_empty());
         assert_eq!(project.default_branch.as_deref(), Some("main"));
+    }
+
+    /// `git worktree prune` drops the worktree from discovery while its shells
+    /// keep running.  Dropping the row too would leave them with nowhere to be
+    /// reached from.
+    #[test]
+    fn apply_keeps_a_dropped_worktree_that_still_holds_sessions() {
+        let mut project = Project::placeholder(PathBuf::from("/repo"));
+        project.worktrees = vec![Worktree {
+            name: "gone".to_string(),
+            path: PathBuf::from("/repo-worktrees/gone"),
+            branch: Some("feature".to_string()),
+            is_main: false,
+            prunable: false,
+            upstream: None,
+        }];
+
+        let mut fresh = Project::placeholder(PathBuf::from("/repo"));
+        fresh.worktrees.clear();
+        let occupied = HashSet::from([PathBuf::from("/repo-worktrees/gone")]);
+
+        project.apply(Discovered::found(fresh), &occupied);
+
+        let kept = project.worktrees.first().expect("the row survives its checkout");
+        assert_eq!(kept.path, PathBuf::from("/repo-worktrees/gone"));
+        assert_eq!(kept.branch.as_deref(), Some("feature"), "the branch still names the row");
+        assert!(kept.prunable, "but it can no longer host a new shell");
+    }
+
+    #[test]
+    fn apply_drops_a_worktree_once_its_last_session_is_gone() {
+        let mut project = Project::placeholder(PathBuf::from("/repo"));
+        project.worktrees = vec![Worktree {
+            name: "gone".to_string(),
+            path: PathBuf::from("/repo-worktrees/gone"),
+            branch: None,
+            is_main: false,
+            prunable: true,
+            upstream: None,
+        }];
+
+        let mut fresh = Project::placeholder(PathBuf::from("/repo"));
+        fresh.worktrees.clear();
+
+        project.apply(Discovered::found(fresh), &HashSet::new());
+
+        assert!(project.worktrees.is_empty());
     }
 
     #[test]
@@ -767,7 +831,7 @@ worktree /home/lev/wt/tmp\0HEAD 0011223344556677\0detached\0\0";
         fresh.default_branch = Some("main".to_string());
         fresh.home = Some("/home/lev".to_string());
 
-        existing.apply(Discovered::found(fresh));
+        existing.apply(Discovered::found(fresh), &HashSet::new());
 
         assert_eq!(existing.home.as_deref(), Some("/home/lev"));
         assert_eq!(existing.default_branch.as_deref(), Some("main"));

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -17,7 +17,7 @@ use crate::color_glyph::{CachedColorGlyph, ColorGlyphCache};
 use crate::colors::{background, foreground, resolve, rgb_to_color32};
 use crate::config::Config;
 use crate::fonts::{BOLD_FAMILY, BOLD_ITALIC_FAMILY, ITALIC_FAMILY};
-use crate::glyph_cache::{Face, GlyphCache, MAX_EXTRA_CELLS, growth_offset};
+use crate::glyph_cache::{Face, GlyphCache, MAX_EXTRA_CELLS, growth_offset, may_grow};
 use crate::input::event_to_bytes;
 use crate::links::{self, Link};
 use crate::mouse;
@@ -1120,10 +1120,10 @@ fn paint_run(
                 continue;
             }
             let galley = glyphs.get(ctx, ch, face, font_id.size);
-            // A glyph wider than its cell is drawn across the blanks that
-            // follow rather than over the top of them, centred on the span it
-            // ends up with, the way kitty grows one.
-            let grow_dx = if config.font.wide_glyph_growth {
+            // A private-use icon wider than its cell is drawn across the
+            // blanks that follow rather than over the top of them, centred on
+            // the span it ends up with, the way kitty grows one.
+            let grow_dx = if may_grow(ch) {
                 let spare = run[byte + ch.len_utf8()..]
                     .chars()
                     .take(MAX_EXTRA_CELLS)
@@ -1589,19 +1589,6 @@ mod tests {
     /// A context whose monospace fallback is scaled far past the primary face,
     /// so a character the primary lacks comes back several times wider than
     /// the cell — a Nerd Font icon against a half-width cell, in miniature.
-    fn ctx_with_oversized_fallback() -> egui::Context {
-        let ctx = egui::Context::default();
-        let mut fonts = egui::FontDefinitions::default();
-        let mut fallback = (*fonts.font_data["Ubuntu-Light"]).clone();
-        fallback.tweak.scale = 4.0;
-        fonts.font_data.insert("Ubuntu-Light".into(), std::sync::Arc::new(fallback));
-        let mono = fonts.families[&FontFamily::Monospace].clone();
-        for name in [BOLD_FAMILY, ITALIC_FAMILY, BOLD_ITALIC_FAMILY] {
-            fonts.families.insert(FontFamily::Name(name.into()), mono.clone());
-        }
-        ctx.set_fonts(fonts);
-        ctx
-    }
 
     /// Where each glyph of a painted frame was placed.
     fn painted_at(
@@ -1644,6 +1631,31 @@ mod tests {
             _ => {},
         }
     }
+    /// A context whose monospace fallbacks are scaled far past the primary
+    /// face, so a character the primary lacks comes back several times wider
+    /// than the cell — a Nerd Font icon against a half-width cell, in
+    /// miniature.  U+E600 arrives from the bundled icon font, U+FB01 from
+    /// Ubuntu-Light.
+    fn ctx_with_oversized_fallback() -> egui::Context {
+        let ctx = egui::Context::default();
+        let mut fonts = egui::FontDefinitions::default();
+        // Scaled to overrun by more than the slack but by less than the four
+        // extra cells growth may claim, so the icon is centred rather than
+        // refused for want of room.
+        for (name, scale) in
+            [("Ubuntu-Light", 4.0), ("emoji-icon-font", 2.0), ("NotoEmoji-Regular", 2.0)]
+        {
+            let mut fallback = (*fonts.font_data[name]).clone();
+            fallback.tweak.scale = scale;
+            fonts.font_data.insert(name.into(), std::sync::Arc::new(fallback));
+        }
+        let mono = fonts.families[&FontFamily::Monospace].clone();
+        for name in [BOLD_FAMILY, ITALIC_FAMILY, BOLD_ITALIC_FAMILY] {
+            fonts.families.insert(FontFamily::Name(name.into()), mono.clone());
+        }
+        ctx.set_fonts(fonts);
+        ctx
+    }
 
     /// Every glyph's x position after one frame of a terminal fed `row`.
     fn painted_row(
@@ -1668,54 +1680,75 @@ mod tests {
         painted.iter().find(|(g, _)| g == ch).unwrap_or_else(|| panic!("{ch} was not painted")).1
     }
 
-    /// An icon sized to its own face's em overruns a narrower cell.  With
-    /// growth on it is drawn across the blanks that follow instead, centred on
-    /// the span it was granted; the glyphs beside it do not move.
-    ///
-    /// U+FB01 is absent from the primary face, so it comes back from the
-    /// oversized fallback rather than at the cell's width.
+    /// The cell's width and the left edge of column 0, read off a painted row
+    /// of characters the primary face serves at its own advance.
+    fn cell_geometry(ctx: &egui::Context, config: &Config, screen: Vec2) -> (f32, f32) {
+        let row = painted_row(ctx, config, screen, b"MM");
+        let xs: Vec<f32> = row.iter().filter(|(g, _)| g == "M").map(|(_, x)| *x).collect();
+        let (first, second) = (xs[0].min(xs[1]), xs[0].max(xs[1]));
+        (first, second - first)
+    }
+
+    /// An icon sized to its own face's em overruns a narrower cell.  It is
+    /// drawn across the blanks that follow instead, centred on the span it was
+    /// granted.
     #[test]
-    fn an_over_wide_glyph_is_centred_over_the_blanks_after_it() {
+    fn an_over_wide_icon_is_centred_over_the_blanks_after_it() {
         let ctx = ctx_with_oversized_fallback();
-        let mut config = Config::default();
+        let config = Config::default();
         let screen = Vec2::new(640.0, 480.0);
+        let (origin, cell_w) = cell_geometry(&ctx, &config, screen);
 
-        let plain = painted_row(&ctx, &config, screen, "M\u{fb01}".as_bytes());
-        let (anchor, cell_w) = (x_of(&plain, "M"), x_of(&plain, "\u{fb01}") - x_of(&plain, "M"));
-
-        config.font.wide_glyph_growth = true;
-        let grown = painted_row(&ctx, &config, screen, "M\u{fb01}".as_bytes());
+        let painted = painted_row(&ctx, &config, screen, "M\u{e600}".as_bytes());
 
         let glyph_w =
-            ctx.fonts(|f| f.glyph_width(&FontId::monospace(config.font.egui_size()), '\u{fb01}'));
+            ctx.fonts(|f| f.glyph_width(&FontId::monospace(config.font.egui_size()), '\u{e600}'));
         let cells = crate::glyph_cache::grown_cells(glyph_w, cell_w, MAX_EXTRA_CELLS);
         assert!(cells > 1, "the fixture's fallback glyph is not over-wide");
 
-        assert_eq!(x_of(&grown, "M"), anchor, "growth moved a glyph that fits its cell");
-        let start = anchor + cell_w;
-        let left = x_of(&grown, "\u{fb01}") - start;
-        let right = start + cells as f32 * cell_w - (x_of(&grown, "\u{fb01}") + glyph_w);
-        assert!(left > 0.5, "the over-wide glyph was left in its own cell");
+        let start = origin + cell_w;
+        let left = x_of(&painted, "\u{e600}") - start;
+        let right = start + cells as f32 * cell_w - (x_of(&painted, "\u{e600}") + glyph_w);
+        assert!(left > 0.5, "the over-wide icon was left in its own cell");
         assert!((left - right).abs() < 0.5, "not centred: {left} left, {right} right");
     }
 
-    /// Growth may only claim blanks, so a glyph can want more cells than it
+    /// Growth may only claim blanks, so an icon can want more cells than it
     /// gets.  Centring it on the shorter span would put it left of its own
     /// cell, over the character before it — worse than the right-hand overrun
     /// growth exists to avoid.  It stays where it is instead.
     #[test]
-    fn an_over_wide_glyph_is_not_pulled_left_when_the_room_falls_short() {
+    fn an_over_wide_icon_is_not_pulled_left_when_the_room_falls_short() {
         let ctx = ctx_with_oversized_fallback();
-        let mut config = Config::default();
+        let config = Config::default();
         let screen = Vec2::new(640.0, 480.0);
+        let (origin, cell_w) = cell_geometry(&ctx, &config, screen);
 
-        let plain = painted_row(&ctx, &config, screen, "M\u{fb01}X".as_bytes());
-        let placed = x_of(&plain, "\u{fb01}");
+        let painted = painted_row(&ctx, &config, screen, "M\u{e600} X".as_bytes());
 
-        config.font.wide_glyph_growth = true;
-        let grown = painted_row(&ctx, &config, screen, "M\u{fb01}X".as_bytes());
+        assert_eq!(
+            x_of(&painted, "\u{e600}"),
+            origin + cell_w,
+            "the icon was pulled left of its own cell"
+        );
+    }
 
-        assert_eq!(x_of(&grown, "\u{fb01}"), placed, "the glyph was pulled left of its own cell");
+    /// Growth is for icons.  A letter that happens to arrive from an over-wide
+    /// fallback face keeps its cell, so ordinary text never moves — which is
+    /// what makes growing safe to do without a switch.
+    #[test]
+    fn an_over_wide_letter_is_not_grown() {
+        let ctx = ctx_with_oversized_fallback();
+        let config = Config::default();
+        let screen = Vec2::new(640.0, 480.0);
+        let (origin, cell_w) = cell_geometry(&ctx, &config, screen);
+
+        let painted = painted_row(&ctx, &config, screen, "M\u{fb01}".as_bytes());
+
+        let glyph_w =
+            ctx.fonts(|f| f.glyph_width(&FontId::monospace(config.font.egui_size()), '\u{fb01}'));
+        assert!(glyph_w > cell_w * 1.25, "the fixture's letter is not over-wide");
+        assert_eq!(x_of(&painted, "\u{fb01}"), origin + cell_w, "a letter was grown");
     }
 
     /// The snapshot resolves every cell's foreground, background and face

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -17,7 +17,7 @@ use crate::color_glyph::{CachedColorGlyph, ColorGlyphCache};
 use crate::colors::{background, foreground, resolve, rgb_to_color32};
 use crate::config::Config;
 use crate::fonts::{BOLD_FAMILY, BOLD_ITALIC_FAMILY, ITALIC_FAMILY};
-use crate::glyph_cache::{Face, GlyphCache};
+use crate::glyph_cache::{Face, GlyphCache, MAX_EXTRA_CELLS, grown_cells};
 use crate::input::event_to_bytes;
 use crate::links::{self, Link};
 use crate::mouse;
@@ -1073,7 +1073,7 @@ fn paint_run(
             Face::new(style.flags.contains(Flags::BOLD), style.flags.contains(Flags::ITALIC));
         let glyph_dx = config.font.glyph_offset.x as f32;
         let glyph_dy = config.font.glyph_offset.y as f32;
-        for (i, ch) in run.chars().enumerate() {
+        for (i, (byte, ch)) in run.char_indices().enumerate() {
             if ch == ' ' {
                 continue;
             }
@@ -1101,9 +1101,24 @@ fn paint_run(
                 continue;
             }
             let galley = glyphs.get(ctx, ch, face, font_id.size);
+            // A glyph wider than its cell is drawn across the blanks that
+            // follow rather than over the top of them, centred on the span it
+            // ends up with, the way kitty grows one.
+            let grow_dx = if config.font.wide_glyph_growth {
+                let spare = run[byte + ch.len_utf8()..]
+                    .chars()
+                    .take(MAX_EXTRA_CELLS)
+                    .take_while(|c| *c == ' ')
+                    .count();
+                let glyph_w = galley.size().x;
+                let cells = grown_cells(glyph_w, cell_w, spare);
+                if cells > 1 { (cells as f32 * cell_w - glyph_w) / 2.0 } else { 0.0 }
+            } else {
+                0.0
+            };
             painter.add(
                 egui::epaint::TextShape::new(
-                    Pos2::new(cell_x + glyph_dx, y + glyph_dy),
+                    Pos2::new(cell_x + glyph_dx + grow_dx, y + glyph_dy),
                     galley,
                     fg,
                 )
@@ -1512,6 +1527,125 @@ mod tests {
             egui::Shape::Vec(shapes) => shapes.iter().for_each(|s| collect_cells(s, glyphs, fills)),
             _ => {},
         }
+    }
+
+    /// A context whose monospace fallback is scaled far past the primary face,
+    /// so a character the primary lacks comes back several times wider than
+    /// the cell — a Nerd Font icon against a half-width cell, in miniature.
+    fn ctx_with_oversized_fallback() -> egui::Context {
+        let ctx = egui::Context::default();
+        let mut fonts = egui::FontDefinitions::default();
+        let mut fallback = (*fonts.font_data["Ubuntu-Light"]).clone();
+        fallback.tweak.scale = 4.0;
+        fonts.font_data.insert("Ubuntu-Light".into(), std::sync::Arc::new(fallback));
+        let mono = fonts.families[&FontFamily::Monospace].clone();
+        for name in [BOLD_FAMILY, ITALIC_FAMILY, BOLD_ITALIC_FAMILY] {
+            fonts.families.insert(FontFamily::Name(name.into()), mono.clone());
+        }
+        ctx.set_fonts(fonts);
+        ctx
+    }
+
+    /// Where each glyph of a painted frame was placed.
+    fn painted_at(
+        ctx: &egui::Context,
+        session: &mut Session,
+        config: &Config,
+        caches: &mut Caches,
+        screen: Vec2,
+    ) -> Vec<(String, f32)> {
+        let raw = egui::RawInput {
+            screen_rect: Some(Rect::from_min_size(Pos2::ZERO, screen)),
+            ..Default::default()
+        };
+        let out = ctx.run(raw, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                show(
+                    ui,
+                    session,
+                    config,
+                    true,
+                    &mut caches.builtin,
+                    &mut caches.ime,
+                    &mut caches.colors,
+                    &mut caches.glyphs,
+                    &mut caches.snapshot,
+                );
+            });
+        });
+        let mut found = Vec::new();
+        for clipped in &out.shapes {
+            collect_positions(&clipped.shape, &mut found);
+        }
+        found
+    }
+
+    fn collect_positions(shape: &egui::Shape, out: &mut Vec<(String, f32)>) {
+        match shape {
+            egui::Shape::Text(text) => out.push((text.galley.text().to_owned(), text.pos.x)),
+            egui::Shape::Vec(shapes) => shapes.iter().for_each(|s| collect_positions(s, out)),
+            _ => {},
+        }
+    }
+
+    /// An icon sized to its own face's em overruns a narrower cell.  With
+    /// growth on it is drawn across the blanks that follow instead, centred on
+    /// the span it was granted; the glyphs beside it do not move.
+    #[test]
+    fn an_over_wide_glyph_is_centred_over_the_blanks_after_it() {
+        // U+FB01 is absent from the primary face, so it comes back from the
+        // oversized fallback rather than at the cell's width.
+        const ROW: &[u8] = "M\u{fb01}".as_bytes();
+        let ctx = ctx_with_oversized_fallback();
+        let mut config = Config::default();
+        let screen = Vec2::new(640.0, 480.0);
+        let x_of = |painted: &[(String, f32)], ch: &str| {
+            painted
+                .iter()
+                .find(|(g, _)| g == ch)
+                .unwrap_or_else(|| panic!("{ch} was not painted"))
+                .1
+        };
+
+        let plain = {
+            let (mut session, _dir) = headless_session(&ctx, &config);
+            let mut caches = Caches::new();
+            painted_at(&ctx, &mut session, &config, &mut caches, screen);
+            let (cols, rows) = (session.size.columns, session.size.screen_lines);
+            {
+                let mut term = session.term.lock();
+                term.resize(TermSize::new(cols, rows));
+                Processor::<StdSyncHandler>::new().advance(&mut *term, ROW);
+            }
+            painted_at(&ctx, &mut session, &config, &mut caches, screen)
+        };
+        let (anchor, cell_w) = (x_of(&plain, "M"), x_of(&plain, "\u{fb01}") - x_of(&plain, "M"));
+
+        config.font.wide_glyph_growth = true;
+        let grown = {
+            let (mut session, _dir) = headless_session(&ctx, &config);
+            let mut caches = Caches::new();
+            painted_at(&ctx, &mut session, &config, &mut caches, screen);
+            let (cols, rows) = (session.size.columns, session.size.screen_lines);
+            {
+                let mut term = session.term.lock();
+                term.resize(TermSize::new(cols, rows));
+                Processor::<StdSyncHandler>::new().advance(&mut *term, ROW);
+            }
+            painted_at(&ctx, &mut session, &config, &mut caches, screen)
+        };
+
+        let glyph_w =
+            ctx.fonts(|f| f.glyph_width(&FontId::monospace(config.font.egui_size()), '\u{fb01}'));
+        let cells = crate::glyph_cache::grown_cells(glyph_w, cell_w, MAX_EXTRA_CELLS);
+        assert!(cells > 1, "the fixture's fallback glyph is not over-wide");
+
+        assert_eq!(x_of(&grown, "M"), anchor, "growth moved a glyph that fits its cell");
+        let start = anchor + cell_w;
+        let left = x_of(&grown, "\u{fb01}") - start;
+        let right = start + cells as f32 * cell_w - (x_of(&grown, "\u{fb01}") + glyph_w);
+        assert!(left > 0.5, "the over-wide glyph was left in its own cell");
+        assert!((left - right).abs() < 0.5, "not centred: {left} left, {right} right");
     }
 
     /// The snapshot resolves every cell's foreground, background and face

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -17,7 +17,7 @@ use crate::color_glyph::{CachedColorGlyph, ColorGlyphCache};
 use crate::colors::{background, foreground, resolve, rgb_to_color32};
 use crate::config::Config;
 use crate::fonts::{BOLD_FAMILY, BOLD_ITALIC_FAMILY, ITALIC_FAMILY};
-use crate::glyph_cache::{Face, GlyphCache, MAX_EXTRA_CELLS, grown_cells};
+use crate::glyph_cache::{Face, GlyphCache, MAX_EXTRA_CELLS, growth_offset};
 use crate::input::event_to_bytes;
 use crate::links::{self, Link};
 use crate::mouse;
@@ -764,6 +764,23 @@ impl Style {
         }
         Self { fg: cell.fg, bg: cell.bg, flags }
     }
+
+    /// Whether a blank cell styled as `other` can be painted as part of a run
+    /// in this style.
+    ///
+    /// A blank draws nothing but its background, so its foreground is free to
+    /// differ — unless something in the run paints with the foreground, which
+    /// underlines, strikeout and reverse video all do.  Keeping the two
+    /// together is what lets an over-wide glyph grow into the space an icon is
+    /// authored with, since growth may only claim blanks its own run holds;
+    /// kitty reaches the same place by copying the icon's foreground into the
+    /// blank.
+    fn absorbs(&self, other: &Self, blank: bool) -> bool {
+        blank
+            && other.bg == self.bg
+            && other.flags == self.flags
+            && !self.flags.intersects(Flags::ALL_UNDERLINES | Flags::STRIKEOUT | Flags::INVERSE)
+    }
 }
 
 /// The visible grid, copied out from under the terminal lock.
@@ -845,7 +862,9 @@ impl GridSnapshot {
                 let text_start = self.text.len();
                 while col < cols {
                     let cell = &cells[Column(col)];
-                    if Style::from_cell(cell, in_link(line, Column(col))) != style
+                    let cell_style = Style::from_cell(cell, in_link(line, Column(col)));
+                    let blank = matches!(cell.c, ' ' | '\0');
+                    if (cell_style != style && !style.absorbs(&cell_style, blank))
                         || is_selected(selection_range.as_ref(), line, Column(col)) != selected
                     {
                         break;
@@ -1110,9 +1129,7 @@ fn paint_run(
                     .take(MAX_EXTRA_CELLS)
                     .take_while(|c| *c == ' ')
                     .count();
-                let glyph_w = galley.size().x;
-                let cells = grown_cells(glyph_w, cell_w, spare);
-                if cells > 1 { (cells as f32 * cell_w - glyph_w) / 2.0 } else { 0.0 }
+                growth_offset(galley.size().x, cell_w, spare)
             } else {
                 0.0
             };
@@ -1529,6 +1546,46 @@ mod tests {
         }
     }
 
+    /// A blank paints nothing but its background, so a run can hold one in
+    /// whatever foreground it carries.  Icons are authored with a trailing
+    /// space that the surrounding highlight usually owns, and an over-wide
+    /// glyph can only grow into blanks its own run holds.
+    #[test]
+    fn a_blank_in_another_foreground_joins_the_run() {
+        let term = term_running(b"\x1b[31mA\x1b[39m \x1b[31mB");
+        let mut snapshot = GridSnapshot::new();
+
+        snapshot.capture(&term, &Config::default(), None, true);
+
+        let run = snapshot
+            .runs
+            .iter()
+            .find(|r| snapshot.text[r.text.clone()].starts_with('A'))
+            .expect("a run holding 'A'");
+        assert!(
+            snapshot.text[run.text.clone()].starts_with("A "),
+            "the blank after 'A' left the run"
+        );
+    }
+
+    /// An underline spans the whole run and is drawn in the run's foreground,
+    /// so a blank carrying a different one would come out underlined in the
+    /// wrong colour.
+    #[test]
+    fn an_underlined_blank_in_another_foreground_keeps_its_own_run() {
+        let term = term_running(b"\x1b[4;31mA\x1b[39m \x1b[31mB");
+        let mut snapshot = GridSnapshot::new();
+
+        snapshot.capture(&term, &Config::default(), None, true);
+
+        let run = snapshot
+            .runs
+            .iter()
+            .find(|r| snapshot.text[r.text.clone()].starts_with('A'))
+            .expect("a run holding 'A'");
+        assert_eq!(&snapshot.text[run.text.clone()], "A", "an underlined blank was absorbed");
+    }
+
     /// A context whose monospace fallback is scaled far past the primary face,
     /// so a character the primary lacks comes back several times wider than
     /// the cell — a Nerd Font icon against a half-width cell, in miniature.
@@ -1588,52 +1645,46 @@ mod tests {
         }
     }
 
+    /// Every glyph's x position after one frame of a terminal fed `row`.
+    fn painted_row(
+        ctx: &egui::Context,
+        config: &Config,
+        screen: Vec2,
+        row: &[u8],
+    ) -> Vec<(String, f32)> {
+        let (mut session, _dir) = headless_session(ctx, config);
+        let mut caches = Caches::new();
+        painted_at(ctx, &mut session, config, &mut caches, screen);
+        let (cols, rows) = (session.size.columns, session.size.screen_lines);
+        {
+            let mut term = session.term.lock();
+            term.resize(TermSize::new(cols, rows));
+            Processor::<StdSyncHandler>::new().advance(&mut *term, row);
+        }
+        painted_at(ctx, &mut session, config, &mut caches, screen)
+    }
+
+    fn x_of(painted: &[(String, f32)], ch: &str) -> f32 {
+        painted.iter().find(|(g, _)| g == ch).unwrap_or_else(|| panic!("{ch} was not painted")).1
+    }
+
     /// An icon sized to its own face's em overruns a narrower cell.  With
     /// growth on it is drawn across the blanks that follow instead, centred on
     /// the span it was granted; the glyphs beside it do not move.
+    ///
+    /// U+FB01 is absent from the primary face, so it comes back from the
+    /// oversized fallback rather than at the cell's width.
     #[test]
     fn an_over_wide_glyph_is_centred_over_the_blanks_after_it() {
-        // U+FB01 is absent from the primary face, so it comes back from the
-        // oversized fallback rather than at the cell's width.
-        const ROW: &[u8] = "M\u{fb01}".as_bytes();
         let ctx = ctx_with_oversized_fallback();
         let mut config = Config::default();
         let screen = Vec2::new(640.0, 480.0);
-        let x_of = |painted: &[(String, f32)], ch: &str| {
-            painted
-                .iter()
-                .find(|(g, _)| g == ch)
-                .unwrap_or_else(|| panic!("{ch} was not painted"))
-                .1
-        };
 
-        let plain = {
-            let (mut session, _dir) = headless_session(&ctx, &config);
-            let mut caches = Caches::new();
-            painted_at(&ctx, &mut session, &config, &mut caches, screen);
-            let (cols, rows) = (session.size.columns, session.size.screen_lines);
-            {
-                let mut term = session.term.lock();
-                term.resize(TermSize::new(cols, rows));
-                Processor::<StdSyncHandler>::new().advance(&mut *term, ROW);
-            }
-            painted_at(&ctx, &mut session, &config, &mut caches, screen)
-        };
+        let plain = painted_row(&ctx, &config, screen, "M\u{fb01}".as_bytes());
         let (anchor, cell_w) = (x_of(&plain, "M"), x_of(&plain, "\u{fb01}") - x_of(&plain, "M"));
 
         config.font.wide_glyph_growth = true;
-        let grown = {
-            let (mut session, _dir) = headless_session(&ctx, &config);
-            let mut caches = Caches::new();
-            painted_at(&ctx, &mut session, &config, &mut caches, screen);
-            let (cols, rows) = (session.size.columns, session.size.screen_lines);
-            {
-                let mut term = session.term.lock();
-                term.resize(TermSize::new(cols, rows));
-                Processor::<StdSyncHandler>::new().advance(&mut *term, ROW);
-            }
-            painted_at(&ctx, &mut session, &config, &mut caches, screen)
-        };
+        let grown = painted_row(&ctx, &config, screen, "M\u{fb01}".as_bytes());
 
         let glyph_w =
             ctx.fonts(|f| f.glyph_width(&FontId::monospace(config.font.egui_size()), '\u{fb01}'));
@@ -1646,6 +1697,25 @@ mod tests {
         let right = start + cells as f32 * cell_w - (x_of(&grown, "\u{fb01}") + glyph_w);
         assert!(left > 0.5, "the over-wide glyph was left in its own cell");
         assert!((left - right).abs() < 0.5, "not centred: {left} left, {right} right");
+    }
+
+    /// Growth may only claim blanks, so a glyph can want more cells than it
+    /// gets.  Centring it on the shorter span would put it left of its own
+    /// cell, over the character before it — worse than the right-hand overrun
+    /// growth exists to avoid.  It stays where it is instead.
+    #[test]
+    fn an_over_wide_glyph_is_not_pulled_left_when_the_room_falls_short() {
+        let ctx = ctx_with_oversized_fallback();
+        let mut config = Config::default();
+        let screen = Vec2::new(640.0, 480.0);
+
+        let plain = painted_row(&ctx, &config, screen, "M\u{fb01}X".as_bytes());
+        let placed = x_of(&plain, "\u{fb01}");
+
+        config.font.wide_glyph_growth = true;
+        let grown = painted_row(&ctx, &config, screen, "M\u{fb01}X".as_bytes());
+
+        assert_eq!(x_of(&grown, "\u{fb01}"), placed, "the glyph was pulled left of its own cell");
     }
 
     /// The snapshot resolves every cell's foreground, background and face

--- a/alacritree/src/worktree_liveness.rs
+++ b/alacritree/src/worktree_liveness.rs
@@ -94,37 +94,39 @@ impl LivenessCache {
     }
 
     /// Take the batch to probe, forgetting every path the sidebar no longer
-    /// draws.  All visible paths go in together: they are checked on one
-    /// worker, so splitting them by individual freshness would buy nothing.
+    /// draws — including all of them, when a filter or a collapsed project
+    /// leaves nothing eligible.  All visible paths go in together: they are
+    /// checked on one worker, so splitting them by individual freshness would
+    /// buy nothing.
     pub fn batch(&mut self, visible: &[PathBuf]) -> Vec<PathBuf> {
         self.states.retain(|path, _| visible.contains(path));
         visible.to_vec()
     }
 
-    /// An `Unknown` result keeps whatever the last definite answer was: a
-    /// distro that stops answering must not silently grey out every row it
-    /// owns.  The interval restarts either way, so an unreachable path is
-    /// retried on the tick rather than on every frame.
+    /// An `Unknown` result replaces the last answer rather than preserving
+    /// it.  Keeping it would leave the row claiming a checkout is gone while
+    /// `is_gone` — which has no memory, and refuses to call an unreadable path
+    /// missing — lets that same path spawn a shell.  Forgetting instead makes
+    /// both say "cannot tell" and hands the row back to discovery's word.
+    ///
+    /// A round that probed nothing still restarts the interval, so a frame
+    /// with no eligible rows cannot leave `wants_probe` true forever.
     pub fn adopt(&mut self, results: Vec<(PathBuf, Liveness)>, now: Instant) {
         for (path, state) in results {
-            match state {
-                Liveness::Unknown => {
-                    self.states.entry(path).or_insert(Liveness::Unknown);
-                },
-                definite => {
-                    self.states.insert(path, definite);
-                },
-            }
+            self.states.insert(path, state);
         }
         self.next_probe = Some(now + FRESH_FOR);
     }
 
-    /// How long until the next batch is due, for `request_repaint_after`.
+    /// How long until the next batch is due, for `request_repaint_after`, or
+    /// `None` when no batch has ever run and there is nothing to wake up for.
     /// Without that wake-up the sidebar would only re-probe when something
     /// else happened to draw a frame, and a worktree deleted from an otherwise
-    /// idle terminal would stay marked live indefinitely.
-    pub fn wait(&self, now: Instant) -> Duration {
-        self.next_probe.map_or(Duration::ZERO, |due| due.saturating_duration_since(now))
+    /// idle terminal would stay marked live indefinitely.  The `Option` is
+    /// what keeps "no deadline" from collapsing into a zero wait, which
+    /// `request_repaint_after` reads as "repaint now" — every frame, forever.
+    pub fn wait(&self, now: Instant) -> Option<Duration> {
+        self.next_probe.map(|due| due.saturating_duration_since(now))
     }
 }
 
@@ -190,22 +192,37 @@ mod tests {
         assert_eq!(cache.missing(&p("/a")), Some(true));
     }
 
-    /// A distro that stops answering turns every path it owns `Unknown`.
-    /// Letting that grey the rows would report a deleted worktree every time
-    /// WSL hiccups.
+    /// A distro that stops answering turns every path it owns `Unknown`.  The
+    /// row has to stop claiming those checkouts are gone, because `is_gone`
+    /// has already stopped refusing to spawn shells in them.
     #[test]
-    fn an_unknown_result_leaves_the_last_answer_standing() {
+    fn an_unknown_result_forgets_the_last_answer() {
         let now = Instant::now();
         let mut cache = LivenessCache::default();
         cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
 
         cache.adopt(vec![(p("/a"), Liveness::Unknown)], now + FRESH_FOR);
 
-        assert_eq!(cache.missing(&p("/a")), Some(true), "the last definite answer stands");
+        assert_eq!(cache.missing(&p("/a")), None, "neither greyed nor vouched for");
         assert!(
             !cache.wants_probe(now + FRESH_FOR),
             "but the failed probe still restarts the tick"
         );
+    }
+
+    /// A frame whose rows are all collapsed, filtered away or on WSL probes
+    /// nothing.  Leaving the interval open would keep `wait` at zero, and the
+    /// caller's `request_repaint_after` would then ask for the next frame on
+    /// every frame.
+    #[test]
+    fn a_round_that_probed_nothing_still_restarts_the_interval() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+
+        cache.adopt(Vec::new(), now);
+
+        assert!(!cache.wants_probe(now + FRESH_FOR / 2));
+        assert_eq!(cache.wait(now), Some(FRESH_FOR));
     }
 
     /// `git worktree add` on the same path brings the checkout back; the row
@@ -236,10 +253,12 @@ mod tests {
     fn the_wait_counts_down_to_the_next_batch() {
         let now = Instant::now();
         let mut cache = LivenessCache::default();
+        assert_eq!(cache.wait(now), None, "nothing to wake up for before the first batch");
+
         cache.adopt(vec![(p("/a"), Liveness::Present)], now);
 
-        assert_eq!(cache.wait(now + FRESH_FOR / 2), FRESH_FOR / 2);
+        assert_eq!(cache.wait(now + FRESH_FOR / 2), Some(FRESH_FOR / 2));
         // An overdue tick asks for the next frame, not a negative span.
-        assert_eq!(cache.wait(now + FRESH_FOR * 2), Duration::ZERO);
+        assert_eq!(cache.wait(now + FRESH_FOR * 2), Some(Duration::ZERO));
     }
 }

--- a/alacritree/src/worktree_liveness.rs
+++ b/alacritree/src/worktree_liveness.rs
@@ -1,0 +1,205 @@
+//! Whether a worktree's checkout is still on disk, for the sidebar's benefit.
+//!
+//! `Project::discover` owns `Worktree::prunable` and stays the only writer of
+//! it: the delete flow reads that flag to choose between `git worktree remove`
+//! and a prune, and `Project::apply` reads it to decide which rows survive a
+//! refresh.  This cache never touches it.  It answers one question — "should
+//! this row paint as gone?" — so a wrong answer costs a frame of styling and
+//! can never pick a destructive branch.  Every action stats the path itself at
+//! the moment it runs.
+//!
+//! Cost is the whole design.  Probing is a syscall per path, and on a
+//! `\\wsl.localhost\` UNC path that is a 9P round trip, so probes run on a
+//! worker, one batch at a time, only for rows the sidebar is drawing, and only
+//! once per interval.  `wants_probe` is what the paint path asks first: on the
+//! other ~89 frames of every 90 it is false and nothing here allocates.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// How long a batch of results stands before the visible rows are checked
+/// again.  Matches `git_status::StatusCache`, which answers the same "did this
+/// worktree change under us" question at the same human timescale.
+pub const FRESH_FOR: Duration = Duration::from_millis(1500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Liveness {
+    Present,
+    Missing,
+    /// The probe failed for a reason other than "not found" — a distro that
+    /// did not answer, a permission error.  Distinct from `Missing` because a
+    /// filesystem that cannot be reached is not a filesystem without the
+    /// directory, and greying the row on that would be a lie.
+    Unknown,
+}
+
+/// Read `path`'s state.  `metadata` rather than `is_dir` so the difference
+/// between "not there" and "could not tell" survives: `is_dir` folds every
+/// error into `false`.
+pub fn probe(path: &Path) -> Liveness {
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_dir() => Liveness::Present,
+        // Something is there but cannot host a shell, which is all the flag
+        // governs.
+        Ok(_) => Liveness::Missing,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Liveness::Missing,
+        Err(_) => Liveness::Unknown,
+    }
+}
+
+/// Probe results keyed by worktree path, plus when the next batch is due.
+/// Entries live only as long as the sidebar keeps drawing their path, so a
+/// project the user removes does not leave its worktrees behind.
+#[derive(Default)]
+pub struct LivenessCache {
+    states: HashMap<PathBuf, Liveness>,
+    /// `None` until the first batch lands, which is what makes the first
+    /// painted frame probe rather than wait out an interval.
+    next_probe: Option<Instant>,
+}
+
+impl LivenessCache {
+    /// Whether `path` is gone, or `None` when no definite answer exists and
+    /// the row should keep discovery's word.  A definite answer overrides that
+    /// word in *both* directions: a checkout restored under a path discovery
+    /// last saw as pruned has to lose the grey, or this fixes one stale
+    /// direction and leaves its mirror image behind.
+    pub fn missing(&self, path: &Path) -> Option<bool> {
+        match self.states.get(path)? {
+            Liveness::Present => Some(false),
+            Liveness::Missing => Some(true),
+            Liveness::Unknown => None,
+        }
+    }
+
+    /// Whether the interval has elapsed.  The sidebar asks this *before* it
+    /// starts collecting the paths it draws, so a steady frame does no work
+    /// and makes no allocation on this path at all.
+    pub fn wants_probe(&self, now: Instant) -> bool {
+        self.next_probe.is_none_or(|due| now >= due)
+    }
+
+    /// Take the batch to probe, forgetting every path the sidebar no longer
+    /// draws.  All visible paths go in together: they are checked on one
+    /// worker, so splitting them by individual freshness would buy nothing.
+    pub fn batch(&mut self, visible: &[PathBuf]) -> Vec<PathBuf> {
+        self.states.retain(|path, _| visible.contains(path));
+        visible.to_vec()
+    }
+
+    /// An `Unknown` result keeps whatever the last definite answer was: a
+    /// distro that stops answering must not silently grey out every row it
+    /// owns.  The interval restarts either way, so an unreachable path is
+    /// retried on the tick rather than on every frame.
+    pub fn adopt(&mut self, results: Vec<(PathBuf, Liveness)>, now: Instant) {
+        for (path, state) in results {
+            match state {
+                Liveness::Unknown => {
+                    self.states.entry(path).or_insert(Liveness::Unknown);
+                },
+                definite => {
+                    self.states.insert(path, definite);
+                },
+            }
+        }
+        self.next_probe = Some(now + FRESH_FOR);
+    }
+
+    /// How long until the next batch is due, for `request_repaint_after`.
+    /// Without that wake-up the sidebar would only re-probe when something
+    /// else happened to draw a frame, and a worktree deleted from an otherwise
+    /// idle terminal would stay marked live indefinitely.
+    pub fn wait(&self, now: Instant) -> Duration {
+        self.next_probe.map_or(Duration::ZERO, |due| due.saturating_duration_since(now))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn the_first_frame_probes_rather_than_waiting_out_an_interval() {
+        assert!(LivenessCache::default().wants_probe(Instant::now()));
+    }
+
+    #[test]
+    fn a_batch_holds_the_interval_shut_until_it_expires() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Present)], now);
+
+        assert!(!cache.wants_probe(now + FRESH_FOR / 2), "the steady frame does nothing");
+        assert!(cache.wants_probe(now + FRESH_FOR));
+    }
+
+    #[test]
+    fn only_a_definite_answer_greys_the_row() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+
+        cache.adopt(vec![(p("/a"), Liveness::Present)], now);
+        assert_eq!(cache.missing(&p("/a")), Some(false));
+
+        cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
+        assert_eq!(cache.missing(&p("/a")), Some(true));
+    }
+
+    /// A distro that stops answering turns every path it owns `Unknown`.
+    /// Letting that grey the rows would report a deleted worktree every time
+    /// WSL hiccups.
+    #[test]
+    fn an_unknown_result_leaves_the_last_answer_standing() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
+
+        cache.adopt(vec![(p("/a"), Liveness::Unknown)], now + FRESH_FOR);
+
+        assert_eq!(cache.missing(&p("/a")), Some(true), "the last definite answer stands");
+        assert!(
+            !cache.wants_probe(now + FRESH_FOR),
+            "but the failed probe still restarts the tick"
+        );
+    }
+
+    /// `git worktree add` on the same path brings the checkout back; the row
+    /// has to lose the grey again rather than stay marked gone.
+    #[test]
+    fn a_path_that_reappears_goes_back_to_present() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
+
+        cache.adopt(vec![(p("/a"), Liveness::Present)], now + FRESH_FOR);
+
+        assert_eq!(cache.missing(&p("/a")), Some(false));
+    }
+
+    #[test]
+    fn a_path_the_sidebar_stopped_drawing_is_forgotten() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Missing)], now);
+
+        assert_eq!(cache.batch(&[p("/b")]), vec![p("/b")]);
+
+        assert_eq!(cache.missing(&p("/a")), None, "the entry went with the row");
+    }
+
+    #[test]
+    fn the_wait_counts_down_to_the_next_batch() {
+        let now = Instant::now();
+        let mut cache = LivenessCache::default();
+        cache.adopt(vec![(p("/a"), Liveness::Present)], now);
+
+        assert_eq!(cache.wait(now + FRESH_FOR / 2), FRESH_FOR / 2);
+        // An overdue tick asks for the next frame, not a negative span.
+        assert_eq!(cache.wait(now + FRESH_FOR * 2), Duration::ZERO);
+    }
+}

--- a/alacritree/src/worktree_liveness.rs
+++ b/alacritree/src/worktree_liveness.rs
@@ -52,6 +52,15 @@ pub fn probe(path: &Path) -> Liveness {
     }
 }
 
+/// Whether git would call this checkout gone.  The single question the row,
+/// the activate guard, the spawn guard and discovery all ask, so a greyed row
+/// and a refused shell never disagree about the same directory.  A probe that
+/// could not tell answers `false`: an unreachable filesystem must not turn
+/// into a refusal.
+pub fn is_gone(path: &Path) -> bool {
+    probe(path) == Liveness::Missing
+}
+
 /// Probe results keyed by worktree path, plus when the next batch is due.
 /// Entries live only as long as the sidebar keeps drawing their path, so a
 /// project the user removes does not leave its worktrees behind.

--- a/alacritree/src/worktree_liveness.rs
+++ b/alacritree/src/worktree_liveness.rs
@@ -34,15 +34,19 @@ pub enum Liveness {
     Unknown,
 }
 
-/// Read `path`'s state.  `metadata` rather than `is_dir` so the difference
-/// between "not there" and "could not tell" survives: `is_dir` folds every
-/// error into `false`.
+/// Whether `path` is still a worktree checkout, which is `.git`'s presence
+/// rather than the directory's.  `git worktree remove` deletes the contents
+/// first and only then the directory itself, so a remove that loses the last
+/// step — the usual outcome on Windows, where a shell sitting in the directory
+/// pins it — leaves an empty husk behind.  Git calls that worktree gone and
+/// refuses to remove it twice ("validation failed: '<path>/.git' does not
+/// exist"); stat'ing the directory would call it alive.
+///
+/// `metadata` rather than `exists` so the difference between "not there" and
+/// "could not tell" survives: `exists` folds every error into `false`.
 pub fn probe(path: &Path) -> Liveness {
-    match std::fs::metadata(path) {
-        Ok(meta) if meta.is_dir() => Liveness::Present,
-        // Something is there but cannot host a shell, which is all the flag
-        // governs.
-        Ok(_) => Liveness::Missing,
+    match std::fs::metadata(path.join(".git")) {
+        Ok(_) => Liveness::Present,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Liveness::Missing,
         Err(_) => Liveness::Unknown,
     }
@@ -121,6 +125,33 @@ mod tests {
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
+    }
+
+    #[test]
+    fn a_checkout_with_its_git_link_is_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".git"), "gitdir: /somewhere/.git/worktrees/x").unwrap();
+
+        assert_eq!(probe(dir.path()), Liveness::Present);
+    }
+
+    /// `git worktree remove` deletes the contents and only then the directory,
+    /// so on Windows a shell sitting in it leaves this behind.  Git treats the
+    /// worktree as gone; stat'ing the directory would not.
+    #[test]
+    fn the_husk_left_by_a_half_finished_remove_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert_eq!(probe(dir.path()), Liveness::Missing);
+    }
+
+    #[test]
+    fn a_checkout_deleted_outright_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        drop(dir);
+
+        assert_eq!(probe(&path), Liveness::Missing);
     }
 
     #[test]

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -171,7 +171,7 @@ seamless cells regardless of the user's monospace font choice — borders,
 braille blocks, and powerline separators always tile perfectly. The behaviour
 can be toggled with `font.builtin_box_drawing = false`.
 
-### Over-wide glyphs
+### Over-wide icons
 
 An icon outside the built-in ranges comes from whichever fallback face has it,
 sized to *that* face's em rather than to the cell. On a narrow cell — a
@@ -179,25 +179,29 @@ CJK-derived face's half-width advance, say — a Nerd Font icon is wider than
 the column the terminal gave it and spills into the next one, where the next
 run's background paints over the part that escaped.
 
-`font.wide_glyph_growth = true` draws such a glyph across the blank cells that
-follow it instead, centred on the span it ends up with, up to four extra
-cells. This is kitty's behaviour; alacritty and Windows Terminal both let the
-overflow happen.
+Such an icon is drawn across the blank cells that follow it instead, centred
+on the span it ends up with, up to four extra cells. This is kitty's
+behaviour; alacritty and Windows Terminal both let the overflow happen.
 
-Blanks are the only cells it may take — anything else is a character it would
-paint over — and a glyph wanting more room than it gets stays where it is
+Only the private use areas grow. A letter that happens to arrive from an
+over-wide fallback face keeps its cell however far it overruns, which is why
+this needs no switch — ordinary text can never move. `U+E0A0`–`U+E0A3` and
+`U+E0C0`–`U+E0C7` are held back as well, matching kitty's `narrow_symbols`
+default: those marks read as part of the segment beside them, so a wider one
+looks wrong where a clipped one only looks cramped.
+
+Blanks are the only cells an icon may take — anything else is a character it
+would paint over — and one wanting more room than it gets stays where it is
 rather than being pulled left. A blank draws nothing but its background, so it
 counts even when its foreground differs from the icon's, which is what lets an
 icon and the differently-highlighted space beside it share a run. Icons are
 commonly authored with exactly that trailing space (`" "`).
 
-Off by default, since it moves glyphs that render acceptably today.
-
 Two things it leaves alone. A double-width character already owns two columns
 and is sized to them, so it never grows — it also never shares a run, since
 the flags marking its second column end one. And a block cursor parked on a
-grown glyph redraws it at its own cell while the cursor is there, so the
-glyph shifts back for as long as the cursor sits on it.
+grown icon redraws it at its own cell while the cursor is there, so the icon
+shifts back for as long as the cursor sits on it.
 
 ### Clickable links
 

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -181,10 +181,15 @@ run's background paints over the part that escaped.
 
 `font.wide_glyph_growth = true` draws such a glyph across the blank cells that
 follow it instead, centred on the span it ends up with, up to four extra
-cells. Blanks are the only cells it may take; anything else is a character it
-would paint over. This is kitty's behaviour — alacritty and Windows Terminal
-both let the overflow happen. Icons are commonly authored with a trailing
-space (`" "`), which is exactly the room this needs.
+cells. This is kitty's behaviour; alacritty and Windows Terminal both let the
+overflow happen.
+
+Blanks are the only cells it may take — anything else is a character it would
+paint over — and a glyph wanting more room than it gets stays where it is
+rather than being pulled left. A blank draws nothing but its background, so it
+counts even when its foreground differs from the icon's, which is what lets an
+icon and the differently-highlighted space beside it share a run. Icons are
+commonly authored with exactly that trailing space (`" "`).
 
 Off by default, since it moves glyphs that render acceptably today.
 

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -171,6 +171,23 @@ seamless cells regardless of the user's monospace font choice — borders,
 braille blocks, and powerline separators always tile perfectly. The behaviour
 can be toggled with `font.builtin_box_drawing = false`.
 
+### Over-wide glyphs
+
+An icon outside the built-in ranges comes from whichever fallback face has it,
+sized to *that* face's em rather than to the cell. On a narrow cell — a
+CJK-derived face's half-width advance, say — a Nerd Font icon is wider than
+the column the terminal gave it and spills into the next one, where the next
+run's background paints over the part that escaped.
+
+`font.wide_glyph_growth = true` draws such a glyph across the blank cells that
+follow it instead, centred on the span it ends up with, up to four extra
+cells. Blanks are the only cells it may take; anything else is a character it
+would paint over. This is kitty's behaviour — alacritty and Windows Terminal
+both let the overflow happen. Icons are commonly authored with a trailing
+space (`" "`), which is exactly the room this needs.
+
+Off by default, since it moves glyphs that render acceptably today.
+
 ### Clickable links
 
 URL detection mirrors Alacritty's default URL hint behaviour:

--- a/docs/alacritree.md
+++ b/docs/alacritree.md
@@ -193,6 +193,12 @@ commonly authored with exactly that trailing space (`" "`).
 
 Off by default, since it moves glyphs that render acceptably today.
 
+Two things it leaves alone. A double-width character already owns two columns
+and is sized to them, so it never grows — it also never shares a run, since
+the flags marking its second column end one. And a block cursor parked on a
+grown glyph redraws it at its own cell while the cursor is there, so the
+glyph shifts back for as long as the cursor sits on it.
+
 ### Clickable links
 
 URL detection mirrors Alacritty's default URL hint behaviour:


### PR DESCRIPTION
Nerd Font icons render oversized and clipped on a narrow cell. This draws them across the blank cells they are authored with instead, the way kitty does.

Stacked on #179 and #180; both are in this branch's history, so review only the last four commits.

## Problem

An icon outside the built-in ranges comes from whichever fallback face has it, sized to *that* face's em rather than to the cell. On a CJK-derived face — `Sarasa Fixed K`, whose half-width advance is 0.50 em against a line height near 1.17 em — a `Symbols Nerd Font Mono` icon is roughly twice the column it was given.

Measured against a real config, cell advance 8.0:

| codepoint | | advance | ratio |
|---|---|---|---|
| U+F057 | LazyVim's diagnostic error icon | 13.578 | 1.70 |
| U+F002 | noice's search prompt | 13.578 | 1.70 |
| U+F103 | `angle_double_down` | 10.187 | 1.27 |

`paint_run` draws glyphs unclipped, so the overrun lands in the next column and the following run's background rect paints over it. The icon comes out cut.

## Fix

Draw an over-wide icon across the blank cells that follow it, centred on the span it ends up with, up to four extra cells — kitty's `MAX_NUM_EXTRA_GLYPHS_PUA` (`kitty/fonts.c:2119-2160`). alacritty and Windows Terminal both let the overflow happen and clip it; WezTerm instead shrinks the glyph.

Two pieces make it work:

**A blank can join the run beside it.** A run breaks wherever the foreground changes, and an icon and the space after it usually carry different highlights — so the space formed its own run, growth found no room, and nothing changed. A blank draws nothing but its background, so `Style::absorbs` lets a run take one whose foreground differs. Underlines, strikeout and reverse video all paint with the foreground, so a run carrying any of them still breaks. kitty reaches the same place by copying the icon's foreground into the blank (`fonts.c:2138-2144`, their issue #467). This part is behaviour-preserving on its own and slightly reduces the run count.

**Only private-use codepoints grow.** kitty decides on the codepoint rather than on width (`fonts.c:2120-2121`) — private-use, symbol and dingbat characters from a non-primary face, never ordinary text. Same here: a letter served by an over-wide fallback face keeps its cell however far it overruns. `U+E0A0`–`U+E0A3` and `U+E0C0`–`U+E0C7` are held back too, matching kitty's `narrow_symbols` default, since those marks read as part of the segment beside them.

Because ordinary text can never move, there is no config key. The trigger is the safety mechanism, and the one real failure mode — a particular range looking wrong grown — is what kitty answers with a per-range cap rather than an on/off switch.

## Notes

- A glyph wanting more cells than are blank stays at its own cell and overruns right, rather than being centred on a span too short and pulled left over its neighbour.
- The 1.25 slack before a glyph counts as over-wide is WezTerm's figure (`wezterm-gui/src/glyphcache.rs:702-812`). It is not cosmetic: cell width is floored to whole device pixels, so an ordinary glyph's advance is routinely a shade wider than the cell measured from it.
- A double-width character never grows — it already owns two columns, and the flags marking its second one end the run.
- A block cursor parked on a grown icon redraws it at its own cell while the cursor is there. Documented rather than fixed.

## Cost

Measured with the repo's own `report_paint_cost` harness, same binary, dense full-screen output:

| grid | before | after | allocations | vertices |
|---|---|---|---|---|
| 158x41 | 1.140 ms | 1.124 ms | 60 -> 60 | 25932 -> 25932 |
| 318x83 | 4.630 ms | 4.688 ms | 64 -> 64 | 105596 -> 105596 |

Opposite signs at ~1.3% each — noise. The lookahead is bounded at four characters and allocates nothing.

## Tests

978 unit + 7 integration pass; `cargo fmt --check` clean.

- `grown_cells` / `growth_offset`: fits, inside the slack, nowhere to go, takes only what it needs, capped, and not pulled left when the room falls short.
- `may_grow`: private use and supplementary private use grow; a letter, a presentation-form ligature and a CJK ideograph do not; kitty's held-back ranges do not, with U+E0A4 pinning where the range ends.
- `Style::absorbs`: a blank in another foreground joins the run; an underlined one keeps its own.
- End-to-end through the real paint path, with a scaled fallback face: an over-wide icon is centred over its span, is not pulled left when the room falls short, and an over-wide *letter* does not move.

Each was confirmed failing for the right reason before being made to pass.

---

Written by Claude Opus 5 in Claude Code, reviewed by a Fable 5 subagent and OpenAI Codex. Both independently found a sign error in the centring offset, fixed in df659439.
