### PR TITLE
scoop: bump alacritree to v0.11.0

### DIFF
--- a/bucket/alacritree.json
+++ b/bucket/alacritree.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.10.0",
+    "version": "0.11.0",
     "description": "Alacritty fork with worktree-aware sidebars",
     "homepage": "https://github.com/mathix420/alacritree",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mathix420/alacritree/releases/download/v0.10.0/alacritree-x86_64-pc-windows-msvc.zip",
-            "hash": "3f94f4ce42e901b940fc984cab851795b596afe9f999656e38b486db2266562a"
+            "url": "https://github.com/mathix420/alacritree/releases/download/v0.11.0/alacritree-x86_64-pc-windows-msvc.zip",
+            "hash": "3ef4b095cb94934115ebe543373b8144366940ad25911143a7e2c2a07994a0fd"
         }
     },
     "bin": "alacritree.exe",


### PR DESCRIPTION
Automated manifest bump triggered by the release of `v0.11.0`.