### PR TITLE
feat(doctor): report what each WSL distro can do [1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ projects still exist on disk, and whether a running instance is reachable. It
 needs no running window — "nothing happens when I run it" is exactly when it
 gets used.
 
+On Windows it also reports each installed WSL distro and where `git`, `gh`,
+`delta` and `doppler` resolve *inside* it. Those are the paths alacritree uses
+for a project that lives in a distro, and nothing else ever names them: a
+distro without `git` shows an empty git panel rather than an error.
+
 It exits non-zero only when something is genuinely broken. A missing optional
 tool is a warning, and a tool driving a feature you have never opted into (an
 absent `doppler` on a machine with no Doppler config) is not even that — a report

--- a/alacritree/src/cli/doctor.rs
+++ b/alacritree/src/cli/doctor.rs
@@ -12,9 +12,10 @@
 //! It answers without a running instance, because "nothing happens when I run
 //! it" is precisely when it gets used.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 
@@ -95,9 +96,12 @@ pub fn run(as_json: bool, socket: Option<&Path>) -> i32 {
 fn report(socket: Option<&Path>) -> Vec<Check> {
     let config = config::load();
 
+    // Rows are grouped by section on the way out, so each section has to be
+    // added in one run — a section split in two prints its header twice.
     let mut checks = binary_checks();
     checks.extend(gh_auth_check());
     checks.push(shell_check(config.shell.as_ref()));
+    checks.extend(wsl_checks(&wsl::distros()));
     checks.extend(config_checks(&config::diagnose()));
     checks.extend(persisted_state_checks(&config));
     checks.extend(ipc_checks(socket, config.ipc_socket));
@@ -186,6 +190,134 @@ fn gh_auth_check() -> Option<Check> {
         let detail = "not authenticated — PR base branches fall back to the repo default";
         check("binaries", "gh auth", Status::Warn, detail)
     })
+}
+
+/// The tools alacritree resolves inside a distro, and the order a probe
+/// answers in.  `doppler` is here even though nothing runs it there yet,
+/// because [`wsl_doppler_check`] is the only place that says so.
+const WSL_TOOLS: [&str; 4] = ["git", "gh", "delta", "doppler"];
+
+/// One wsl.exe round trip per distro, in parallel and on a deadline: a distro
+/// whose VM is cold takes seconds to answer and one that is wedged never
+/// does, and a report that hangs is worse than one that says it could not
+/// tell.
+const WSL_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// What a probe of one distro found — a path per entry of [`WSL_TOOLS`] — or
+/// why the distro could not be asked.
+type Probe = Result<Vec<Option<String>>, String>;
+
+/// What each installed distro can actually do for alacritree.  Nothing else
+/// reports on the inside of a distro: git, gh and delta are resolved there
+/// silently, and their absence looks exactly like a repository with nothing
+/// to say.  Empty when WSL is not installed, which is also every non-Windows
+/// machine.
+fn wsl_checks(distros: &[wsl::WslDistro]) -> Vec<Check> {
+    if distros.is_empty() {
+        return Vec::new();
+    }
+    let names: Vec<String> = distros
+        .iter()
+        .map(|d| if d.is_default { format!("{} (default)", d.name) } else { d.name.clone() })
+        .collect();
+
+    let probes = probe_distros(distros);
+    let mut checks = vec![check("wsl", "distros", Status::Ok, names.join(", "))];
+    checks.extend(probes.iter().map(|(name, probe)| wsl_distro_check(name, probe)));
+    checks.extend(wsl_doppler_check(&probes));
+    checks
+}
+
+fn probe_distros(distros: &[wsl::WslDistro]) -> Vec<(String, Probe)> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    for distro in distros {
+        let tx = tx.clone();
+        let name = distro.name.clone();
+        std::thread::spawn(move || {
+            let probe = wsl::probe_tools(&name, &WSL_TOOLS);
+            let _ = tx.send((name, probe));
+        });
+    }
+    drop(tx);
+
+    let deadline = Instant::now() + WSL_PROBE_TIMEOUT;
+    let mut answered: HashMap<String, Probe> = HashMap::new();
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        match rx.recv_timeout(remaining) {
+            Ok((name, probe)) => {
+                answered.insert(name, probe);
+            },
+            Err(_) => break,
+        }
+    }
+
+    distros
+        .iter()
+        .map(|d| {
+            let probe = answered
+                .remove(&d.name)
+                .unwrap_or_else(|| Err(format!("no answer in {}s", WSL_PROBE_TIMEOUT.as_secs())));
+            (d.name.clone(), probe)
+        })
+        .collect()
+}
+
+fn wsl_distro_check(name: &str, probe: &Probe) -> Check {
+    let found = match probe {
+        Ok(found) => found,
+        // Not alacritree's fault, but every project inside the distro is
+        // unreadable until it starts.
+        Err(e) => return check("wsl", name, Status::Warn, format!("unreachable — {e}")),
+    };
+
+    let mut present = Vec::new();
+    let mut missing = Vec::new();
+    for tool in WSL_TOOLS {
+        match tool_path(found, tool) {
+            Some(path) => present.push(format!("{tool} {path}")),
+            None => missing.push(tool),
+        }
+    }
+    let mut detail =
+        if present.is_empty() { "nothing found".to_string() } else { present.join(", ") };
+    if !missing.is_empty() {
+        detail.push_str(&format!("; no {}", missing.join(", ")));
+    }
+
+    // git is what reads a project that lives in the distro; without it the
+    // sidebar lists the worktree and can say nothing else about it.
+    let status = if tool_path(found, "git").is_some() { Status::Ok } else { Status::Warn };
+    check("wsl", name, status, detail)
+}
+
+/// Scope mirroring runs the Windows `doppler` against Windows paths, so a
+/// distro's own doppler is never consulted and a WSL project's worktrees come
+/// out unscoped however well doppler is set up inside the distro.  Someone
+/// who installed it there did so expecting otherwise.
+fn wsl_doppler_check(probes: &[(String, Probe)]) -> Option<Check> {
+    let distros: Vec<&str> = probes
+        .iter()
+        .filter(|(_, probe)| {
+            probe.as_ref().is_ok_and(|found| tool_path(found, "doppler").is_some())
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if distros.is_empty() {
+        return None;
+    }
+    let detail = format!(
+        "installed in {} — scope mirroring only runs the Windows doppler, so worktrees of a \
+         project inside a distro are not scoped",
+        distros.join(", ")
+    );
+    Some(check("wsl", "doppler", Status::Warn, detail))
+}
+
+/// Where a probe put `tool`, by name rather than by index, so [`WSL_TOOLS`]
+/// can be reordered without silently renaming everyone's results.
+fn tool_path<'a>(found: &'a [Option<String>], tool: &str) -> Option<&'a str> {
+    let slot = WSL_TOOLS.iter().position(|t| *t == tool)?;
+    found.get(slot)?.as_deref()
 }
 
 /// A configured shell that cannot be resolved takes every session with it: the
@@ -621,6 +753,69 @@ mod tests {
     fn doppler_is_only_worth_warning_about_once_it_has_been_set_up() {
         assert_eq!(doppler_need(true), Need::Optional);
         assert_eq!(doppler_need(false), Need::Unused);
+    }
+
+    fn probe(paths: &[Option<&str>]) -> Probe {
+        Ok(paths.iter().map(|p| p.map(str::to_string)).collect())
+    }
+
+    /// Nothing to say on a machine without WSL, which includes every
+    /// non-Windows one — a section of rows about an absent subsystem is noise
+    /// in the report that has to stay readable.
+    #[test]
+    fn no_distros_means_no_wsl_section() {
+        assert!(wsl_checks(&[]).is_empty());
+    }
+
+    /// The whole point of the section: git, gh and delta are resolved inside
+    /// the distro and nothing else ever names the paths they resolved to.
+    #[test]
+    fn a_distro_reports_where_each_tool_resolved() {
+        let found = probe(&[Some("/usr/bin/git"), Some("/home/lev/.local/bin/gh"), None, None]);
+        let detail = wsl_distro_check("Ubuntu", &found).detail;
+        assert!(detail.contains("git /usr/bin/git"), "{detail:?}");
+        assert!(detail.contains("gh /home/lev/.local/bin/gh"), "{detail:?}");
+        assert!(detail.contains("no delta, doppler"), "{detail:?}");
+    }
+
+    /// A distro without git reads as a repository with nothing to report:
+    /// the sidebar lists the worktree, the git panel stays empty, and no
+    /// error is ever shown.
+    #[test]
+    fn a_distro_without_git_warns() {
+        assert_eq!(wsl_distro_check("Ubuntu", &probe(&[None; 4])).status, Status::Warn);
+        assert_eq!(
+            wsl_distro_check("Ubuntu", &probe(&[Some("/usr/bin/git"), None, None, None])).status,
+            Status::Ok
+        );
+    }
+
+    #[test]
+    fn a_distro_that_cannot_be_reached_says_why() {
+        let probe: Probe = Err("no answer in 15s".to_string());
+        let check = wsl_distro_check("Ubuntu", &probe);
+        assert_eq!(check.status, Status::Warn);
+        assert!(check.detail.contains("no answer in 15s"), "{:?}", check.detail);
+    }
+
+    /// Doppler inside a distro is set up by someone who expects worktrees
+    /// there to inherit its scopes.  They do not, and the app never says so.
+    #[test]
+    fn doppler_inside_a_distro_is_reported_as_unused() {
+        let probes = vec![
+            ("Ubuntu".to_string(), probe(&[None, None, None, Some("/usr/bin/doppler")])),
+            ("kali-linux".to_string(), probe(&[None; 4])),
+        ];
+        let check = wsl_doppler_check(&probes).expect("a warning about the unused doppler");
+        assert_eq!(check.status, Status::Warn);
+        assert!(check.detail.contains("Ubuntu"), "{:?}", check.detail);
+        assert!(!check.detail.contains("kali-linux"), "{:?}", check.detail);
+    }
+
+    #[test]
+    fn no_distro_has_doppler_and_nothing_is_said() {
+        let probes = vec![("Ubuntu".to_string(), probe(&[None; 4]))];
+        assert!(wsl_doppler_check(&probes).is_none());
     }
 
     /// A missing optional tool has to say what it costs, or the reader has no

--- a/alacritree/src/wsl.rs
+++ b/alacritree/src/wsl.rs
@@ -342,13 +342,9 @@ pub fn run_batch(distro: &str, script: &str, args: &[&str]) -> Result<Vec<u8>, S
     Ok(output.stdout)
 }
 
-/// Resolve `delta`'s absolute path inside `distro`, as the user's login shell
-/// sees it.  `wsl.exe --exec sh` only inherits the default system PATH, which
-/// omits per-user install dirs like `~/.cargo/bin`; sourcing the login shell
-/// (`getent passwd` → the user's shell, run with `-lc`) picks up the profile
-/// that puts delta on PATH.  One wsl.exe round trip — call off the UI thread.
-/// Returns `None` when delta isn't found; callers must not cache that, so an
-/// install mid-session is picked up on the next attempt.
+/// Resolve `delta`'s absolute path inside `distro`.  Returns `None` when delta
+/// isn't found; callers must not cache that, so an install mid-session is
+/// picked up on the next attempt.
 pub fn discover_delta(distro: &str) -> Option<String> {
     // The helper's hello already resolved delta through the login shell; a
     // missing capability is not a cached miss — fall through and re-check
@@ -356,21 +352,56 @@ pub fn discover_delta(distro: &str) -> Option<String> {
     if let Some(path) = crate::wsl_helper::capability_delta(distro) {
         return Some(path);
     }
-    let script = r#"s=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7); [ -x "$s" ] || s=${SHELL:-/bin/sh}; exec "$s" -lc 'command -v delta'"#;
+    probe_tools(distro, &["delta"]).ok()?.into_iter().next().flatten()
+}
+
+/// Resolve each of `programs` inside `distro` as the user's login shell sees
+/// them, in one wsl.exe round trip — call off the UI thread.  Results are
+/// positional: a program that is not on that PATH comes back `None`.
+///
+/// `wsl.exe --exec sh` inherits only the default system PATH, which omits
+/// per-user install dirs like `~/.cargo/bin`; sourcing the login shell
+/// (`getent passwd` → the user's shell, run with `-lc`) picks up the profile
+/// that puts them there.  `|| echo` keeps a missing program's slot occupied,
+/// and is written the way the resident helper's hello line writes it because
+/// that form works in fish as well as in POSIX shells.
+///
+/// Program names are interpolated into the script, so they must be literals —
+/// nothing a user typed belongs here.
+pub fn probe_tools(distro: &str, programs: &[&str]) -> Result<Vec<Option<String>>, String> {
+    let probes: Vec<String> = programs.iter().map(|p| format!("command -v {p} || echo")).collect();
+    let script = format!(
+        r#"s=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7); [ -x "$s" ] || s=${{SHELL:-/bin/sh}}; exec "$s" -lc '{}'"#,
+        probes.join("; ")
+    );
     let output = command(distro, None)
         .arg("sh")
         .arg("-c")
         .arg(script)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+        .map_err(|e| format!("failed to run wsl.exe: {e}"))?;
+    // Empty stdout with a failing exit means wsl.exe itself refused, not that
+    // the probes came back empty-handed.
+    if !output.status.success() && output.stdout.is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() { "wsl.exe failed".to_string() } else { stderr });
     }
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if path.is_empty() { None } else { Some(path) }
+    Ok(parse_tool_paths(&output.stdout, programs.len()))
+}
+
+/// One line per program asked for, in order; an empty line is a program the
+/// login shell could not find.  A short answer — the shell died partway —
+/// pads with `None` rather than sliding every later result onto the wrong
+/// name.
+fn parse_tool_paths(stdout: &[u8], count: usize) -> Vec<Option<String>> {
+    let text = String::from_utf8_lossy(stdout);
+    let mut lines = text.lines();
+    (0..count)
+        .map(|_| lines.next().map(str::trim).filter(|l| !l.is_empty()).map(str::to_string))
+        .collect()
 }
 
 /// Split batched stdout on `SECTION_SEP`.  Always returns at least one
@@ -614,6 +645,30 @@ mod tests {
         );
         assert_eq!(ShellChoice::parse("profile:"), None);
         assert_eq!(ShellChoice::Profile("pwsh".to_string()).to_state_string(), "profile:pwsh");
+    }
+
+    #[test]
+    fn reads_one_probe_line_per_program() {
+        let stdout = b"/usr/bin/git\n\n/home/lev/.local/bin/gh\n";
+        assert_eq!(
+            parse_tool_paths(stdout, 3),
+            vec![
+                Some("/usr/bin/git".to_string()),
+                None,
+                Some("/home/lev/.local/bin/gh".to_string())
+            ]
+        );
+    }
+
+    /// A truncated answer must not slide the surviving paths onto the names
+    /// that follow them — reporting delta's path as doppler's is worse than
+    /// reporting neither.
+    #[test]
+    fn a_short_probe_answer_pads_rather_than_shifts() {
+        assert_eq!(
+            parse_tool_paths(b"/usr/bin/git\n", 3),
+            vec![Some("/usr/bin/git".to_string()), None, None]
+        );
     }
 
     /// Live round trip against the default distro.  Requires WSL; run


### PR DESCRIPTION
`alacritree doctor` said nothing about WSL. A project inside a distro is read
with that distro's own `git`, `gh` and `delta`, resolved through its login
shell, and none of that was reported. A distro without `git` shows an empty git
panel and no error, which looks exactly like a repository with nothing to
report.

Adds a WSL section that names each installed distro, says where those tools
resolved, and warns when `git` is missing. It also warns when a distro has
`doppler`: scope mirroring only ever runs the Windows one, so a WSL project's
worktrees come out unscoped however well doppler is set up inside the distro.

Probes run in parallel on a 15 s deadline. A cold VM takes seconds to answer
and a wedged one never does, and a report that hangs is worse than one that
says it could not tell.

Behaviour on machines without WSL is unchanged: the section is skipped.

---

Stack, merge in order:

1. **this PR** feat(doctor): report what each WSL distro can do
2. #185 fix(render): paint backgrounds before glyphs

Written by Claude Opus 5 in Claude Code.

Closes AbysmalBiscuit/alacritree#7
