### PR TITLE
fix(pty): hold a read-loop visit to one announcement [1]

### DIFF
--- a/alacritree/src/pty_rearm.rs
+++ b/alacritree/src/pty_rearm.rs
@@ -12,12 +12,18 @@
 //! exiting — which is why a pane streaming megabytes only advances while the
 //! user types.
 //!
-//! Wrapping the reader posts that packet, one per visit of the read loop.  One
-//! is enough: the visit it wakes hands back everything the loop will take
-//! before it stops, and announces again if anything is left behind it.  One is
-//! also the ceiling — see `HANDBACK`.  A visit that emptied the pipe announces
-//! nothing at all, because reaching that empty read is what makes `piper`
-//! install its waker, and the waker announces the next byte.
+//! Wrapping the reader posts that packet.  What has to hold is that the
+//! packets a visit posts never outnumber the visits they buy, or the backlog
+//! doubles every round until a wait returns nothing but stale packets.  A visit
+//! that emptied the pipe announces nothing at all, because reaching that empty
+//! read is what makes `piper` install its waker, and the waker announces the
+//! next byte.  Every other visit announces once — see `HANDBACK`.
+//!
+//! One case still posts more than it consumes: a visit that cannot reach the
+//! terminal lock reads again without parsing, and each of those reads
+//! announces.  Nothing inside a reader can see a visit boundary, so this is
+//! bounded only by how long the UI thread holds the lock.  It is worth knowing
+//! about; it is not what stalls a pane.
 
 use std::io::{self, Read};
 use std::sync::Arc;
@@ -37,31 +43,34 @@ const MAX_LOCKED_READ: usize = u16::MAX as usize;
 /// The read loop reserves the terminal for as long as it runs and stops once
 /// it has parsed `MAX_LOCKED_READ`, but it checks that cap only after parsing
 /// whatever the last read returned.  A read carrying the whole cap therefore
-/// ends the visit by itself, which is what holds the announcement above to one
-/// packet per visit.
+/// ends the visit by itself, which is what holds an uncontended visit to one
+/// announcement.  `take` fills the whole cap even across a refill for the same
+/// reason: a short hand-back leaves the visit under the cap, so it reads once
+/// more and announces once more.
 ///
-/// Handing back less does not bound the parse — the cap already does that — it
-/// only costs the visit a second read, and a read that leaves bytes behind
-/// announces the pipe again.  Two packets per visit buy two visits, which post
-/// four, and the backlog doubles until every wait returns a thousand stale
-/// packets.  The loop drains the channel carrying keystrokes once per wait, so
-/// by then a Ctrl-C waits behind tens of megabytes of parsing and does not
-/// reach the child while output is streaming.
+/// Handing back less does not bound the parse — the cap already does that.  It
+/// costs the visit a second read, and two packets per visit buy two visits,
+/// which post four, and the backlog doubles until every wait returns a thousand
+/// stale packets.  The loop drains the channel carrying keystrokes once per
+/// wait, and the writable packet that finally carries a Ctrl-C to the child
+/// goes on the tail of that queue, so it waits behind the whole backlog.
 const HANDBACK: usize = MAX_LOCKED_READ;
 
-/// How much one visit may pull out of the console pipe ahead of the read loop.
+/// How much one refill may pull out of the console pipe ahead of the read loop.
 ///
-/// The pipe between the console and the read loop is a ring, filled by a
-/// thread that parks when it runs out of room.  Taking straight from the ring
-/// couples the two: the loop stops after `MAX_LOCKED_READ` and goes back to
-/// the poller, and the ring sits where the loop left it until it returns.
-/// Staging a visit ahead lets the filler keep running at the console's pace
-/// while the loop parses what it already holds.
+/// The pipe between the console and the read loop is a ring, filled by a thread
+/// that parks when it runs out of room.  Staging ahead of the parse lets that
+/// thread keep running at the console's pace while the loop works through what
+/// it already holds.  It does not take much: `piper` wakes the filler after
+/// every chunk it copies out, so the ring does not have to be emptied to unpark
+/// it, and one visit in hand is enough to keep the loop from waiting on a
+/// refill.
 ///
-/// One visit ahead is the whole benefit.  Anything staged past that is output
-/// already committed to the screen, so it is what a Ctrl-C waits through
-/// before the prompt comes back, and at the megabytes per second a terminal
-/// actually retires, every megabyte held here is most of a second of it.
+/// What is staged past that is output already committed to the screen, so it is
+/// what a Ctrl-C waits through before the prompt comes back.  The 1 MiB ring
+/// underneath is in that path too and dominates it; this is the half this side
+/// owns.  The value is reasoned, not measured — compare TermMarkV2 before
+/// changing it.
 const DRAIN_AHEAD: usize = 2 * HANDBACK;
 
 /// Bytes taken out of the console pipe ahead of the read loop, and how far the
@@ -70,23 +79,28 @@ const DRAIN_AHEAD: usize = 2 * HANDBACK;
 struct Staging {
     buf: Vec<u8>,
     taken: usize,
-    /// Whether the last refill reached the read that came up empty.  When it
-    /// stopped at `DRAIN_AHEAD` instead, `piper` was never asked for a byte it
-    /// could not supply and holds no waker, so nothing but this side can
-    /// announce what is left in the ring.
-    drained: bool,
+    /// Whether the last refill ended on a read that returned nothing, which is
+    /// what `UnblockedReader` reports once `piper` has taken the waker.  A
+    /// refill that stopped at `DRAIN_AHEAD` instead never asked for a byte
+    /// `piper` could not supply, so no waker was installed and nothing but this
+    /// side can announce what is left in the ring.
+    ///
+    /// The converse does not quite hold: `piper` yields on a non-empty ring
+    /// about once in a hundred drains, and that also reads as nothing.  It
+    /// wakes the reader on its way out, so the announcement comes through the
+    /// waker rather than from here.
+    rearmed: bool,
 }
 
 impl Staging {
     /// Empty `source` into the buffer, up to `DRAIN_AHEAD`.
     ///
-    /// Reaching the read that comes up empty is what lets `piper` install the
-    /// waker that announces the next byte, so how far this got decides who
-    /// announces next.
+    /// How far this got decides who announces next, so it records whether it
+    /// reached the read that returned nothing.
     fn refill(&mut self, source: &mut impl Read) -> io::Result<()> {
         self.buf.clear();
         self.taken = 0;
-        self.drained = false;
+        self.rearmed = false;
 
         while self.buf.len() < DRAIN_AHEAD {
             let base = self.buf.len();
@@ -94,14 +108,16 @@ impl Staging {
             match source.read(&mut self.buf[base..]) {
                 Ok(0) => {
                     self.buf.truncate(base);
-                    self.drained = true;
+                    self.rearmed = true;
                     break;
                 },
                 Ok(read) => self.buf.truncate(base + read),
                 Err(err) if err.kind() == io::ErrorKind::Interrupted => self.buf.truncate(base),
+                // `UnblockedReader` never reports this, and a source that did
+                // would not have armed a waker on the way out, so leave the
+                // announcement to this side.
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
                     self.buf.truncate(base);
-                    self.drained = true;
                     break;
                 },
                 Err(err) => {
@@ -113,23 +129,32 @@ impl Staging {
         Ok(())
     }
 
-    /// Hand the read loop one visit's worth, refilling first when the buffer
-    /// has run out.
+    /// Hand the read loop a whole visit's worth, refilling as the buffer runs
+    /// out, and stopping short only when the pipe has no more to give.
     ///
     /// Returns how much was handed back and whether anything is left for the
-    /// caller to announce, either here or behind an undrained ring.
+    /// caller to announce, either staged here or behind a ring nothing else
+    /// will speak for.
     fn take(&mut self, out: &mut [u8], source: &mut impl Read) -> io::Result<(usize, bool)> {
-        if self.taken == self.buf.len() {
-            self.refill(source)?;
+        let want = out.len().min(HANDBACK);
+        let mut read = 0;
+
+        while read < want {
+            if self.taken == self.buf.len() {
+                self.refill(source)?;
+                if self.buf.is_empty() {
+                    break;
+                }
+            }
+
+            let end = (self.taken + want - read).min(self.buf.len());
+            let staged = &self.buf[self.taken..end];
+            out[read..read + staged.len()].copy_from_slice(staged);
+            read += staged.len();
+            self.taken = end;
         }
 
-        let end = (self.taken + out.len().min(HANDBACK)).min(self.buf.len());
-        let staged = &self.buf[self.taken..end];
-        let read = staged.len();
-        out[..read].copy_from_slice(staged);
-        self.taken = end;
-
-        Ok((read, self.taken < self.buf.len() || !self.drained))
+        Ok((read, self.taken < self.buf.len() || !self.rearmed))
     }
 }
 
@@ -221,6 +246,39 @@ mod tests {
     /// than one hand-back.
     fn parse_buffer() -> Vec<u8> {
         vec![0; 4 * HANDBACK]
+    }
+
+    /// A source that gives back at most `chunk` bytes at a time, the way
+    /// `piper` does when the reader is at the filling thread's heels.
+    struct ShortReads {
+        remaining: usize,
+        chunk: usize,
+    }
+
+    impl Read for ShortReads {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let read = buf.len().min(self.chunk).min(self.remaining);
+            buf[..read].fill(b'x');
+            self.remaining -= read;
+            Ok(read)
+        }
+    }
+
+    /// A refill built out of short reads does not land on a multiple of the
+    /// visit cap, so somewhere in it a hand-back runs out mid-visit.  Stopping
+    /// there leaves the visit under the cap, so it reads again and announces
+    /// again: one visit, two packets, and the backlog grows every refill.
+    /// Crossing into the next refill instead keeps the visit to one read.
+    #[test]
+    fn a_short_read_still_fills_a_whole_handback() {
+        let mut source = ShortReads { remaining: 64 * HANDBACK, chunk: 20_000 };
+        let mut staging = Staging::default();
+        let mut buf = parse_buffer();
+
+        for take in 1..=8 {
+            let (read, _) = staging.take(&mut buf, &mut source).unwrap();
+            assert_eq!(read, HANDBACK, "take {take} left the visit short of its cap");
+        }
     }
 
     /// The read loop parses what a read returned before re-checking its own

--- a/alacritree/src/pty_rearm.rs
+++ b/alacritree/src/pty_rearm.rs
@@ -14,10 +14,10 @@
 //!
 //! Wrapping the reader posts that packet, one per visit of the read loop.  One
 //! is enough: the visit it wakes hands back everything the loop will take
-//! before it stops, and announces again only if bytes are still staged behind
-//! it.  One is also the ceiling — see `HANDBACK`.  A drain that emptied the
-//! pipe announces nothing at all, because reaching that empty read is what
-//! makes `piper` install its waker, and the waker announces the next byte.
+//! before it stops, and announces again if anything is left behind it.  One is
+//! also the ceiling — see `HANDBACK`.  A visit that emptied the pipe announces
+//! nothing at all, because reaching that empty read is what makes `piper`
+//! install its waker, and the waker announces the next byte.
 
 use std::io::{self, Read};
 use std::sync::Arc;
@@ -51,19 +51,18 @@ const HANDBACK: usize = MAX_LOCKED_READ;
 
 /// How much one visit may pull out of the console pipe ahead of the read loop.
 ///
-/// The pipe between the console and the read loop is a ring of exactly this
-/// size, filled by a thread that parks when it runs out of room.  The loop
-/// stops taking bytes after `MAX_LOCKED_READ`, so left to itself it empties
-/// sixty-four kilobytes per visit and goes back to the poller.  The ring stays
-/// full, the filling thread stays parked, and the console blocks on its own
-/// writes.  Draining the whole ring into a staging buffer first decouples the
-/// two: the filler keeps running at the console's pace while the loop takes
-/// what it can hold.
-const DRAIN_AHEAD: usize = PIPE_CAPACITY;
-
-/// Mirrors `alacritty_terminal::tty::windows::conpty::PIPE_CAPACITY`, which is
-/// private.
-const PIPE_CAPACITY: usize = 0x10_0000;
+/// The pipe between the console and the read loop is a ring, filled by a
+/// thread that parks when it runs out of room.  Taking straight from the ring
+/// couples the two: the loop stops after `MAX_LOCKED_READ` and goes back to
+/// the poller, and the ring sits where the loop left it until it returns.
+/// Staging a visit ahead lets the filler keep running at the console's pace
+/// while the loop parses what it already holds.
+///
+/// One visit ahead is the whole benefit.  Anything staged past that is output
+/// already committed to the screen, so it is what a Ctrl-C waits through
+/// before the prompt comes back, and at the megabytes per second a terminal
+/// actually retires, every megabyte held here is most of a second of it.
+const DRAIN_AHEAD: usize = 2 * HANDBACK;
 
 /// Bytes taken out of the console pipe ahead of the read loop, and how far the
 /// loop has got through them.
@@ -71,16 +70,23 @@ const PIPE_CAPACITY: usize = 0x10_0000;
 struct Staging {
     buf: Vec<u8>,
     taken: usize,
+    /// Whether the last refill reached the read that came up empty.  When it
+    /// stopped at `DRAIN_AHEAD` instead, `piper` was never asked for a byte it
+    /// could not supply and holds no waker, so nothing but this side can
+    /// announce what is left in the ring.
+    drained: bool,
 }
 
 impl Staging {
-    /// Empty `source` into the buffer.
+    /// Empty `source` into the buffer, up to `DRAIN_AHEAD`.
     ///
-    /// Stops on the read that comes up empty, which is what lets `piper`
-    /// install the waker that announces the next byte.
+    /// Reaching the read that comes up empty is what lets `piper` install the
+    /// waker that announces the next byte, so how far this got decides who
+    /// announces next.
     fn refill(&mut self, source: &mut impl Read) -> io::Result<()> {
         self.buf.clear();
         self.taken = 0;
+        self.drained = false;
 
         while self.buf.len() < DRAIN_AHEAD {
             let base = self.buf.len();
@@ -88,12 +94,14 @@ impl Staging {
             match source.read(&mut self.buf[base..]) {
                 Ok(0) => {
                     self.buf.truncate(base);
+                    self.drained = true;
                     break;
                 },
                 Ok(read) => self.buf.truncate(base + read),
                 Err(err) if err.kind() == io::ErrorKind::Interrupted => self.buf.truncate(base),
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
                     self.buf.truncate(base);
+                    self.drained = true;
                     break;
                 },
                 Err(err) => {
@@ -108,8 +116,8 @@ impl Staging {
     /// Hand the read loop one visit's worth, refilling first when the buffer
     /// has run out.
     ///
-    /// Returns how much was handed back and whether bytes are still staged,
-    /// which is what the caller has to announce.
+    /// Returns how much was handed back and whether anything is left for the
+    /// caller to announce, either here or behind an undrained ring.
     fn take(&mut self, out: &mut [u8], source: &mut impl Read) -> io::Result<(usize, bool)> {
         if self.taken == self.buf.len() {
             self.refill(source)?;
@@ -121,7 +129,7 @@ impl Staging {
         out[..read].copy_from_slice(staged);
         self.taken = end;
 
-        Ok((read, self.taken < self.buf.len()))
+        Ok((read, self.taken < self.buf.len() || !self.drained))
     }
 }
 
@@ -209,10 +217,10 @@ impl OnResize for RearmingPty {
 mod tests {
     use super::*;
 
-    /// What the read loop hands a read: its whole parse buffer, minus whatever
-    /// earlier reads in the same visit already filled.
+    /// What the read loop hands a read: its parse buffer, always room for more
+    /// than one hand-back.
     fn parse_buffer() -> Vec<u8> {
-        vec![0; PIPE_CAPACITY]
+        vec![0; 4 * HANDBACK]
     }
 
     /// The read loop parses what a read returned before re-checking its own
@@ -243,11 +251,30 @@ mod tests {
         assert_eq!(staging.take(&mut parse_buffer(), &mut source).unwrap(), (0, false));
     }
 
+    /// A refill that stopped at `DRAIN_AHEAD` never asked `piper` for a byte it
+    /// could not supply, so `piper` holds no waker and the ring may still be
+    /// full.  Handing back the last staged byte has to announce anyway: being
+    /// wrong costs one wakeup that finds nothing, and staying quiet costs a
+    /// pane that stops until the user types.
+    #[test]
+    fn a_refill_that_hit_the_cap_announces_its_last_byte() {
+        let mut source = io::Cursor::new(vec![b'x'; 4 * DRAIN_AHEAD]);
+        let mut staging = Staging::default();
+        let mut buf = parse_buffer();
+
+        let mut taken = 0;
+        while taken < DRAIN_AHEAD {
+            let (read, staged_behind) = staging.take(&mut buf, &mut source).unwrap();
+            taken += read;
+            assert!(staged_behind, "the ring was never drained, so only this side can announce");
+        }
+    }
+
     /// Every visit takes its cap and announces the remainder once, until the
     /// drain runs out.  Anything above one packet per visit compounds.
     #[test]
     fn a_drain_announces_once_per_visit() {
-        let staged = 4 * MAX_LOCKED_READ;
+        let staged = 4 * MAX_LOCKED_READ + 100;
         let mut source = io::Cursor::new(vec![b'x'; staged]);
         let mut staging = Staging::default();
         let mut buf = parse_buffer();

--- a/alacritree/src/pty_rearm.rs
+++ b/alacritree/src/pty_rearm.rs
@@ -12,12 +12,12 @@
 //! exiting — which is why a pane streaming megabytes only advances while the
 //! user types.
 //!
-//! Wrapping the reader posts that packet.  Every read carrying data announces
-//! the pipe again, so the loop keeps coming back until a drain finally comes
-//! up empty and `piper` takes over.  Announcing after the read that empties
-//! the pipe costs one wakeup that finds nothing; skipping it would restore the
-//! stall, because then no drain ever reaches the pending path that installs
-//! the waker.
+//! Wrapping the reader posts that packet, one per visit of the read loop.  One
+//! is enough: the visit it wakes hands back everything the loop will take
+//! before it stops, and announces again only if bytes are still staged behind
+//! it.  One is also the ceiling — see `HANDBACK`.  A drain that emptied the
+//! pipe announces nothing at all, because reaching that empty read is what
+//! makes `piper` install its waker, and the waker announces the next byte.
 
 use std::io::{self, Read};
 use std::sync::Arc;
@@ -29,17 +29,25 @@ use alacritty_terminal::tty::{
 use polling::os::iocp::{CompletionPacket, PollerIocpExt};
 use polling::{Event, PollMode, Poller};
 
+/// Mirrors `alacritty_terminal::event_loop::MAX_LOCKED_READ`, which is private.
+const MAX_LOCKED_READ: usize = u16::MAX as usize;
+
 /// How much one read may hand back.
 ///
 /// The read loop reserves the terminal for as long as it runs and stops once
-/// it has parsed its own cap, but it checks that cap only after parsing
-/// whatever the last read returned — so a single drain the size of its buffer
-/// becomes a single parse of the same size, and the pane holds the grid for as
-/// long as that takes.  A console delivers hundreds of kilobytes at a time
-/// under load, which is tens of milliseconds the UI thread spends queued for a
-/// lock it needs every frame.  Handing back a slice instead splits that into
-/// batches the loop can be interrupted between.
-const READ_CHUNK: usize = 32 * 1024;
+/// it has parsed `MAX_LOCKED_READ`, but it checks that cap only after parsing
+/// whatever the last read returned.  A read carrying the whole cap therefore
+/// ends the visit by itself, which is what holds the announcement above to one
+/// packet per visit.
+///
+/// Handing back less does not bound the parse — the cap already does that — it
+/// only costs the visit a second read, and a read that leaves bytes behind
+/// announces the pipe again.  Two packets per visit buy two visits, which post
+/// four, and the backlog doubles until every wait returns a thousand stale
+/// packets.  The loop drains the channel carrying keystrokes once per wait, so
+/// by then a Ctrl-C waits behind tens of megabytes of parsing and does not
+/// reach the child while output is streaming.
+const HANDBACK: usize = MAX_LOCKED_READ;
 
 /// How much one visit may pull out of the console pipe ahead of the read loop.
 ///
@@ -57,66 +65,81 @@ const DRAIN_AHEAD: usize = PIPE_CAPACITY;
 /// private.
 const PIPE_CAPACITY: usize = 0x10_0000;
 
-/// Owns the PTY because `EventedReadWrite` hands out `&mut Self::Reader`, and
-/// only the type holding the reader can supply that.
-pub struct RearmingReader {
-    pty: Pty,
-    poller: Option<Arc<Poller>>,
-    /// Bytes taken out of the pipe ahead of the read loop, and how far the loop
-    /// has got through them.
-    staged: Vec<u8>,
+/// Bytes taken out of the console pipe ahead of the read loop, and how far the
+/// loop has got through them.
+#[derive(Default)]
+struct Staging {
+    buf: Vec<u8>,
     taken: usize,
 }
 
-impl RearmingReader {
-    /// Empty the console pipe into the staging buffer.
+impl Staging {
+    /// Empty `source` into the buffer.
     ///
     /// Stops on the read that comes up empty, which is what lets `piper`
     /// install the waker that announces the next byte.
-    fn drain_pipe(&mut self) -> io::Result<()> {
-        let Self { pty, staged, .. } = self;
-        while staged.len() < DRAIN_AHEAD {
-            let base = staged.len();
-            staged.resize(base + READ_CHUNK, 0);
-            match pty.reader().read(&mut staged[base..]) {
+    fn refill(&mut self, source: &mut impl Read) -> io::Result<()> {
+        self.buf.clear();
+        self.taken = 0;
+
+        while self.buf.len() < DRAIN_AHEAD {
+            let base = self.buf.len();
+            self.buf.resize(base + HANDBACK, 0);
+            match source.read(&mut self.buf[base..]) {
                 Ok(0) => {
-                    staged.truncate(base);
+                    self.buf.truncate(base);
                     break;
                 },
-                Ok(read) => staged.truncate(base + read),
-                Err(err) if err.kind() == io::ErrorKind::Interrupted => staged.truncate(base),
+                Ok(read) => self.buf.truncate(base + read),
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => self.buf.truncate(base),
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
-                    staged.truncate(base);
+                    self.buf.truncate(base);
                     break;
                 },
                 Err(err) => {
-                    staged.truncate(base);
+                    self.buf.truncate(base);
                     return Err(err);
                 },
             }
         }
         Ok(())
     }
+
+    /// Hand the read loop one visit's worth, refilling first when the buffer
+    /// has run out.
+    ///
+    /// Returns how much was handed back and whether bytes are still staged,
+    /// which is what the caller has to announce.
+    fn take(&mut self, out: &mut [u8], source: &mut impl Read) -> io::Result<(usize, bool)> {
+        if self.taken == self.buf.len() {
+            self.refill(source)?;
+        }
+
+        let end = (self.taken + out.len().min(HANDBACK)).min(self.buf.len());
+        let staged = &self.buf[self.taken..end];
+        let read = staged.len();
+        out[..read].copy_from_slice(staged);
+        self.taken = end;
+
+        Ok((read, self.taken < self.buf.len()))
+    }
+}
+
+/// Owns the PTY because `EventedReadWrite` hands out `&mut Self::Reader`, and
+/// only the type holding the reader can supply that.
+pub struct RearmingReader {
+    pty: Pty,
+    poller: Option<Arc<Poller>>,
+    staged: Staging,
 }
 
 impl Read for RearmingReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if self.taken == self.staged.len() {
-            self.staged.clear();
-            self.taken = 0;
-            self.drain_pipe()?;
-        }
+        let Self { pty, staged, poller } = self;
+        let (read, staged_behind) = staged.take(buf, pty.reader())?;
 
-        let end = (self.taken + buf.len().min(READ_CHUNK)).min(self.staged.len());
-        let staged = &self.staged[self.taken..end];
-        let read = staged.len();
-        buf[..read].copy_from_slice(staged);
-        self.taken = end;
-
-        if read > 0 {
-            if let Some(poller) = &self.poller {
-                let _ = poller.post(CompletionPacket::new(Event::readable(PTY_READ_WRITE_TOKEN)));
-            }
+        if staged_behind && let Some(poller) = poller {
+            let _ = poller.post(CompletionPacket::new(Event::readable(PTY_READ_WRITE_TOKEN)));
         }
         Ok(read)
     }
@@ -128,7 +151,7 @@ pub struct RearmingPty {
 
 impl RearmingPty {
     pub fn new(pty: Pty) -> Self {
-        Self { reader: RearmingReader { pty, poller: None, staged: Vec::new(), taken: 0 } }
+        Self { reader: RearmingReader { pty, poller: None, staged: Staging::default() } }
     }
 }
 
@@ -179,5 +202,68 @@ impl EventedPty for RearmingPty {
 impl OnResize for RearmingPty {
     fn on_resize(&mut self, window_size: WindowSize) {
         self.reader.pty.on_resize(window_size);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// What the read loop hands a read: its whole parse buffer, minus whatever
+    /// earlier reads in the same visit already filled.
+    fn parse_buffer() -> Vec<u8> {
+        vec![0; PIPE_CAPACITY]
+    }
+
+    /// The read loop parses what a read returned before re-checking its own
+    /// `MAX_LOCKED_READ` cap, so a take carrying the cap ends the visit by
+    /// itself.  A shorter one costs the visit a second take, and every take
+    /// that leaves bytes behind announces the pipe again — the packets one
+    /// visit posts are the visits the next wait runs, so the backlog doubles.
+    #[test]
+    fn one_take_serves_a_whole_visit() {
+        let mut source = io::Cursor::new(vec![b'x'; 4 * MAX_LOCKED_READ]);
+        let mut staging = Staging::default();
+
+        let (read, staged_behind) = staging.take(&mut parse_buffer(), &mut source).unwrap();
+
+        assert!(read >= MAX_LOCKED_READ, "a visit stops after {MAX_LOCKED_READ}, got {read}");
+        assert!(staged_behind, "the rest of the drain still has to be announced");
+    }
+
+    /// Emptying the pipe leaves `piper` holding the waker, and that is what
+    /// announces the next byte.  Announcing here as well queues a packet the
+    /// loop wakes for and finds nothing behind.
+    #[test]
+    fn a_drained_pipe_announces_nothing() {
+        let mut source = io::Cursor::new(b"hello".to_vec());
+        let mut staging = Staging::default();
+
+        assert_eq!(staging.take(&mut parse_buffer(), &mut source).unwrap(), (5, false));
+        assert_eq!(staging.take(&mut parse_buffer(), &mut source).unwrap(), (0, false));
+    }
+
+    /// Every visit takes its cap and announces the remainder once, until the
+    /// drain runs out.  Anything above one packet per visit compounds.
+    #[test]
+    fn a_drain_announces_once_per_visit() {
+        let staged = 4 * MAX_LOCKED_READ;
+        let mut source = io::Cursor::new(vec![b'x'; staged]);
+        let mut staging = Staging::default();
+        let mut buf = parse_buffer();
+
+        let mut announced = 0;
+        let mut visits = 0;
+        loop {
+            let (read, staged_behind) = staging.take(&mut buf, &mut source).unwrap();
+            if read == 0 {
+                break;
+            }
+            visits += 1;
+            announced += usize::from(staged_behind);
+        }
+
+        assert_eq!(visits, staged.div_ceil(MAX_LOCKED_READ));
+        assert_eq!(announced, visits - 1, "only the last visit finds nothing staged behind it");
     }
 }

--- a/alacritree/src/pty_rearm.rs
+++ b/alacritree/src/pty_rearm.rs
@@ -12,18 +12,24 @@
 //! exiting — which is why a pane streaming megabytes only advances while the
 //! user types.
 //!
-//! Wrapping the reader posts that packet.  What has to hold is that the
-//! packets a visit posts never outnumber the visits they buy, or the backlog
-//! doubles every round until a wait returns nothing but stale packets.  A visit
-//! that emptied the pipe announces nothing at all, because reaching that empty
-//! read is what makes `piper` install its waker, and the waker announces the
-//! next byte.  Every other visit announces once — see `HANDBACK`.
+//! Wrapping the reader posts that packet.  Two things have to hold, and the
+//! second is the one that bites.
+//!
+//! A visit must not post more packets than it consumes, or the queue doubles
+//! every round until a wait returns nothing but stale packets — see `HANDBACK`.
+//!
+//! And a burst must end with a visit that posts nothing, or the queue never
+//! returns to empty.  Posting one for one holds the depth steady rather than
+//! draining it, so whatever depth a burst once reached it keeps, and the
+//! writable packet carrying a Ctrl-C sits on the tail behind all of it while
+//! the child keeps running.  The chain ends where `piper` takes the waker back,
+//! which is the read that comes up empty — see `DRAIN_AHEAD`.
 //!
 //! One case still posts more than it consumes: a visit that cannot reach the
 //! terminal lock reads again without parsing, and each of those reads
-//! announces.  Nothing inside a reader can see a visit boundary, so this is
-//! bounded only by how long the UI thread holds the lock.  It is worth knowing
-//! about; it is not what stalls a pane.
+//! announces.  Nothing inside a reader can see a visit boundary, so that is
+//! bounded only by how long the UI thread holds the lock.  It is survivable
+//! because the queue drains: the depth it adds goes away with the burst.
 
 use std::io::{self, Read};
 use std::sync::Arc;
@@ -56,22 +62,27 @@ const MAX_LOCKED_READ: usize = u16::MAX as usize;
 /// goes on the tail of that queue, so it waits behind the whole backlog.
 const HANDBACK: usize = MAX_LOCKED_READ;
 
-/// How much one refill may pull out of the console pipe ahead of the read loop.
+/// Mirrors `alacritty_terminal::tty::windows::conpty::PIPE_CAPACITY`, the ring
+/// between the console and the read loop.  Private upstream.
+const PIPE_CAPACITY: usize = 0x10_0000;
+
+/// A backstop on one refill, not a target.
 ///
-/// The pipe between the console and the read loop is a ring, filled by a thread
-/// that parks when it runs out of room.  Staging ahead of the parse lets that
-/// thread keep running at the console's pace while the loop works through what
-/// it already holds.  It does not take much: `piper` wakes the filler after
-/// every chunk it copies out, so the ring does not have to be emptied to unpark
-/// it, and one visit in hand is enough to keep the loop from waiting on a
-/// refill.
+/// This has to sit above the ring.  A refill that stops before the ring runs
+/// dry never asked `piper` for a byte it could not supply, so `piper` takes no
+/// waker and only this side can announce what is left.  Every visit then
+/// announces: one packet in, one packet out, and whatever depth the poller's
+/// queue once reached it holds forever.  The writable packet carrying a Ctrl-C
+/// is posted on the tail of that queue, so it waits behind all of it while the
+/// child keeps running.
 ///
-/// What is staged past that is output already committed to the screen, so it is
-/// what a Ctrl-C waits through before the prompt comes back.  The 1 MiB ring
-/// underneath is in that path too and dominates it; this is the half this side
-/// owns.  The value is reasoned, not measured — compare TermMarkV2 before
-/// changing it.
-const DRAIN_AHEAD: usize = 2 * HANDBACK;
+/// Reaching the empty read is what ends the chain.  The visit that empties the
+/// staging goes quiet, the queue drains to nothing, and `piper` announces the
+/// next byte.  Set below the ring, that never happens under load.
+///
+/// So the cap is only here to stop a filler thread that somehow outran a memcpy
+/// from growing the staging without bound.
+const DRAIN_AHEAD: usize = 2 * PIPE_CAPACITY;
 
 /// Bytes taken out of the console pipe ahead of the read loop, and how far the
 /// loop has got through them.
@@ -295,6 +306,22 @@ mod tests {
 
         assert!(read >= MAX_LOCKED_READ, "a visit stops after {MAX_LOCKED_READ}, got {read}");
         assert!(staged_behind, "the rest of the drain still has to be announced");
+    }
+
+    /// The whole ring arriving at once is the ordinary case under load, not an
+    /// extreme.  A refill has to get through it and reach the read that comes
+    /// up empty, because that is where `piper` takes the waker back and the
+    /// chain of announcements ends.  A cap at or below the ring stops the
+    /// refill first, every visit announces, and the poller's queue never
+    /// returns to empty — which is what leaves a Ctrl-C waiting behind it.
+    #[test]
+    fn a_ring_sized_burst_hands_the_waker_back() {
+        let mut source = io::Cursor::new(vec![b'x'; PIPE_CAPACITY]);
+        let mut staging = Staging::default();
+
+        staging.refill(&mut source).unwrap();
+
+        assert!(staging.rearmed, "the refill stopped short of the pipe, so nobody holds the waker");
     }
 
     /// Emptying the pipe leaves `piper` holding the waker, and that is what

--- a/alacritree/src/pty_rearm.rs
+++ b/alacritree/src/pty_rearm.rs
@@ -25,24 +25,23 @@
 //! the child keeps running.  The chain ends where `piper` takes the waker back,
 //! which is the read that comes up empty — see `DRAIN_AHEAD`.
 //!
-//! One case still posts more than it consumes: a visit that cannot reach the
-//! terminal lock reads again without parsing, and each of those reads
-//! announces.  Nothing inside a reader can see a visit boundary, so that is
-//! bounded only by how long the UI thread holds the lock.  It is survivable
-//! because the queue drains: the depth it adds goes away with the burst.
+//! A visit that cannot reach the terminal lock reads again without parsing.
+//! Those reads consume no packet, so announcing on each of them posts a parse
+//! buffer's worth of hand-backs for the one packet the visit took.  Painting
+//! the grid is what holds that lock, so under load this is the ordinary case
+//! rather than a rare one.  The loop offers its whole parse buffer at the top
+//! of a visit and what is left of it on every read after — see `VisitBudget`.
 
 use std::io::{self, Read};
 use std::sync::Arc;
 
 use alacritty_terminal::event::{OnResize, WindowSize};
+use alacritty_terminal::event_loop::{MAX_LOCKED_READ, READ_BUFFER_SIZE};
 use alacritty_terminal::tty::{
     ChildEvent, EventedPty, EventedReadWrite, PTY_READ_WRITE_TOKEN, Pty,
 };
 use polling::os::iocp::{CompletionPacket, PollerIocpExt};
 use polling::{Event, PollMode, Poller};
-
-/// Mirrors `alacritty_terminal::event_loop::MAX_LOCKED_READ`, which is private.
-const MAX_LOCKED_READ: usize = u16::MAX as usize;
 
 /// How much one read may hand back.
 ///
@@ -60,11 +59,16 @@ const MAX_LOCKED_READ: usize = u16::MAX as usize;
 /// stale packets.  The loop drains the channel carrying keystrokes once per
 /// wait, and the writable packet that finally carries a Ctrl-C to the child
 /// goes on the tail of that queue, so it waits behind the whole backlog.
+///
+/// Taken from the read loop's own cap rather than copied, because falling
+/// below it is what breaks `VisitBudget`: a hand-back short of the cap lets
+/// the loop parse, reset `unprocessed`, and offer the whole buffer again, and
+/// an offer that wide reads as a fresh visit with a fresh announcement.
 const HANDBACK: usize = MAX_LOCKED_READ;
 
-/// Mirrors `alacritty_terminal::tty::windows::conpty::PIPE_CAPACITY`, the ring
-/// between the console and the read loop.  Private upstream.
-const PIPE_CAPACITY: usize = 0x10_0000;
+/// The ring between the console and the read loop, which `conpty` sizes from
+/// the same constant.
+const PIPE_CAPACITY: usize = READ_BUFFER_SIZE;
 
 /// A backstop on one refill, not a target.
 ///
@@ -84,11 +88,22 @@ const PIPE_CAPACITY: usize = 0x10_0000;
 /// from growing the staging without bound.
 const DRAIN_AHEAD: usize = 2 * PIPE_CAPACITY;
 
+const _: () = assert!(
+    DRAIN_AHEAD > PIPE_CAPACITY,
+    "a refill that cannot outrun the ring never reaches the read that hands \
+     the waker back, so the announcements never stop",
+);
+
 /// Bytes taken out of the console pipe ahead of the read loop, and how far the
 /// loop has got through them.
 #[derive(Default)]
 struct Staging {
+    /// Kept at the high-water mark of what a refill has needed rather than
+    /// resized per read, because a lock the renderer holds turns the read loop
+    /// into a spin and every turn of it would otherwise zero a hand-back.
+    /// Bytes past `filled` are whatever the last refill left.
     buf: Vec<u8>,
+    filled: usize,
     taken: usize,
     /// Whether the last refill ended on a read that returned nothing, which is
     /// what `UnblockedReader` reports once `piper` has taken the waker.  A
@@ -96,10 +111,13 @@ struct Staging {
     /// `piper` could not supply, so no waker was installed and nothing but this
     /// side can announce what is left in the ring.
     ///
-    /// The converse does not quite hold: `piper` yields on a non-empty ring
-    /// about once in a hundred drains, and that also reads as nothing.  It
-    /// wakes the reader on its way out, so the announcement comes through the
-    /// waker rather than from here.
+    /// The converse does not quite hold.  `piper` drops the waker on a
+    /// non-empty ring and then, about once in a hundred drains, wakes it and
+    /// reports nothing anyway so a fast reader cannot starve the writer.  That
+    /// is indistinguishable from an empty ring here, and it has already queued
+    /// a packet — so a refill it interrupts mid-staging leaves this side
+    /// announcing on top of it, one extra packet in the queue until some visit
+    /// finds the staging empty.
     rearmed: bool,
 }
 
@@ -109,33 +127,37 @@ impl Staging {
     /// How far this got decides who announces next, so it records whether it
     /// reached the read that returned nothing.
     fn refill(&mut self, source: &mut impl Read) -> io::Result<()> {
-        self.buf.clear();
+        self.filled = 0;
         self.taken = 0;
         self.rearmed = false;
 
-        while self.buf.len() < DRAIN_AHEAD {
-            let base = self.buf.len();
-            self.buf.resize(base + HANDBACK, 0);
-            match source.read(&mut self.buf[base..]) {
+        while self.filled < DRAIN_AHEAD {
+            let room = self.filled + HANDBACK;
+            if self.buf.len() < room {
+                self.buf.resize(room, 0);
+            }
+            match source.read(&mut self.buf[self.filled..room]) {
                 Ok(0) => {
-                    self.buf.truncate(base);
                     self.rearmed = true;
                     break;
                 },
-                Ok(read) => self.buf.truncate(base + read),
-                Err(err) if err.kind() == io::ErrorKind::Interrupted => self.buf.truncate(base),
+                Ok(read) => self.filled += read,
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => {},
                 // `UnblockedReader` never reports this, and a source that did
                 // would not have armed a waker on the way out, so leave the
                 // announcement to this side.
-                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
-                    self.buf.truncate(base);
-                    break;
-                },
-                Err(err) => {
-                    self.buf.truncate(base);
-                    return Err(err);
-                },
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
+                Err(err) => return Err(err),
             }
+        }
+
+        // A burst leaves the high-water mark at `DRAIN_AHEAD`, which every
+        // session that ever saw one would otherwise hold for its whole life.
+        // A drained pipe with a hand-back or less behind it is the burst
+        // ending, so give the room back and pay one growth if it resumes.
+        if self.rearmed && self.filled <= HANDBACK && self.buf.len() > HANDBACK {
+            self.buf.truncate(HANDBACK);
+            self.buf.shrink_to_fit();
         }
         Ok(())
     }
@@ -151,21 +173,56 @@ impl Staging {
         let mut read = 0;
 
         while read < want {
-            if self.taken == self.buf.len() {
+            if self.taken == self.filled {
                 self.refill(source)?;
-                if self.buf.is_empty() {
+                if self.filled == 0 {
                     break;
                 }
             }
 
-            let end = (self.taken + want - read).min(self.buf.len());
+            let end = (self.taken + want - read).min(self.filled);
             let staged = &self.buf[self.taken..end];
             out[read..read + staged.len()].copy_from_slice(staged);
             read += staged.len();
             self.taken = end;
         }
 
-        Ok((read, self.taken < self.buf.len() || !self.rearmed))
+        Ok((read, self.taken < self.filled || !self.rearmed))
+    }
+}
+
+/// Holds a visit to one announcement, however many times it reads.
+///
+/// A visit starts with the whole parse buffer and reads `buf[unprocessed..]`
+/// after that, so an offer narrower than the widest yet seen is the loop going
+/// round again on a lock it could not take.  Calibrating on the widest offer
+/// rather than on a constant keeps this from mirroring a buffer size the read
+/// loop owns.
+///
+/// The count is per visit rather than per opening read because the read that
+/// has something to announce need not be the first.  An opening read that
+/// finds the pipe nearly empty leaves the waker with `piper` and says nothing;
+/// a burst landing before the next read fills the staging to `DRAIN_AHEAD`,
+/// where `piper` holds no waker and this side is all that can speak.
+#[derive(Default)]
+struct VisitBudget {
+    widest: usize,
+    spent: bool,
+}
+
+impl VisitBudget {
+    /// Whether a read offered this much room still has its visit's
+    /// announcement to give.  A read that says nothing keeps it for the next.
+    fn may_announce(&mut self, offered: usize) -> bool {
+        if offered >= self.widest {
+            self.widest = offered;
+            self.spent = false;
+        }
+        !self.spent
+    }
+
+    fn spend(&mut self) {
+        self.spent = true;
     }
 }
 
@@ -175,15 +232,26 @@ pub struct RearmingReader {
     pty: Pty,
     poller: Option<Arc<Poller>>,
     staged: Staging,
+    visit: VisitBudget,
 }
 
 impl Read for RearmingReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let Self { pty, staged, poller } = self;
+        let Self { pty, staged, poller, visit } = self;
+        let may_announce = visit.may_announce(buf.len());
         let (read, staged_behind) = staged.take(buf, pty.reader())?;
 
-        if staged_behind && let Some(poller) = poller {
-            let _ = poller.post(CompletionPacket::new(Event::readable(PTY_READ_WRITE_TOKEN)));
+        if staged_behind
+            && may_announce
+            && let Some(poller) = poller
+        {
+            // A post that failed announced nothing, and after a refill that hit
+            // the cap there is no waker either, so keep the budget for the next
+            // read of this visit rather than leaving the staging unspoken for.
+            let packet = CompletionPacket::new(Event::readable(PTY_READ_WRITE_TOKEN));
+            if poller.post(packet).is_ok() {
+                visit.spend();
+            }
         }
         Ok(read)
     }
@@ -195,7 +263,14 @@ pub struct RearmingPty {
 
 impl RearmingPty {
     pub fn new(pty: Pty) -> Self {
-        Self { reader: RearmingReader { pty, poller: None, staged: Staging::default() } }
+        Self {
+            reader: RearmingReader {
+                pty,
+                poller: None,
+                staged: Staging::default(),
+                visit: VisitBudget::default(),
+            },
+        }
     }
 }
 
@@ -292,6 +367,47 @@ mod tests {
         }
     }
 
+    /// A visit that cannot take the terminal lock reads again without parsing,
+    /// and reads its way down `buf[unprocessed..]` until the buffer is full.
+    /// Those reads consume no packet, so announcing on each of them hands the
+    /// poller a buffer's worth for the one the visit took — sixteen for one at
+    /// a megabyte buffer and a sixty-four kilobyte hand-back.
+    #[test]
+    fn a_visit_announces_once_however_often_it_reads() {
+        let mut visit = VisitBudget::default();
+        let buffer = 16 * HANDBACK;
+
+        assert!(visit.may_announce(buffer), "a visit opens with its announcement to give");
+        visit.spend();
+        for unprocessed in (HANDBACK..buffer).step_by(HANDBACK) {
+            let offered = buffer - unprocessed;
+            assert!(
+                !visit.may_announce(offered),
+                "{offered} of {buffer} is the loop going round on a lock it could not take",
+            );
+        }
+        assert!(visit.may_announce(buffer), "the next visit opens with one to give again");
+    }
+
+    /// The read with something to announce need not be the one that opened the
+    /// visit.  An opening read that finds the pipe nearly empty leaves the
+    /// waker with `piper` and says nothing; a burst landing before the next
+    /// read fills the staging to `DRAIN_AHEAD`, where `piper` holds no waker
+    /// and this side is all that can speak for what is staged.
+    #[test]
+    fn a_visit_that_opened_quiet_can_still_announce() {
+        let mut visit = VisitBudget::default();
+        let buffer = 16 * HANDBACK;
+
+        assert!(visit.may_announce(buffer), "the opening read is offered its announcement");
+        assert!(
+            visit.may_announce(buffer - HANDBACK),
+            "an opening read that said nothing leaves the announcement for the next",
+        );
+        visit.spend();
+        assert!(!visit.may_announce(buffer - 2 * HANDBACK), "the visit has now spent it");
+    }
+
     /// The read loop parses what a read returned before re-checking its own
     /// `MAX_LOCKED_READ` cap, so a take carrying the cap ends the visit by
     /// itself.  A shorter one costs the visit a second take, and every take
@@ -322,6 +438,22 @@ mod tests {
         staging.refill(&mut source).unwrap();
 
         assert!(staging.rearmed, "the refill stopped short of the pipe, so nobody holds the waker");
+    }
+
+    /// The staging grows to whatever the heaviest burst needed and the read
+    /// loop never asks for it back, so a pane that once printed a large file
+    /// would hold megabytes for the rest of its life — once per pane.
+    #[test]
+    fn a_burst_gives_its_room_back_when_the_pipe_drains() {
+        let mut staging = Staging::default();
+
+        staging.refill(&mut io::Cursor::new(vec![b'x'; PIPE_CAPACITY])).unwrap();
+        assert!(staging.buf.capacity() >= PIPE_CAPACITY, "the burst should have grown the staging");
+
+        staging.refill(&mut io::Cursor::new(Vec::new())).unwrap();
+
+        let held = staging.buf.capacity();
+        assert!(held <= 2 * HANDBACK, "a drained pipe left {held} bytes of staging behind");
     }
 
     /// Emptying the pipe leaves `piper` holding the waker, and that is what

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -21,10 +21,10 @@ use crate::{thread, tty};
 use vte::ansi;
 
 /// Max bytes to read from the PTY before forced terminal synchronization.
-pub(crate) const READ_BUFFER_SIZE: usize = 0x10_0000;
+pub const READ_BUFFER_SIZE: usize = 0x10_0000;
 
 /// Max bytes to read from the PTY while the terminal is locked.
-const MAX_LOCKED_READ: usize = u16::MAX as usize;
+pub const MAX_LOCKED_READ: usize = u16::MAX as usize;
 
 /// Messages that may be sent to the `EventLoop`.
 #[derive(Debug)]


### PR DESCRIPTION
Ctrl-C took about two seconds to reach a child under load, and a busy pane's output
arrived in lurches. Both were the same cause: the console reader was posting far more
IOCP completion packets than it consumed, and the writable packet carrying the Ctrl-C
byte queued behind the backlog.

## Problem

`RearmingReader` posts a completion packet whenever a read leaves bytes behind, because
`piper` arms its waker only on a read that comes up empty. That accounting assumed one
read per read-loop visit.

`pty_read` breaks the assumption. When it cannot take the terminal lock it does
`None => continue` (`alacritty_terminal/src/event_loop.rs:146`) and reads again *without
parsing*, on what is left of its parse buffer. One visit can read a megabyte buffer's
worth of 64 KiB hand-backs while consuming a single packet, and each of those reads was
announcing. Painting the grid is what holds that lock, so under load this was the
ordinary case rather than a rare one.

Measured with temporary instrumentation in `pty_read`, under termbench:

| | before | after |
| --- | --- | --- |
| deepest batch per `poll.wait` | 315 to 564 to 661 to 1024 | 1 to 4 |
| waits per second | 2 | 12 to 101 |
| Ctrl-C from write queue to pipe | 1.079s, 0.810s | 34us, 6.7ms, 53ms |

1024 is `Events::with_capacity(1024)`: the queue was saturated.

## Fix

Give each visit one announcement. The loop offers its whole parse buffer at the top of a
visit and `buf[unprocessed..]` on every read after, so an offer at least as wide as the
widest yet seen opens a new visit and refills the budget. The budget is spent only on a
post that succeeded and only when there was something to announce, so a visit that opened
on a near-empty pipe can still speak for a burst that lands before its next read.

That argument holds only while one hand-back ends a visit, so `HANDBACK` now comes from
the read loop's own `MAX_LOCKED_READ` rather than a copied number.

Two supporting changes in the same file: `Staging` keeps its buffer at the high-water mark
instead of clearing and regrowing, since the contended path would otherwise zero a
hand-back on every turn of the spin; and it returns the room when a refill finds the pipe
drained, rather than holding megabytes per pane for the process lifetime.

## Vendored change, flagging it explicitly

This touches `alacritty_terminal/src/event_loop.rs`, two visibility keywords and nothing
else:

```diff
-pub(crate) const READ_BUFFER_SIZE: usize = 0x10_0000;
+pub const READ_BUFFER_SIZE: usize = 0x10_0000;
-const MAX_LOCKED_READ: usize = u16::MAX as usize;
+pub const MAX_LOCKED_READ: usize = u16::MAX as usize;
```

No behavior change. It is there so `pty_rearm.rs` agrees with the read loop by
construction. With the constant hand-copied, a vendor bump that raised `MAX_LOCKED_READ`
past `HANDBACK` would let the loop parse, reset `unprocessed`, and offer the full buffer
again mid-visit, which reads as a fresh visit with a fresh announcement: the storm back at
sixteen posts per packet, with no compile error to catch it. A `const _: () = assert!(...)`
cannot see private constants, so the alternative is a comment and nothing else. Happy to
drop it for the comment if you would rather keep the vendored tree untouched.

## Testing

Nine unit tests on the reader, full suite green (1031 passed). Verified on Windows 11
against termbench with the instrumentation in place, then re-verified with it removed.

## Scope

The residual delay before a child actually dies is ConPTY's. Windows Terminal shows the
same magnitude on the same test, and the instrumentation puts this side at microseconds.
Nothing here tries to go further than that.

One known limitation is documented on `Staging::rearmed`: `piper`'s fairness yield
(`piper-0.2.4/src/lib.rs:1093`) reports nothing on a non-empty ring roughly once in a
hundred drains, which is indistinguishable from an empty ring from outside the crate. A
yield landing mid-staging adds one packet to the queue. Additive rather than
multiplicative, and cleared by any lull.

---

Written with Claude Opus 5 in Claude Code.

Closes AbysmalBiscuit/alacritree#18
