### PR TITLE
fix(ci): use GITHUB_TOKEN for upstream sync PRs

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -25,14 +25,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.ALACRITREE_BOT_TOKEN }}
           # We rev-parse upstream/master to compare commit ranges, which
           # needs the full history rather than the shallow default.
           fetch-depth: 0
 
       - name: Check for upstream updates
         env:
-          GH_TOKEN: ${{ secrets.ALACRITREE_BOT_TOKEN }}
+          # The explicit permissions above and the repository setting allow
+          # this short-lived, repository-scoped token to push and open PRs.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           marker=.github/upstream-sync.toml


### PR DESCRIPTION
## Summary

- use the built-in `GITHUB_TOKEN` for checkout, branch pushes, and PR creation
- retain the workflow’s explicit `contents: write` and `pull-requests: write` permissions
- avoid the repository PAT that pushes successfully but cannot run the GraphQL `createPullRequest` mutation

The repository setting already permits GitHub Actions to create pull requests. The built-in token is short-lived and scoped to this repository; its marker-only PR does not need to trigger another workflow run.

Fixes the failure in https://github.com/mathix420/alacritree/actions/runs/32687822982.

## Validation

- `actionlint v1.7.12 .github/workflows/upstream-sync.yml`
- `git diff --check origin/master...HEAD`