### PR TITLE
feat(profiles): open shell profiles from the palette and sidebar [3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ projects still exist on disk, and whether a running instance is reachable. It
 needs no running window — "nothing happens when I run it" is exactly when it
 gets used.
 
+On Windows it also reports each installed WSL distro and where `git`, `gh`,
+`delta` and `doppler` resolve *inside* it. Those are the paths alacritree uses
+for a project that lives in a distro, and nothing else ever names them: a
+distro without `git` shows an empty git panel rather than an error.
+
 It exits non-zero only when something is genuinely broken. A missing optional
 tool is a warning, and a tool driving a feature you have never opted into (an
 absent `doppler` on a machine with no Doppler config) is not even that — a report

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -1209,13 +1209,20 @@ impl AlacritreeApp {
     /// override/auto resolution chain — the user asked for this profile
     /// explicitly.
     fn spawn_profile_session(&mut self, ctx: &Context, name: &str) {
+        let ws = self.current_workspace.clone();
+        self.spawn_profile_session_in(ctx, name, ws);
+    }
+
+    /// Spawn a named profile into an arbitrary workspace — the worktree
+    /// sidebar's profile menu targets the row it was opened on, which is
+    /// often not the workspace currently on screen.
+    fn spawn_profile_session_in(&mut self, ctx: &Context, name: &str, ws: WorkspaceKey) {
         let Some(profile) = self.config.profile(name) else {
             log::warn!("no shell profile named `{name}`");
             self.error_dialog = Some(format!("no shell profile named `{name}`"));
             return;
         };
         let (shell, wsl_probe) = profile_session_shell(profile);
-        let ws = self.current_workspace.clone();
         if let Err(e) = self.spawn_session_with_shell(ctx, ws, shell, wsl_probe) {
             self.error_dialog = Some(format!("failed to spawn profile `{name}`: {e}"));
         }
@@ -3211,6 +3218,8 @@ impl AlacritreeApp {
         let delete_request: std::cell::Cell<Option<PathBuf>> = std::cell::Cell::new(None);
         let create_request: std::cell::Cell<Option<usize>> = std::cell::Cell::new(None);
         let spawn_shell_request: std::cell::Cell<Option<WorkspaceKey>> = std::cell::Cell::new(None);
+        let spawn_profile_request: std::cell::Cell<Option<(PathBuf, String)>> =
+            std::cell::Cell::new(None);
         let activate_session_request: std::cell::Cell<Option<(WorkspaceKey, SessionId)>> =
             std::cell::Cell::new(None);
         let close_session_request: std::cell::Cell<Option<SessionId>> = std::cell::Cell::new(None);
@@ -3350,6 +3359,20 @@ impl AlacritreeApp {
         let icons = self.config.ui.icons.clone();
         let profile_names: Vec<String> =
             self.config.profiles.iter().map(|p| p.name.clone()).collect();
+        // Name + command pairs for the worktree row's "Open session" menu —
+        // the command is only ever shown as hover text, never painted.
+        let worktree_profiles: Vec<(String, String)> = self
+            .config
+            .profiles
+            .iter()
+            .map(|p| {
+                let command = std::iter::once(p.program.as_str())
+                    .chain(p.args.iter().map(String::as_str))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                (p.name.clone(), command)
+            })
+            .collect();
         let mut shell_override_changed: Option<PathBuf> = None;
         let mut label_cleared: Option<PathBuf> = None;
         let mut rename_request: Option<RenameState> = None;
@@ -3812,6 +3835,7 @@ impl AlacritreeApp {
                                     wt_attention,
                                     wt_glyph,
                                     is_deleting,
+                                    &worktree_profiles,
                                     &icons,
                                     &theme,
                                 );
@@ -3826,6 +3850,9 @@ impl AlacritreeApp {
                                 }
                                 if action.set_base {
                                     base_picker_request.set(Some(wt.path.clone()));
+                                }
+                                if let Some(name) = action.spawn_profile {
+                                    spawn_profile_request.set(Some((wt.path.clone(), name)));
                                 }
                                 let session_rows = worktree_session_rows
                                     .get(idx)
@@ -3937,6 +3964,19 @@ impl AlacritreeApp {
                     self.current_workspace = previous;
                     self.report_spawn_failure(ctx, &ws, &e);
                 },
+            }
+        }
+        if let Some((path, name)) = spawn_profile_request.take() {
+            // Same activate-on-success shape as `spawn_shell_request`, but
+            // `spawn_profile_session_in` already reports its own failure
+            // through `error_dialog` rather than a `Result` — a grown session
+            // count is what stands in for success here.
+            let ws = Some(path);
+            let sessions_before = self.sessions.len();
+            self.spawn_profile_session_in(ctx, &name, ws.clone());
+            if self.sessions.len() > sessions_before {
+                self.current_workspace = ws;
+                workspace_activated = true;
             }
         }
         self.poll_worktree_liveness(ctx, probing, &drawn_worktrees.into_inner());
@@ -5984,6 +6024,8 @@ struct WorktreeAction {
     delete: bool,
     spawn: bool,
     set_base: bool,
+    /// Name of the profile picked from the row's "Open session" menu, if any.
+    spawn_profile: Option<String>,
 }
 
 /// Everything a sidebar session row needs, snapshotted before the panel
@@ -6495,6 +6537,17 @@ fn upstream_badge<'a>(
     }
 }
 
+/// Width the worktree row's context menu is held to, so a long profile name
+/// wraps onto a second line instead of stretching the popup to fit it.
+const WORKTREE_MENU_MAX_WIDTH: f32 = 220.0;
+
+/// The "index. name" label for a profile entry in the worktree row's "Open
+/// session" menu, 1-based to match `SpawnProfile1`..`SpawnProfile9` in the
+/// palette.
+fn profile_menu_label(index: usize, name: &str) -> String {
+    format!("{index}. {name}")
+}
+
 fn worktree_row(
     ui: &mut egui::Ui,
     wt: &Worktree,
@@ -6511,6 +6564,10 @@ fn worktree_row(
     attention: bool,
     agent_glyph: Option<char>,
     deleting: bool,
+    // Shell profiles offered in the row's "Open session" menu: `.0` is the
+    // profile name (spawned and shown as the button label), `.1` is the
+    // command shown on hover.
+    profiles: &[(String, String)],
     icons: &Icons,
     theme: &Theme,
 ) -> WorktreeAction {
@@ -6669,10 +6726,23 @@ fn worktree_row(
     }
 
     let mut set_base_clicked = false;
+    let mut spawn_profile_clicked: Option<String> = None;
     resp.context_menu(|ui| {
+        ui.set_max_width(WORKTREE_MENU_MAX_WIDTH);
         if ui.button("Set base branch…").clicked() {
             set_base_clicked = true;
             ui.close_menu();
+        }
+        if !profiles.is_empty() {
+            ui.separator();
+            ui.label(RichText::new("Open session").color(theme.text_muted).small());
+            for (i, (name, command)) in profiles.iter().enumerate() {
+                let btn = ui.button(profile_menu_label(i + 1, name));
+                if btn.on_hover_text(command.as_str()).clicked() {
+                    spawn_profile_clicked = Some(name.clone());
+                    ui.close_menu();
+                }
+            }
         }
     });
 
@@ -6700,6 +6770,7 @@ fn worktree_row(
         delete: delete_clicked,
         spawn: spawn_clicked,
         set_base: set_base_clicked,
+        spawn_profile: spawn_profile_clicked,
     }
 }
 
@@ -9052,6 +9123,12 @@ mod tests {
     }
 
     #[test]
+    fn profile_menu_label_numbers_from_one() {
+        assert_eq!(profile_menu_label(1, "WSL"), "1. WSL");
+        assert_eq!(profile_menu_label(2, "cmd"), "2. cmd");
+    }
+
+    #[test]
     fn base_branch_precedence_is_override_then_pr_then_default() {
         let f = effective_base_branch;
         assert_eq!(f(Some("develop"), Some("main"), Some("master")), Some("develop".into()));
@@ -10212,7 +10289,19 @@ mod tests {
 
         let texts = texts_while_hovering(140.0, |ui| {
             worktree_row(
-                ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                ui,
+                &wt,
+                None,
+                &wt.name,
+                None,
+                true,
+                false,
+                false,
+                false,
+                None,
+                false,
+                &[],
+                &icons,
                 &theme,
             );
         });
@@ -10373,7 +10462,19 @@ mod tests {
         let output = ctx.run(input, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 worktree_row(
-                    ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                    ui,
+                    &wt,
+                    None,
+                    &wt.name,
+                    None,
+                    true,
+                    false,
+                    false,
+                    false,
+                    None,
+                    false,
+                    &[],
+                    &icons,
                     &theme,
                 );
             });
@@ -10506,6 +10607,7 @@ mod tests {
                 false,
                 None,
                 false,
+                &[],
                 &icons,
                 theme,
             );
@@ -10806,7 +10908,19 @@ mod tests {
         let output = ctx.run(input, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 worktree_row(
-                    ui, &wt, None, &wt.name, None, true, false, false, false, None, false, &icons,
+                    ui,
+                    &wt,
+                    None,
+                    &wt.name,
+                    None,
+                    true,
+                    false,
+                    false,
+                    false,
+                    None,
+                    false,
+                    &[],
+                    &icons,
                     &theme,
                 );
             });
@@ -10860,7 +10974,19 @@ mod tests {
 
             let texts = texts_while_hovering(140.0, |ui| {
                 worktree_row(
-                    ui, &wt, None, name, None, true, false, false, false, None, false, &icons,
+                    ui,
+                    &wt,
+                    None,
+                    name,
+                    None,
+                    true,
+                    false,
+                    false,
+                    false,
+                    None,
+                    false,
+                    &[],
+                    &icons,
                     &theme,
                 );
             });
@@ -10932,6 +11058,7 @@ mod tests {
                     false,
                     None,
                     false,
+                    &[],
                     &icons,
                     &theme,
                 );

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -6728,7 +6728,6 @@ fn worktree_row(
     let mut set_base_clicked = false;
     let mut spawn_profile_clicked: Option<String> = None;
     resp.context_menu(|ui| {
-        ui.set_max_width(WORKTREE_MENU_MAX_WIDTH);
         if ui.button("Set base branch…").clicked() {
             set_base_clicked = true;
             ui.close_menu();
@@ -6736,6 +6735,7 @@ fn worktree_row(
         if !profiles.is_empty() {
             ui.separator();
             ui.label(RichText::new("Open session").color(theme.text_muted).small());
+            ui.set_max_width(WORKTREE_MENU_MAX_WIDTH);
             for (i, (name, command)) in profiles.iter().enumerate() {
                 let btn = ui.button(profile_menu_label(i + 1, name));
                 if btn.on_hover_text(command.as_str()).clicked() {

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -23,7 +23,7 @@ use crate::config::{
     DEFAULT_UPSTREAM_DIVERGED_ICON, DEFAULT_UPSTREAM_GONE_ICON, DEFAULT_UPSTREAM_LEVEL_ICON,
     DEFAULT_UPSTREAM_UNTRACKED_ICON, DEFAULT_WORKTREE_ICON, DEFAULT_WORKTREE_MAIN_ICON, FontConfig,
     IconStyle, Icons, LastSessionClose, PathStyleConfig, ScrollbarStyle, SearchScope, SidebarFocus,
-    SidebarTooltips, TextEmphasis, UiFont,
+    SidebarTooltips, TextEmphasis, UiFont, profile_command,
 };
 use crate::doppler;
 use crate::file_drop;
@@ -1207,25 +1207,35 @@ impl AlacritreeApp {
 
     /// Spawn a named profile into the current workspace, bypassing the
     /// override/auto resolution chain — the user asked for this profile
-    /// explicitly.
+    /// explicitly.  Raises `error_dialog` directly: this wrapper's three
+    /// callers (the `SpawnProfileN` keybinding, the tab strip `+`, and the
+    /// palette) have no stale-row state to reconcile, unlike the sidebar's
+    /// `spawn_profile_session_in` caller.
     fn spawn_profile_session(&mut self, ctx: &Context, name: &str) {
         let ws = self.current_workspace.clone();
-        self.spawn_profile_session_in(ctx, name, ws);
+        if let Err(e) = self.spawn_profile_session_in(ctx, name, ws) {
+            self.error_dialog = Some(format!("failed to spawn profile `{name}`: {e}"));
+        }
     }
 
     /// Spawn a named profile into an arbitrary workspace — the worktree
     /// sidebar's profile menu targets the row it was opened on, which is
-    /// often not the workspace currently on screen.
-    fn spawn_profile_session_in(&mut self, ctx: &Context, name: &str, ws: WorkspaceKey) {
+    /// often not the workspace currently on screen.  Returns the error
+    /// instead of raising `error_dialog` itself so the sidebar caller can
+    /// run it through `report_spawn_failure`, matching `spawn_shell_request`.
+    fn spawn_profile_session_in(
+        &mut self,
+        ctx: &Context,
+        name: &str,
+        ws: WorkspaceKey,
+    ) -> std::io::Result<SessionId> {
         let Some(profile) = self.config.profile(name) else {
-            log::warn!("no shell profile named `{name}`");
-            self.error_dialog = Some(format!("no shell profile named `{name}`"));
-            return;
+            let msg = format!("no shell profile named `{name}`");
+            log::warn!("{msg}");
+            return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg));
         };
         let (shell, wsl_probe) = profile_session_shell(profile);
-        if let Err(e) = self.spawn_session_with_shell(ctx, ws, shell, wsl_probe) {
-            self.error_dialog = Some(format!("failed to spawn profile `{name}`: {e}"));
-        }
+        self.spawn_session_with_shell(ctx, ws, shell, wsl_probe)
     }
 
     /// Shell for a workspace; `None` means "no override" — `Session::spawn`
@@ -3361,18 +3371,8 @@ impl AlacritreeApp {
             self.config.profiles.iter().map(|p| p.name.clone()).collect();
         // Name + command pairs for the worktree row's "Open session" menu —
         // the command is only ever shown as hover text, never painted.
-        let worktree_profiles: Vec<(String, String)> = self
-            .config
-            .profiles
-            .iter()
-            .map(|p| {
-                let command = std::iter::once(p.program.as_str())
-                    .chain(p.args.iter().map(String::as_str))
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                (p.name.clone(), command)
-            })
-            .collect();
+        let worktree_profiles: Vec<(String, String)> =
+            self.config.profiles.iter().map(|p| (p.name.clone(), profile_command(p))).collect();
         let mut shell_override_changed: Option<PathBuf> = None;
         let mut label_cleared: Option<PathBuf> = None;
         let mut rename_request: Option<RenameState> = None;
@@ -3967,16 +3967,18 @@ impl AlacritreeApp {
             }
         }
         if let Some((path, name)) = spawn_profile_request.take() {
-            // Same activate-on-success shape as `spawn_shell_request`, but
-            // `spawn_profile_session_in` already reports its own failure
-            // through `error_dialog` rather than a `Result` — a grown session
-            // count is what stands in for success here.
+            // Same activate-on-success and stale-row-recovery shape as
+            // `spawn_shell_request`: a stale worktree row's `+` reaches
+            // `report_spawn_failure` today, and a profile picked from the
+            // same row's menu must un-grey it the same way.
             let ws = Some(path);
-            let sessions_before = self.sessions.len();
-            self.spawn_profile_session_in(ctx, &name, ws.clone());
-            if self.sessions.len() > sessions_before {
-                self.current_workspace = ws;
-                workspace_activated = true;
+            let previous = std::mem::replace(&mut self.current_workspace, ws.clone());
+            match self.spawn_profile_session_in(ctx, &name, ws.clone()) {
+                Ok(_) => workspace_activated = true,
+                Err(e) => {
+                    self.current_workspace = previous;
+                    self.report_spawn_failure(ctx, &ws, &e);
+                },
             }
         }
         self.poll_worktree_liveness(ctx, probing, &drawn_worktrees.into_inner());
@@ -7437,10 +7439,7 @@ impl AlacritreeApp {
             // config name to search by.
             let config_name =
                 if index <= 9 { format!("SpawnProfile{index}") } else { String::new() };
-            let command = std::iter::once(profile.program.as_str())
-                .chain(profile.args.iter().map(String::as_str))
-                .collect::<Vec<_>>()
-                .join(" ");
+            let command = profile_command(profile);
             let keys = command_palette::profile_keys(&self.config.bindings, index as u8);
             items.push(PaletteItem::profile(profile.name.clone(), command, keys, &config_name));
         }

--- a/alacritree/src/app.rs
+++ b/alacritree/src/app.rs
@@ -7355,11 +7355,24 @@ impl AlacritreeApp {
     }
 
     /// Everything the palette can act on this frame: every runnable keyboard
-    /// action, then each open session, then each switchable workspace.  Rebuilt
-    /// each frame — cheap beside ranking, and always current as sessions and
-    /// worktrees come and go.
+    /// action, then each configured shell profile, then each open session,
+    /// then each switchable workspace.  Rebuilt each frame — cheap beside
+    /// ranking, and always current as sessions and worktrees come and go.
     fn palette_items(&self) -> Vec<PaletteItem> {
         let mut items = command_palette::action_items(&self.config.bindings);
+        for (i, profile) in self.config.profiles.iter().enumerate() {
+            let index = i + 1;
+            // SpawnProfile only binds indices 1..=9; past that there is no
+            // config name to search by.
+            let config_name =
+                if index <= 9 { format!("SpawnProfile{index}") } else { String::new() };
+            let command = std::iter::once(profile.program.as_str())
+                .chain(profile.args.iter().map(String::as_str))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let keys = command_palette::profile_keys(&self.config.bindings, index as u8);
+            items.push(PaletteItem::profile(profile.name.clone(), command, keys, &config_name));
+        }
         for session in &self.sessions {
             let ws = self.workspace_label(&session.working_directory);
             items.push(PaletteItem::session(
@@ -7437,6 +7450,10 @@ impl AlacritreeApp {
                         error: None,
                     });
                 }
+            },
+            PaletteAction::SpawnProfile(name) => {
+                self.spawn_profile_session(ctx, &name);
+                self.focus_terminal();
             },
         }
     }

--- a/alacritree/src/cli/doctor.rs
+++ b/alacritree/src/cli/doctor.rs
@@ -12,9 +12,10 @@
 //! It answers without a running instance, because "nothing happens when I run
 //! it" is precisely when it gets used.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 
@@ -95,9 +96,12 @@ pub fn run(as_json: bool, socket: Option<&Path>) -> i32 {
 fn report(socket: Option<&Path>) -> Vec<Check> {
     let config = config::load();
 
+    // Rows are grouped by section on the way out, so each section has to be
+    // added in one run — a section split in two prints its header twice.
     let mut checks = binary_checks();
     checks.extend(gh_auth_check());
     checks.push(shell_check(config.shell.as_ref()));
+    checks.extend(wsl_checks(&wsl::distros()));
     checks.extend(config_checks(&config::diagnose()));
     checks.extend(persisted_state_checks(&config));
     checks.extend(ipc_checks(socket, config.ipc_socket));
@@ -186,6 +190,134 @@ fn gh_auth_check() -> Option<Check> {
         let detail = "not authenticated — PR base branches fall back to the repo default";
         check("binaries", "gh auth", Status::Warn, detail)
     })
+}
+
+/// The tools alacritree resolves inside a distro, and the order a probe
+/// answers in.  `doppler` is here even though nothing runs it there yet,
+/// because [`wsl_doppler_check`] is the only place that says so.
+const WSL_TOOLS: [&str; 4] = ["git", "gh", "delta", "doppler"];
+
+/// One wsl.exe round trip per distro, in parallel and on a deadline: a distro
+/// whose VM is cold takes seconds to answer and one that is wedged never
+/// does, and a report that hangs is worse than one that says it could not
+/// tell.
+const WSL_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// What a probe of one distro found — a path per entry of [`WSL_TOOLS`] — or
+/// why the distro could not be asked.
+type Probe = Result<Vec<Option<String>>, String>;
+
+/// What each installed distro can actually do for alacritree.  Nothing else
+/// reports on the inside of a distro: git, gh and delta are resolved there
+/// silently, and their absence looks exactly like a repository with nothing
+/// to say.  Empty when WSL is not installed, which is also every non-Windows
+/// machine.
+fn wsl_checks(distros: &[wsl::WslDistro]) -> Vec<Check> {
+    if distros.is_empty() {
+        return Vec::new();
+    }
+    let names: Vec<String> = distros
+        .iter()
+        .map(|d| if d.is_default { format!("{} (default)", d.name) } else { d.name.clone() })
+        .collect();
+
+    let probes = probe_distros(distros);
+    let mut checks = vec![check("wsl", "distros", Status::Ok, names.join(", "))];
+    checks.extend(probes.iter().map(|(name, probe)| wsl_distro_check(name, probe)));
+    checks.extend(wsl_doppler_check(&probes));
+    checks
+}
+
+fn probe_distros(distros: &[wsl::WslDistro]) -> Vec<(String, Probe)> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    for distro in distros {
+        let tx = tx.clone();
+        let name = distro.name.clone();
+        std::thread::spawn(move || {
+            let probe = wsl::probe_tools(&name, &WSL_TOOLS);
+            let _ = tx.send((name, probe));
+        });
+    }
+    drop(tx);
+
+    let deadline = Instant::now() + WSL_PROBE_TIMEOUT;
+    let mut answered: HashMap<String, Probe> = HashMap::new();
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        match rx.recv_timeout(remaining) {
+            Ok((name, probe)) => {
+                answered.insert(name, probe);
+            },
+            Err(_) => break,
+        }
+    }
+
+    distros
+        .iter()
+        .map(|d| {
+            let probe = answered
+                .remove(&d.name)
+                .unwrap_or_else(|| Err(format!("no answer in {}s", WSL_PROBE_TIMEOUT.as_secs())));
+            (d.name.clone(), probe)
+        })
+        .collect()
+}
+
+fn wsl_distro_check(name: &str, probe: &Probe) -> Check {
+    let found = match probe {
+        Ok(found) => found,
+        // Not alacritree's fault, but every project inside the distro is
+        // unreadable until it starts.
+        Err(e) => return check("wsl", name, Status::Warn, format!("unreachable — {e}")),
+    };
+
+    let mut present = Vec::new();
+    let mut missing = Vec::new();
+    for tool in WSL_TOOLS {
+        match tool_path(found, tool) {
+            Some(path) => present.push(format!("{tool} {path}")),
+            None => missing.push(tool),
+        }
+    }
+    let mut detail =
+        if present.is_empty() { "nothing found".to_string() } else { present.join(", ") };
+    if !missing.is_empty() {
+        detail.push_str(&format!("; no {}", missing.join(", ")));
+    }
+
+    // git is what reads a project that lives in the distro; without it the
+    // sidebar lists the worktree and can say nothing else about it.
+    let status = if tool_path(found, "git").is_some() { Status::Ok } else { Status::Warn };
+    check("wsl", name, status, detail)
+}
+
+/// Scope mirroring runs the Windows `doppler` against Windows paths, so a
+/// distro's own doppler is never consulted and a WSL project's worktrees come
+/// out unscoped however well doppler is set up inside the distro.  Someone
+/// who installed it there did so expecting otherwise.
+fn wsl_doppler_check(probes: &[(String, Probe)]) -> Option<Check> {
+    let distros: Vec<&str> = probes
+        .iter()
+        .filter(|(_, probe)| {
+            probe.as_ref().is_ok_and(|found| tool_path(found, "doppler").is_some())
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if distros.is_empty() {
+        return None;
+    }
+    let detail = format!(
+        "installed in {} — scope mirroring only runs the Windows doppler, so worktrees of a \
+         project inside a distro are not scoped",
+        distros.join(", ")
+    );
+    Some(check("wsl", "doppler", Status::Warn, detail))
+}
+
+/// Where a probe put `tool`, by name rather than by index, so [`WSL_TOOLS`]
+/// can be reordered without silently renaming everyone's results.
+fn tool_path<'a>(found: &'a [Option<String>], tool: &str) -> Option<&'a str> {
+    let slot = WSL_TOOLS.iter().position(|t| *t == tool)?;
+    found.get(slot)?.as_deref()
 }
 
 /// A configured shell that cannot be resolved takes every session with it: the
@@ -621,6 +753,69 @@ mod tests {
     fn doppler_is_only_worth_warning_about_once_it_has_been_set_up() {
         assert_eq!(doppler_need(true), Need::Optional);
         assert_eq!(doppler_need(false), Need::Unused);
+    }
+
+    fn probe(paths: &[Option<&str>]) -> Probe {
+        Ok(paths.iter().map(|p| p.map(str::to_string)).collect())
+    }
+
+    /// Nothing to say on a machine without WSL, which includes every
+    /// non-Windows one — a section of rows about an absent subsystem is noise
+    /// in the report that has to stay readable.
+    #[test]
+    fn no_distros_means_no_wsl_section() {
+        assert!(wsl_checks(&[]).is_empty());
+    }
+
+    /// The whole point of the section: git, gh and delta are resolved inside
+    /// the distro and nothing else ever names the paths they resolved to.
+    #[test]
+    fn a_distro_reports_where_each_tool_resolved() {
+        let found = probe(&[Some("/usr/bin/git"), Some("/home/lev/.local/bin/gh"), None, None]);
+        let detail = wsl_distro_check("Ubuntu", &found).detail;
+        assert!(detail.contains("git /usr/bin/git"), "{detail:?}");
+        assert!(detail.contains("gh /home/lev/.local/bin/gh"), "{detail:?}");
+        assert!(detail.contains("no delta, doppler"), "{detail:?}");
+    }
+
+    /// A distro without git reads as a repository with nothing to report:
+    /// the sidebar lists the worktree, the git panel stays empty, and no
+    /// error is ever shown.
+    #[test]
+    fn a_distro_without_git_warns() {
+        assert_eq!(wsl_distro_check("Ubuntu", &probe(&[None; 4])).status, Status::Warn);
+        assert_eq!(
+            wsl_distro_check("Ubuntu", &probe(&[Some("/usr/bin/git"), None, None, None])).status,
+            Status::Ok
+        );
+    }
+
+    #[test]
+    fn a_distro_that_cannot_be_reached_says_why() {
+        let probe: Probe = Err("no answer in 15s".to_string());
+        let check = wsl_distro_check("Ubuntu", &probe);
+        assert_eq!(check.status, Status::Warn);
+        assert!(check.detail.contains("no answer in 15s"), "{:?}", check.detail);
+    }
+
+    /// Doppler inside a distro is set up by someone who expects worktrees
+    /// there to inherit its scopes.  They do not, and the app never says so.
+    #[test]
+    fn doppler_inside_a_distro_is_reported_as_unused() {
+        let probes = vec![
+            ("Ubuntu".to_string(), probe(&[None, None, None, Some("/usr/bin/doppler")])),
+            ("kali-linux".to_string(), probe(&[None; 4])),
+        ];
+        let check = wsl_doppler_check(&probes).expect("a warning about the unused doppler");
+        assert_eq!(check.status, Status::Warn);
+        assert!(check.detail.contains("Ubuntu"), "{:?}", check.detail);
+        assert!(!check.detail.contains("kali-linux"), "{:?}", check.detail);
+    }
+
+    #[test]
+    fn no_distro_has_doppler_and_nothing_is_said() {
+        let probes = vec![("Ubuntu".to_string(), probe(&[None; 4]))];
+        assert!(wsl_doppler_check(&probes).is_none());
     }
 
     /// A missing optional tool has to say what it costs, or the reader has no

--- a/alacritree/src/command_palette.rs
+++ b/alacritree/src/command_palette.rs
@@ -32,6 +32,8 @@ pub enum PaletteAction {
     SwitchWorkspace(WorkspaceKey),
     /// Open the new-worktree prompt for a project, keyed by its root.
     CreateWorktree(PathBuf),
+    /// Spawn a `[[ui.profiles]]` entry by name into the current workspace.
+    SpawnProfile(String),
 }
 
 /// The heading a row files under. Grouping keeps the list readable now that a
@@ -45,6 +47,7 @@ pub enum PaletteSection {
     Sidebar,
     Filters,
     Window,
+    Profiles,
     OpenSessions,
     SwitchWorkspace,
     NewWorktree,
@@ -60,6 +63,7 @@ impl PaletteSection {
             Self::Sidebar => "Sidebar & focus",
             Self::Filters => "Filters",
             Self::Window => "Window & application",
+            Self::Profiles => "Shell profiles",
             Self::OpenSessions => "Open sessions",
             Self::SwitchWorkspace => "Switch workspace",
             Self::NewWorktree => "New worktree",
@@ -155,6 +159,25 @@ impl PaletteItem {
             secondary,
         )
     }
+
+    /// A `[[ui.profiles]]` entry. `config_name` (the `SpawnProfileN` string
+    /// bound-key parsers accept, empty past index 9) is folded into the
+    /// search haystack so typing it still finds the row, without painting a
+    /// name the profile itself never carries.
+    pub fn profile(name: String, command: String, keys: String, config_name: &str) -> Self {
+        let mut item = Self::new(
+            PaletteAction::SpawnProfile(name.clone()),
+            PaletteSection::Profiles,
+            keys,
+            name,
+            command,
+        );
+        if !config_name.is_empty() {
+            item.search.push(' ');
+            item.search.push_str(config_name);
+        }
+        item
+    }
 }
 
 /// Rows the palette must not offer to run: unbinds, the pass-through marker,
@@ -163,8 +186,13 @@ impl PaletteItem {
 /// "scroll the palette" row could never do anything. Their keys are advertised
 /// in the palette's footer hint instead.
 fn is_hidden(a: NamedAction) -> bool {
-    matches!(a, NamedAction::NoOp | NamedAction::ReceiveChar | NamedAction::TogglePalette)
-        || a.is_palette_scoped()
+    matches!(
+        a,
+        NamedAction::NoOp
+            | NamedAction::ReceiveChar
+            | NamedAction::TogglePalette
+            | NamedAction::SpawnProfile(_)
+    ) || a.is_palette_scoped()
 }
 
 /// Every runnable keyboard action as one row, listing every key bound to it.
@@ -195,6 +223,11 @@ fn keys_for(bindings: &[KeyBinding], action: NamedAction) -> String {
         .map(|b| format_shortcut(b.key, b.mods))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Every trigger bound to `SpawnProfile(index)`, for a profile's palette row.
+pub fn profile_keys(bindings: &[KeyBinding], index: u8) -> String {
+    keys_for(bindings, NamedAction::SpawnProfile(index))
 }
 
 /// The first key bound to `action`, for the footer hint.
@@ -421,10 +454,23 @@ const PAGE: usize = 10;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bindings::parse_bindings;
+    use crate::bindings::{RawBinding, parse_bindings};
 
     fn find<'a>(items: &'a [PaletteItem], config_name: &str) -> Option<&'a PaletteItem> {
         items.iter().find(|i| i.secondary == config_name)
+    }
+
+    /// A binding of `SpawnProfile{index}` to an arbitrary key, for exercising
+    /// the profile palette rows.
+    fn bind_spawn_profile(index: u8) -> RawBinding {
+        RawBinding {
+            key: "1".into(),
+            mods: Some("Control|Shift".into()),
+            mode: None,
+            chars: None,
+            action: Some(format!("SpawnProfile{index}")),
+            command: None,
+        }
     }
 
     #[test]
@@ -600,5 +646,50 @@ mod tests {
         let items = action_items(&parse_bindings(vec![]));
         assert_eq!(find(&items, "TogglePrOpenFilter").unwrap().keys, "");
         assert_eq!(find(&items, "ToggleSessionsFilter").unwrap().keys, "S");
+    }
+
+    #[test]
+    fn profile_row_carries_the_key_bound_to_its_index() {
+        let bindings = parse_bindings(vec![bind_spawn_profile(2)]);
+        let keys = profile_keys(&bindings, 2);
+        assert_eq!(keys, keys_for(&bindings, NamedAction::SpawnProfile(2)));
+        assert!(!keys.is_empty());
+
+        let item =
+            PaletteItem::profile("nushell".into(), "nu.exe".into(), keys.clone(), "SpawnProfile2");
+        assert_eq!(item.keys, keys);
+    }
+
+    #[test]
+    fn profile_row_without_a_binding_has_empty_keys() {
+        let bindings = parse_bindings(vec![]);
+        let keys = profile_keys(&bindings, 3);
+        assert!(keys.is_empty());
+
+        let item = PaletteItem::profile("cmd".into(), "cmd.exe".into(), keys, "SpawnProfile3");
+        assert!(item.keys.is_empty());
+    }
+
+    #[test]
+    fn bound_spawn_profile_produces_no_generic_action_row() {
+        let bindings = parse_bindings(vec![bind_spawn_profile(2)]);
+        let items = action_items(&bindings);
+        assert!(
+            !items.iter().any(|i| i.action == PaletteAction::Run(NamedAction::SpawnProfile(2))),
+            "the Profiles section owns this row now"
+        );
+    }
+
+    #[test]
+    fn searching_the_config_name_ranks_the_profile_row_without_painting_it() {
+        let item =
+            PaletteItem::profile("nushell".into(), "nu.exe".into(), String::new(), "SpawnProfile2");
+        assert!(!item.primary.contains("SpawnProfile2"));
+        assert!(!item.secondary.contains("SpawnProfile2"));
+
+        let items = vec![item];
+        let mut palette = CommandPalette::new();
+        palette.query_mut().push_str("SpawnProfile2");
+        assert_eq!(palette.rank(&items), vec![0]);
     }
 }

--- a/alacritree/src/config.rs
+++ b/alacritree/src/config.rs
@@ -212,6 +212,16 @@ impl Config {
     }
 }
 
+/// The command a profile runs, as shown to the user: `program` followed by
+/// `args`, joined by single spaces. A profile with no args shows just the
+/// program.
+pub fn profile_command(p: &Profile) -> String {
+    std::iter::once(p.program.as_str())
+        .chain(p.args.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 #[derive(Debug, Clone)]
 pub struct Palette {
     pub fg: Rgb,
@@ -2752,6 +2762,19 @@ program = "second"
         let config = raw.into_config();
         assert!(config.profiles.is_empty());
         assert_eq!(config.default_profile, None);
+    }
+
+    #[test]
+    fn profile_command_joins_program_and_args() {
+        let no_args = Profile { name: "cmd".into(), program: "cmd.exe".into(), args: vec![] };
+        assert_eq!(profile_command(&no_args), "cmd.exe");
+
+        let with_args = Profile {
+            name: "ubuntu".into(),
+            program: "wsl.exe".into(),
+            args: vec!["-d".into(), "ubuntu".into()],
+        };
+        assert_eq!(profile_command(&with_args), "wsl.exe -d ubuntu");
     }
 
     #[test]

--- a/alacritree/src/terminal_view.rs
+++ b/alacritree/src/terminal_view.rs
@@ -1000,19 +1000,33 @@ fn paint_grid(
     ctx: &egui::Context,
 ) {
     let bg_color = background(&config.palette);
+    // Every background goes down before any glyph does.  A background is an
+    // opaque fill over the whole run, so painting one run at a time cuts off
+    // whatever the run before it overhung into its first cell — which is how a
+    // Nerd Font icon a shade wider than its cell loses its right edge.
+    // Alacritty's renderer already works this way: one background pass over
+    // the whole batch, then the text passes (`renderer/text/gles2.rs`).
     for run in &snapshot.runs {
-        paint_run(
+        paint_run_background(
             painter,
             rect,
             &snapshot.text[run.text.clone()],
-            run.start_col,
-            rect.min.y + run.row as f32 * cell_h,
+            run,
             cell_w,
             cell_h,
+            bg_color,
+        );
+    }
+    for run in &snapshot.runs {
+        paint_run_glyphs(
+            painter,
+            rect,
+            &snapshot.text[run.text.clone()],
             run,
             config,
             font_id,
-            bg_color,
+            cell_w,
+            cell_h,
             ppp,
             metrics,
             builtin_glyphs,
@@ -1057,19 +1071,41 @@ fn font_for_flags(flags: Flags, normal: &FontId) -> FontId {
     FontId::new(normal.size, family)
 }
 
-#[allow(clippy::too_many_arguments)]
-fn paint_run(
+/// The cells `style` covers, in screen points.
+fn run_rect(rect: Rect, run: &str, style: &Run, cell_w: f32, cell_h: f32) -> Rect {
+    let width = run.chars().count() as f32 * cell_w;
+    let x = rect.min.x + style.start_col as f32 * cell_w;
+    let y = rect.min.y + style.row as f32 * cell_h;
+    Rect::from_min_size(Pos2::new(x, y), Vec2::new(width, cell_h))
+}
+
+/// A run matching the terminal's own background needs no fill: the window is
+/// already that colour, and emitting one shape per run would multiply the
+/// frame's geometry for nothing.
+fn paint_run_background(
     painter: &egui::Painter,
     rect: Rect,
     run: &str,
-    start_col: usize,
-    y: f32,
+    style: &Run,
     cell_w: f32,
     cell_h: f32,
+    default_bg: Color32,
+) {
+    if style.bg != default_bg || style.selected {
+        painter.rect_filled(run_rect(rect, run, style, cell_w, cell_h), 0.0, style.bg);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn paint_run_glyphs(
+    painter: &egui::Painter,
+    rect: Rect,
+    run: &str,
     style: &Run,
     config: &Config,
     font_id: &FontId,
-    default_bg: Color32,
+    cell_w: f32,
+    cell_h: f32,
     ppp: f32,
     metrics: &Metrics,
     builtin_glyphs: &mut BuiltinGlyphCache,
@@ -1077,14 +1113,9 @@ fn paint_run(
     glyphs: &mut GlyphCache,
     ctx: &egui::Context,
 ) {
-    let (fg, bg) = (style.fg, style.bg);
-    let width = run.chars().count() as f32 * cell_w;
-    let x = rect.min.x + start_col as f32 * cell_w;
-    let bg_rect = Rect::from_min_size(Pos2::new(x, y), Vec2::new(width, cell_h));
-
-    if bg != default_bg || style.selected {
-        painter.rect_filled(bg_rect, 0.0, bg);
-    }
+    let fg = style.fg;
+    let cells = run_rect(rect, run, style, cell_w, cell_h);
+    let (x, y) = (cells.min.x, cells.min.y);
 
     if !style.flags.contains(Flags::HIDDEN) {
         // Per-glyph paint: egui's run layout drifts off the cursor's `col * cell_w` grid (worse with zoom).
@@ -1144,6 +1175,9 @@ fn paint_run(
         }
     }
 
+    // Decorations belong to the glyph pass: drawn with the backgrounds, the
+    // next run's fill would bury them.
+    let width = cells.width();
     if style.flags.intersects(Flags::ALL_UNDERLINES) {
         let uy = y + cell_h - 1.5;
         painter
@@ -1749,6 +1783,99 @@ mod tests {
             ctx.fonts(|f| f.glyph_width(&FontId::monospace(config.font.egui_size()), '\u{fb01}'));
         assert!(glyph_w > cell_w * 1.25, "the fixture's letter is not over-wide");
         assert_eq!(x_of(&painted, "\u{fb01}"), origin + cell_w, "a letter was grown");
+    }
+
+    /// One shape from a painted frame, reduced to the two kinds whose order
+    /// decides what survives: a solid fill, and a glyph drawn on top of it.
+    #[derive(Debug, PartialEq)]
+    enum Painted {
+        Fill(Color32),
+        Glyph(String),
+    }
+
+    /// Everything a frame painted, in paint order.
+    fn painted_order(
+        ctx: &egui::Context,
+        session: &mut Session,
+        config: &Config,
+        caches: &mut Caches,
+        screen: Vec2,
+    ) -> Vec<Painted> {
+        let raw = egui::RawInput {
+            screen_rect: Some(Rect::from_min_size(Pos2::ZERO, screen)),
+            ..Default::default()
+        };
+        let out = ctx.run(raw, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                show(
+                    ui,
+                    session,
+                    config,
+                    true,
+                    &mut caches.builtin,
+                    &mut caches.ime,
+                    &mut caches.colors,
+                    &mut caches.glyphs,
+                    &mut caches.snapshot,
+                );
+            });
+        });
+        let mut painted = Vec::new();
+        for clipped in &out.shapes {
+            collect_order(&clipped.shape, &mut painted);
+        }
+        painted
+    }
+
+    fn collect_order(shape: &egui::Shape, out: &mut Vec<Painted>) {
+        match shape {
+            egui::Shape::Rect(rect) => out.push(Painted::Fill(rect.fill)),
+            egui::Shape::Text(text) => out.push(Painted::Glyph(text.galley.text().to_owned())),
+            egui::Shape::Vec(shapes) => shapes.iter().for_each(|s| collect_order(s, out)),
+            _ => {},
+        }
+    }
+
+    /// A run's background is an opaque fill over the whole run, so painting the
+    /// runs one at a time cuts off whatever the run before overhung into its
+    /// first cell — an icon a shade wider than its cell loses its right edge
+    /// wherever a colour changes.  Backgrounds all go down first instead.
+    #[test]
+    fn every_background_is_painted_before_any_glyph() {
+        let config = Config::default();
+        let ctx = ctx_with_terminal_faces();
+        let (mut session, _dir) = headless_session(&ctx, &config);
+        let mut caches = Caches::new();
+        let screen = Vec2::new(640.0, 480.0);
+
+        painted_order(&ctx, &mut session, &config, &mut caches, screen);
+        let (cols, rows) = (session.size.columns, session.size.screen_lines);
+        let red = {
+            let mut term = session.term.lock();
+            term.resize(TermSize::new(cols, rows));
+            // A block cursor fills its cell after every run has painted, which
+            // would fail this on its own; DECTCEM leaves the run passes alone.
+            Processor::<StdSyncHandler>::new().advance(&mut *term, b"\x1b[?25lM\x1b[41mX");
+            rgb_to_color32(resolve(
+                AnsiColor::Named(alacritty_terminal::vte::ansi::NamedColor::Red),
+                Flags::empty(),
+                term.colors(),
+                &config.palette,
+                false,
+            ))
+        };
+
+        let painted = painted_order(&ctx, &mut session, &config, &mut caches, screen);
+
+        let fill = painted
+            .iter()
+            .position(|p| *p == Painted::Fill(red))
+            .expect("the red run painted no background");
+        let glyph = painted
+            .iter()
+            .position(|p| matches!(p, Painted::Glyph(g) if g == "M"))
+            .expect("M was not painted");
+        assert!(fill < glyph, "a background was painted over the glyph before it");
     }
 
     /// The snapshot resolves every cell's foreground, background and face

--- a/alacritree/src/wsl.rs
+++ b/alacritree/src/wsl.rs
@@ -342,13 +342,9 @@ pub fn run_batch(distro: &str, script: &str, args: &[&str]) -> Result<Vec<u8>, S
     Ok(output.stdout)
 }
 
-/// Resolve `delta`'s absolute path inside `distro`, as the user's login shell
-/// sees it.  `wsl.exe --exec sh` only inherits the default system PATH, which
-/// omits per-user install dirs like `~/.cargo/bin`; sourcing the login shell
-/// (`getent passwd` → the user's shell, run with `-lc`) picks up the profile
-/// that puts delta on PATH.  One wsl.exe round trip — call off the UI thread.
-/// Returns `None` when delta isn't found; callers must not cache that, so an
-/// install mid-session is picked up on the next attempt.
+/// Resolve `delta`'s absolute path inside `distro`.  Returns `None` when delta
+/// isn't found; callers must not cache that, so an install mid-session is
+/// picked up on the next attempt.
 pub fn discover_delta(distro: &str) -> Option<String> {
     // The helper's hello already resolved delta through the login shell; a
     // missing capability is not a cached miss — fall through and re-check
@@ -356,21 +352,56 @@ pub fn discover_delta(distro: &str) -> Option<String> {
     if let Some(path) = crate::wsl_helper::capability_delta(distro) {
         return Some(path);
     }
-    let script = r#"s=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7); [ -x "$s" ] || s=${SHELL:-/bin/sh}; exec "$s" -lc 'command -v delta'"#;
+    probe_tools(distro, &["delta"]).ok()?.into_iter().next().flatten()
+}
+
+/// Resolve each of `programs` inside `distro` as the user's login shell sees
+/// them, in one wsl.exe round trip — call off the UI thread.  Results are
+/// positional: a program that is not on that PATH comes back `None`.
+///
+/// `wsl.exe --exec sh` inherits only the default system PATH, which omits
+/// per-user install dirs like `~/.cargo/bin`; sourcing the login shell
+/// (`getent passwd` → the user's shell, run with `-lc`) picks up the profile
+/// that puts them there.  `|| echo` keeps a missing program's slot occupied,
+/// and is written the way the resident helper's hello line writes it because
+/// that form works in fish as well as in POSIX shells.
+///
+/// Program names are interpolated into the script, so they must be literals —
+/// nothing a user typed belongs here.
+pub fn probe_tools(distro: &str, programs: &[&str]) -> Result<Vec<Option<String>>, String> {
+    let probes: Vec<String> = programs.iter().map(|p| format!("command -v {p} || echo")).collect();
+    let script = format!(
+        r#"s=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7); [ -x "$s" ] || s=${{SHELL:-/bin/sh}}; exec "$s" -lc '{}'"#,
+        probes.join("; ")
+    );
     let output = command(distro, None)
         .arg("sh")
         .arg("-c")
         .arg(script)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+        .map_err(|e| format!("failed to run wsl.exe: {e}"))?;
+    // Empty stdout with a failing exit means wsl.exe itself refused, not that
+    // the probes came back empty-handed.
+    if !output.status.success() && output.stdout.is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() { "wsl.exe failed".to_string() } else { stderr });
     }
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if path.is_empty() { None } else { Some(path) }
+    Ok(parse_tool_paths(&output.stdout, programs.len()))
+}
+
+/// One line per program asked for, in order; an empty line is a program the
+/// login shell could not find.  A short answer — the shell died partway —
+/// pads with `None` rather than sliding every later result onto the wrong
+/// name.
+fn parse_tool_paths(stdout: &[u8], count: usize) -> Vec<Option<String>> {
+    let text = String::from_utf8_lossy(stdout);
+    let mut lines = text.lines();
+    (0..count)
+        .map(|_| lines.next().map(str::trim).filter(|l| !l.is_empty()).map(str::to_string))
+        .collect()
 }
 
 /// Split batched stdout on `SECTION_SEP`.  Always returns at least one
@@ -614,6 +645,30 @@ mod tests {
         );
         assert_eq!(ShellChoice::parse("profile:"), None);
         assert_eq!(ShellChoice::Profile("pwsh".to_string()).to_state_string(), "profile:pwsh");
+    }
+
+    #[test]
+    fn reads_one_probe_line_per_program() {
+        let stdout = b"/usr/bin/git\n\n/home/lev/.local/bin/gh\n";
+        assert_eq!(
+            parse_tool_paths(stdout, 3),
+            vec![
+                Some("/usr/bin/git".to_string()),
+                None,
+                Some("/home/lev/.local/bin/gh".to_string())
+            ]
+        );
+    }
+
+    /// A truncated answer must not slide the surviving paths onto the names
+    /// that follow them — reporting delta's path as doppler's is worse than
+    /// reporting neither.
+    #[test]
+    fn a_short_probe_answer_pads_rather_than_shifts() {
+        assert_eq!(
+            parse_tool_paths(b"/usr/bin/git\n", 3),
+            vec![Some("/usr/bin/git".to_string()), None, None]
+        );
     }
 
     /// Live round trip against the default distro.  Requires WSL; run


### PR DESCRIPTION
`[[ui.profiles]]` entries were effectively unreachable. Only two things launched
one: a `SpawnProfileN` binding, or right-clicking the session tab strip's `+`.
`show_tab_strip` returns early (`app.rs:3101`) when a workspace holds fewer than
two sessions and `ui.session_display.tabs_always` is false, so for most configs
that `+` never draws at all. Right-clicking the sidebar `+` bubbled up to the
worktree row's "Set base branch…" menu instead.

Adds two entry points, each appearing only when `[[ui.profiles]]` is non-empty,
so a config without profiles renders exactly as it did before. No config gate,
because there is nothing to gate: an empty profile list produces no UI.

A "Shell profiles" section in the Ctrl+K palette lists one row per profile with
its name, command, and the keys bound to its `SpawnProfileN` index. Searching
`SpawnProfile2` still finds the row, and the generic bindings-derived rows are
suppressed so nothing appears twice.

A numbered "Open session" section in the sidebar worktree row's context menu
sits below "Set base branch…", entries labelled `N. name` with the command as
hover text. It spawns in that row's worktree rather than the active one, which
is the whole point of putting it on the row.

`alacritree/src/{app.rs,command_palette.rs,config.rs}`, +276/−19.

---

Stack, merge in order:

1. #184 feat(doctor): report what each WSL distro can do
2. #185 fix(render): paint backgrounds before glyphs
3. **this PR** feat(profiles): open shell profiles from the palette and sidebar

Based on #185, so its commits show here until those merge.

Written by Claude Opus 5 in Claude Code.

Closes AbysmalBiscuit/alacritree#14
