### PR TITLE
chore: cut dev debuginfo to line tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ resolver = "2"
 edition = "2024"
 rust-version = "1.85.0"
 
+# Dev builds are read through logs, harness output and panic backtraces, all of
+# which line tables carry.  Only a debugger stepping through frames wants the
+# variable and type information that makes up most of `target/debug`.
+[profile.dev]
+debug = "line-tables-only"
+
 [profile.release]
 lto = "thin"
 debug = 1


### PR DESCRIPTION
A debug build carries full variable and type information. Nothing in this project reads it: crash artifacts, `log` output and the `#[ignore]` timing harnesses all resolve through line tables alone. Only a debugger stepping through frames wants the rest, and it costs over half of `target/debug` — once per worktree.

`[profile.dev] debug = "line-tables-only"` keeps symbol names and `file:line`, so panic backtraces, flamegraphs and profiler attribution are unchanged. What it drops is local-variable inspection under a debugger; anyone who needs that can flip the line back for one rebuild.

`[profile.release]` is untouched, so nothing about release timing or profiling moves.

Measured on a clean tree, same build back to back:

| `debug` | `target/debug` | build |
| --- | --- | --- |
| `2` (the default) | 3.0 GB | 1m 08s |
| `"line-tables-only"` | 1.4 GB | 1m 03s |

---
Written by Claude Opus 5 in Claude Code.